### PR TITLE
CI: add GHC 9.12

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,8 +80,9 @@ jobs:
         # support, so the PR *must* have a changelog entry.
         ghc:
           [
+            "9.12.1",
             "9.10.1",
-            "9.8.2",
+            "9.8.4",
             "9.6.6",
             "9.4.8",
             "9.2.8",

--- a/Cabal-syntax/src/Distribution/Backpack.hs
+++ b/Cabal-syntax/src/Distribution/Backpack.hs
@@ -89,7 +89,7 @@ data OpenUnitId
     -- MUST NOT be for an indefinite component; an 'OpenUnitId'
     -- is guaranteed not to have any holes.
     DefiniteUnitId DefUnitId
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 -- TODO: cache holes?
 
@@ -163,7 +163,7 @@ mkDefUnitId cid insts =
 data OpenModule
   = OpenModule OpenUnitId ModuleName
   | OpenModuleVar ModuleName
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary OpenModule
 instance Structured OpenModule

--- a/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
+++ b/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
@@ -35,7 +35,7 @@ data CabalSpecVersion
   | -- 3.10: no changes
     CabalSpecV3_12
   | CabalSpecV3_14
-  deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
+  deriving (Eq, Ord, Show, Read, Enum, Bounded, Data, Generic)
 
 instance Binary CabalSpecVersion
 instance Structured CabalSpecVersion

--- a/Cabal-syntax/src/Distribution/Compat/Graph.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Graph.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -122,7 +121,6 @@ data Graph a = Graph
   , graphKeyToVertex :: Key a -> Maybe G.Vertex
   , graphBroken :: [(a, [Key a])]
   }
-  deriving (Typeable)
 
 -- NB: Not a Functor! (or Traversable), because you need
 -- to restrict Key a ~ Key b.  We provide our own mapping

--- a/Cabal-syntax/src/Distribution/Compat/NonEmptySet.hs
+++ b/Cabal-syntax/src/Distribution/Compat/NonEmptySet.hs
@@ -33,7 +33,6 @@ import Control.DeepSeq (NFData (..))
 import Data.Data (Data)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Semigroup (Semigroup (..))
-import Data.Typeable (Typeable)
 
 import qualified Data.Foldable as F
 import qualified Data.Set as Set
@@ -49,7 +48,7 @@ import Control.Monad (fail)
 
 -- | @since 3.4.0.0
 newtype NonEmptySet a = NES (Set.Set a)
-  deriving (Eq, Ord, Typeable, Data, Read)
+  deriving (Eq, Ord, Data, Read)
 
 -------------------------------------------------------------------------------
 -- Instances

--- a/Cabal-syntax/src/Distribution/Compat/Semigroup.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Semigroup.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -18,7 +17,6 @@ module Distribution.Compat.Semigroup
   , gmempty
   ) where
 
-import Data.Typeable (Typeable)
 import Distribution.Compat.Binary (Binary)
 import Distribution.Utils.Structured (Structured)
 
@@ -39,7 +37,7 @@ instance Semigroup (First' a) where
 
 -- | A copy of 'Data.Semigroup.Last'.
 newtype Last' a = Last' {getLast' :: a}
-  deriving (Eq, Ord, Read, Show, Generic, Binary, Typeable)
+  deriving (Eq, Ord, Read, Show, Generic, Binary)
 
 instance Structured a => Structured (Last' a)
 
@@ -52,7 +50,7 @@ instance Functor Last' where
 -- | A wrapper around 'Maybe', providing the 'Semigroup' and 'Monoid' instances
 -- implemented for 'Maybe' since @base-4.11@.
 newtype Option' a = Option' {getOption' :: Maybe a}
-  deriving (Eq, Ord, Read, Show, Binary, Generic, Functor, Typeable)
+  deriving (Eq, Ord, Read, Show, Binary, Generic, Functor)
 
 instance Structured a => Structured (Option' a)
 

--- a/Cabal-syntax/src/Distribution/Compiler.hs
+++ b/Cabal-syntax/src/Distribution/Compiler.hs
@@ -76,7 +76,7 @@ data CompilerFlavor
   | MHS -- MicroHS, see https://github.com/augustss/MicroHs
   | HaskellSuite String -- string is the id of the actual compiler
   | OtherCompiler String
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary CompilerFlavor
 instance Structured CompilerFlavor
@@ -141,7 +141,6 @@ data PerCompilerFlavor v = PerCompilerFlavor v v
     , Read
     , Eq
     , Ord
-    , Typeable
     , Data
     , Functor
     , Foldable
@@ -172,7 +171,7 @@ instance (Semigroup a, Monoid a) => Monoid (PerCompilerFlavor a) where
 -- ------------------------------------------------------------
 
 data CompilerId = CompilerId CompilerFlavor Version
-  deriving (Eq, Generic, Ord, Read, Show, Typeable)
+  deriving (Eq, Generic, Ord, Read, Show)
 
 instance Binary CompilerId
 instance Structured CompilerId
@@ -222,7 +221,7 @@ instance Binary CompilerInfo
 data AbiTag
   = NoAbiTag
   | AbiTag String
-  deriving (Eq, Generic, Show, Read, Typeable)
+  deriving (Eq, Generic, Show, Read)
 
 instance Binary AbiTag
 instance Structured AbiTag

--- a/Cabal-syntax/src/Distribution/License.hs
+++ b/Cabal-syntax/src/Distribution/License.hs
@@ -111,7 +111,7 @@ data License
     OtherLicense
   | -- | Indicates an erroneous license name.
     UnknownLicense String
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary License
 instance Structured License

--- a/Cabal-syntax/src/Distribution/ModuleName.hs
+++ b/Cabal-syntax/src/Distribution/ModuleName.hs
@@ -40,7 +40,7 @@ import qualified Text.PrettyPrint as Disp
 
 -- | A valid Haskell module name.
 newtype ModuleName = ModuleName ShortText
-  deriving (Eq, Generic, Ord, Read, Show, Typeable, Data)
+  deriving (Eq, Generic, Ord, Read, Show, Data)
 
 unModuleName :: ModuleName -> String
 unModuleName (ModuleName s) = fromShortText s

--- a/Cabal-syntax/src/Distribution/SPDX/License.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/License.hs
@@ -41,7 +41,7 @@ data License
     NONE
   | -- | A valid SPDX License Expression as defined in Appendix IV.
     License LicenseExpression
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Data, Generic)
 
 instance Binary License
 instance Structured License

--- a/Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs
@@ -104,7 +104,7 @@ data LicenseExceptionId
     | Vsftpd_openssl_exception -- ^ @vsftpd-openssl-exception@, vsftpd OpenSSL exception, SPDX License List 3.23, SPDX License List 3.25
     | WxWindows_exception_3_1 -- ^ @WxWindows-exception-3.1@, WxWindows Library Exception 3.1
     | X11vnc_openssl_exception -- ^ @x11vnc-openssl-exception@, x11vnc OpenSSL Exception, SPDX License List 3.23, SPDX License List 3.25
-  deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data, Generic)
+  deriving (Eq, Ord, Enum, Bounded, Show, Read, Data, Generic)
 
 instance Binary LicenseExceptionId where
     put = Binary.putWord8 . fromIntegral . fromEnum

--- a/Cabal-syntax/src/Distribution/SPDX/LicenseExpression.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseExpression.hs
@@ -43,7 +43,7 @@ data LicenseExpression
   = ELicense !SimpleLicenseExpression !(Maybe LicenseExceptionId)
   | EAnd !LicenseExpression !LicenseExpression
   | EOr !LicenseExpression !LicenseExpression
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Data, Generic)
 
 -- | Simple License Expressions.
 data SimpleLicenseExpression
@@ -53,7 +53,7 @@ data SimpleLicenseExpression
     ELicenseIdPlus LicenseId
   | -- | A SPDX user defined license reference: For example: @LicenseRef-23@, @LicenseRef-MIT-Style-1@, or @DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2@
     ELicenseRef LicenseRef
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Data, Generic)
 
 simpleLicenseExpression :: LicenseId -> LicenseExpression
 simpleLicenseExpression i = ELicense (ELicenseId i) Nothing

--- a/Cabal-syntax/src/Distribution/SPDX/LicenseId.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseId.hs
@@ -674,7 +674,7 @@ data LicenseId
     | ZPL_1_1 -- ^ @ZPL-1.1@, Zope Public License 1.1
     | ZPL_2_0 -- ^ @ZPL-2.0@, Zope Public License 2.0
     | ZPL_2_1 -- ^ @ZPL-2.1@, Zope Public License 2.1
-  deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data)
+  deriving (Eq, Ord, Enum, Bounded, Show, Read, Data)
 
 instance Binary LicenseId where
     -- Word16 is encoded in big endianness

--- a/Cabal-syntax/src/Distribution/SPDX/LicenseReference.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseReference.hs
@@ -24,7 +24,7 @@ data LicenseRef = LicenseRef
   { _lrDocument :: !(Maybe String)
   , _lrLicense :: !String
   }
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Data, Generic)
 
 -- | License reference.
 licenseRef :: LicenseRef -> String

--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -110,7 +110,7 @@ data OS
   | Wasi
   | Haiku
   | OtherOS String
-  deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
+  deriving (Eq, Generic, Ord, Show, Read, Data)
 
 instance Binary OS
 instance Structured OS
@@ -213,7 +213,7 @@ data Arch
   | JavaScript
   | Wasm32
   | OtherArch String
-  deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
+  deriving (Eq, Generic, Ord, Show, Read, Data)
 
 instance Binary Arch
 instance Structured Arch
@@ -284,7 +284,7 @@ buildArch = classifyArch Permissive System.Info.arch
 -- ------------------------------------------------------------
 
 data Platform = Platform Arch OS
-  deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
+  deriving (Eq, Generic, Ord, Show, Read, Data)
 
 instance Binary Platform
 instance Structured Platform

--- a/Cabal-syntax/src/Distribution/Types/AbiDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/AbiDependency.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Types.AbiDependency where
@@ -27,7 +26,7 @@ data AbiDependency = AbiDependency
   { depUnitId :: Package.UnitId
   , depAbiHash :: Package.AbiHash
   }
-  deriving (Eq, Generic, Read, Show, Typeable)
+  deriving (Eq, Generic, Read, Show)
 
 instance Pretty AbiDependency where
   pretty (AbiDependency uid abi) =

--- a/Cabal-syntax/src/Distribution/Types/AbiHash.hs
+++ b/Cabal-syntax/src/Distribution/Types/AbiHash.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Types.AbiHash
@@ -26,7 +25,7 @@ import Text.PrettyPrint (text)
 --
 -- @since 2.0.0.2
 newtype AbiHash = AbiHash ShortText
-  deriving (Eq, Show, Read, Generic, Typeable)
+  deriving (Eq, Show, Read, Generic)
 
 -- | Convert 'AbiHash' to 'String'
 --

--- a/Cabal-syntax/src/Distribution/Types/Benchmark.hs
+++ b/Cabal-syntax/src/Distribution/Types/Benchmark.hs
@@ -27,7 +27,7 @@ data Benchmark = Benchmark
   , benchmarkInterface :: BenchmarkInterface
   , benchmarkBuildInfo :: BuildInfo
   }
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary Benchmark
 instance Structured Benchmark

--- a/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
@@ -27,7 +27,7 @@ data BenchmarkInterface
   | -- | A benchmark that does not conform to one of the above
     -- interfaces for the given reason (e.g. unknown benchmark type).
     BenchmarkUnsupported BenchmarkType
-  deriving (Eq, Ord, Generic, Read, Show, Typeable, Data)
+  deriving (Eq, Ord, Generic, Read, Show, Data)
 
 instance Binary BenchmarkInterface
 instance Structured BenchmarkInterface

--- a/Cabal-syntax/src/Distribution/Types/BenchmarkType.hs
+++ b/Cabal-syntax/src/Distribution/Types/BenchmarkType.hs
@@ -22,7 +22,7 @@ data BenchmarkType
     BenchmarkTypeExe Version
   | -- | Some unknown benchmark type e.g. \"type: foo\"
     BenchmarkTypeUnknown String Version
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary BenchmarkType
 instance Structured BenchmarkType

--- a/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
@@ -144,7 +144,7 @@ data BuildInfo = BuildInfo
   -- ^ Dependencies specific to a library or executable target
   , mixins :: [Mixin]
   }
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary BuildInfo
 instance Structured BuildInfo

--- a/Cabal-syntax/src/Distribution/Types/BuildType.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildType.hs
@@ -30,7 +30,7 @@ data BuildType
   | -- | uses user-supplied @Setup.hs@ or @Setup.lhs@ (default)
     Custom
   | Hooks
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary BuildType
 instance Structured BuildType

--- a/Cabal-syntax/src/Distribution/Types/ComponentId.hs
+++ b/Cabal-syntax/src/Distribution/Types/ComponentId.hs
@@ -31,7 +31,7 @@ import Text.PrettyPrint (text)
 --
 -- @since 2.0.0.2
 newtype ComponentId = ComponentId ShortText
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 -- | Construct a 'ComponentId' from a 'String'
 --

--- a/Cabal-syntax/src/Distribution/Types/ComponentName.hs
+++ b/Cabal-syntax/src/Distribution/Types/ComponentName.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE PatternSynonyms #-}
 
@@ -25,14 +24,14 @@ import qualified Text.PrettyPrint as Disp
 data ComponentName
   = CLibName LibraryName
   | CNotLibName NotLibComponentName
-  deriving (Eq, Generic, Ord, Read, Show, Typeable)
+  deriving (Eq, Generic, Ord, Read, Show)
 
 data NotLibComponentName
   = CNLFLibName {toCompName :: UnqualComponentName}
   | CNLExeName {toCompName :: UnqualComponentName}
   | CNLTestName {toCompName :: UnqualComponentName}
   | CNLBenchName {toCompName :: UnqualComponentName}
-  deriving (Eq, Generic, Ord, Read, Show, Typeable)
+  deriving (Eq, Generic, Ord, Read, Show)
 
 pattern CFLibName :: UnqualComponentName -> ComponentName
 pattern CFLibName n = CNotLibName (CNLFLibName n)

--- a/Cabal-syntax/src/Distribution/Types/ComponentRequestedSpec.hs
+++ b/Cabal-syntax/src/Distribution/Types/ComponentRequestedSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Types.ComponentRequestedSpec
@@ -67,7 +66,7 @@ data ComponentRequestedSpec
       , benchmarksRequested :: Bool
       }
   | OneComponentRequestedSpec ComponentName
-  deriving (Generic, Read, Show, Eq, Typeable)
+  deriving (Generic, Read, Show, Eq)
 
 instance Binary ComponentRequestedSpec
 instance Structured ComponentRequestedSpec

--- a/Cabal-syntax/src/Distribution/Types/CondTree.hs
+++ b/Cabal-syntax/src/Distribution/Types/CondTree.hs
@@ -59,7 +59,7 @@ data CondTree v c a = CondNode
   , condTreeConstraints :: c
   , condTreeComponents :: [CondBranch v c a]
   }
-  deriving (Show, Eq, Typeable, Data, Generic, Functor, Foldable, Traversable)
+  deriving (Show, Eq, Data, Generic, Functor, Foldable, Traversable)
 
 instance (Binary v, Binary c, Binary a) => Binary (CondTree v c a)
 instance (Structured v, Structured c, Structured a) => Structured (CondTree v c a)
@@ -80,7 +80,7 @@ data CondBranch v c a = CondBranch
   , condBranchIfTrue :: CondTree v c a
   , condBranchIfFalse :: Maybe (CondTree v c a)
   }
-  deriving (Show, Eq, Typeable, Data, Generic, Functor, Traversable)
+  deriving (Show, Eq, Data, Generic, Functor, Traversable)
 
 -- This instance is written by hand because GHC 8.0.1/8.0.2 infinite
 -- loops when trying to derive it with optimizations.  See

--- a/Cabal-syntax/src/Distribution/Types/Condition.hs
+++ b/Cabal-syntax/src/Distribution/Types/Condition.hs
@@ -19,7 +19,7 @@ data Condition c
   | CNot (Condition c)
   | COr (Condition c) (Condition c)
   | CAnd (Condition c) (Condition c)
-  deriving (Show, Eq, Typeable, Data, Generic)
+  deriving (Show, Eq, Data, Generic)
 
 -- | Boolean negation of a 'Condition' value.
 cNot :: Condition a -> Condition a

--- a/Cabal-syntax/src/Distribution/Types/ConfVar.hs
+++ b/Cabal-syntax/src/Distribution/Types/ConfVar.hs
@@ -19,7 +19,7 @@ data ConfVar
   | Arch Arch
   | PackageFlag FlagName
   | Impl CompilerFlavor VersionRange
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary ConfVar
 instance Structured ConfVar

--- a/Cabal-syntax/src/Distribution/Types/Dependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/Dependency.hs
@@ -41,7 +41,7 @@ data Dependency
       PackageName
       VersionRange
       (NonEmptySet LibraryName)
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 depPkgName :: Dependency -> PackageName
 depPkgName (Dependency pn _ _) = pn

--- a/Cabal-syntax/src/Distribution/Types/ExeDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/ExeDependency.hs
@@ -25,7 +25,7 @@ data ExeDependency
       PackageName
       UnqualComponentName -- name of executable component of package
       VersionRange
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary ExeDependency
 instance Structured ExeDependency

--- a/Cabal-syntax/src/Distribution/Types/Executable.hs
+++ b/Cabal-syntax/src/Distribution/Types/Executable.hs
@@ -26,7 +26,7 @@ data Executable = Executable
   , exeScope :: ExecutableScope
   , buildInfo :: BuildInfo
   }
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance L.HasBuildInfo Executable where
   buildInfo f l = (\x -> l{buildInfo = x}) <$> f (buildInfo l)

--- a/Cabal-syntax/src/Distribution/Types/ExecutableScope.hs
+++ b/Cabal-syntax/src/Distribution/Types/ExecutableScope.hs
@@ -18,7 +18,7 @@ import qualified Text.PrettyPrint as Disp
 data ExecutableScope
   = ExecutablePublic
   | ExecutablePrivate
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Pretty ExecutableScope where
   pretty ExecutablePublic = Disp.text "public"

--- a/Cabal-syntax/src/Distribution/Types/ExposedModule.hs
+++ b/Cabal-syntax/src/Distribution/Types/ExposedModule.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Types.ExposedModule where
@@ -18,7 +17,7 @@ data ExposedModule = ExposedModule
   { exposedName :: ModuleName
   , exposedReexport :: Maybe OpenModule
   }
-  deriving (Eq, Generic, Read, Show, Typeable)
+  deriving (Eq, Generic, Read, Show)
 
 instance Pretty ExposedModule where
   pretty (ExposedModule m reexport) =

--- a/Cabal-syntax/src/Distribution/Types/Flag.hs
+++ b/Cabal-syntax/src/Distribution/Types/Flag.hs
@@ -56,7 +56,7 @@ data PackageFlag = MkPackageFlag
   , flagDefault :: Bool
   , flagManual :: Bool
   }
-  deriving (Show, Eq, Typeable, Data, Generic)
+  deriving (Show, Eq, Data, Generic)
 
 instance Binary PackageFlag
 instance Structured PackageFlag
@@ -80,7 +80,7 @@ emptyFlag name =
 --
 -- @since 2.0.0.2
 newtype FlagName = FlagName ShortText
-  deriving (Eq, Generic, Ord, Show, Read, Typeable, Data, NFData)
+  deriving (Eq, Generic, Ord, Show, Read, Data, NFData)
 
 -- | Construct a 'FlagName' from a 'String'
 --
@@ -127,7 +127,7 @@ instance Parsec FlagName where
 --
 -- TODO: Why we record the multiplicity of the flag?
 newtype FlagAssignment = FlagAssignment {getFlagAssignment :: Map.Map FlagName (Int, Bool)}
-  deriving (Binary, Generic, NFData, Typeable)
+  deriving (Binary, Generic, NFData)
 
 instance Structured FlagAssignment
 

--- a/Cabal-syntax/src/Distribution/Types/ForeignLib.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLib.hs
@@ -61,9 +61,9 @@ data ForeignLib = ForeignLib
   -- This is a list rather than a maybe field so that we can flatten
   -- the condition trees (for instance, when creating an sdist)
   }
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
-data LibVersionInfo = LibVersionInfo Int Int Int deriving (Data, Eq, Generic, Typeable)
+data LibVersionInfo = LibVersionInfo Int Int Int deriving (Data, Eq, Generic)
 
 instance Ord LibVersionInfo where
   LibVersionInfo c r _ `compare` LibVersionInfo c' r' _ =

--- a/Cabal-syntax/src/Distribution/Types/ForeignLibOption.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLibOption.hs
@@ -22,7 +22,7 @@ data ForeignLibOption
     -- This option is compulsory on Windows and unsupported
     -- on other platforms.
     ForeignLibStandalone
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Pretty ForeignLibOption where
   pretty ForeignLibStandalone = Disp.text "standalone"

--- a/Cabal-syntax/src/Distribution/Types/ForeignLibType.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLibType.hs
@@ -27,7 +27,7 @@ data ForeignLibType
     ForeignLibNativeStatic
   | -- TODO: Maybe this should record a string?
     ForeignLibTypeUnknown
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Pretty ForeignLibType where
   pretty ForeignLibNativeShared = Disp.text "native-shared"

--- a/Cabal-syntax/src/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal-syntax/src/Distribution/Types/GenericPackageDescription.hs
@@ -71,7 +71,7 @@ data GenericPackageDescription = GenericPackageDescription
            )
          ]
   }
-  deriving (Show, Eq, Typeable, Data, Generic)
+  deriving (Show, Eq, Data, Generic)
 
 instance Package GenericPackageDescription where
   packageId = packageId . packageDescription

--- a/Cabal-syntax/src/Distribution/Types/IncludeRenaming.hs
+++ b/Cabal-syntax/src/Distribution/Types/IncludeRenaming.hs
@@ -26,7 +26,7 @@ data IncludeRenaming = IncludeRenaming
   { includeProvidesRn :: ModuleRenaming
   , includeRequiresRn :: ModuleRenaming
   }
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Data, Generic)
 
 instance Binary IncludeRenaming
 instance Structured IncludeRenaming

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -95,7 +94,7 @@ data InstalledPackageInfo = InstalledPackageInfo
   , haddockHTMLs :: [FilePath]
   , pkgRoot :: Maybe FilePath
   }
-  deriving (Eq, Generic, Typeable, Read, Show)
+  deriving (Eq, Generic, Read, Show)
 
 instance Binary InstalledPackageInfo
 instance Structured InstalledPackageInfo

--- a/Cabal-syntax/src/Distribution/Types/LegacyExeDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/LegacyExeDependency.hs
@@ -26,7 +26,7 @@ data LegacyExeDependency
   = LegacyExeDependency
       String
       VersionRange
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary LegacyExeDependency
 instance Structured LegacyExeDependency

--- a/Cabal-syntax/src/Distribution/Types/Library.hs
+++ b/Cabal-syntax/src/Distribution/Types/Library.hs
@@ -31,7 +31,7 @@ data Library = Library
   -- ^ Whether this multilib can be used as a dependency for other packages.
   , libBuildInfo :: BuildInfo
   }
-  deriving (Generic, Show, Eq, Ord, Read, Typeable, Data)
+  deriving (Generic, Show, Eq, Ord, Read, Data)
 
 instance L.HasBuildInfo Library where
   buildInfo f l = (\x -> l{libBuildInfo = x}) <$> f (libBuildInfo l)

--- a/Cabal-syntax/src/Distribution/Types/LibraryName.hs
+++ b/Cabal-syntax/src/Distribution/Types/LibraryName.hs
@@ -29,7 +29,7 @@ import qualified Text.PrettyPrint as Disp
 data LibraryName
   = LMainLibName
   | LSubLibName UnqualComponentName
-  deriving (Eq, Generic, Ord, Read, Show, Typeable, Data)
+  deriving (Eq, Generic, Ord, Read, Show, Data)
 
 instance Binary LibraryName
 instance Structured LibraryName

--- a/Cabal-syntax/src/Distribution/Types/LibraryVisibility.hs
+++ b/Cabal-syntax/src/Distribution/Types/LibraryVisibility.hs
@@ -23,7 +23,7 @@ data LibraryVisibility
     LibraryVisibilityPublic
   | -- | Internal library, default
     LibraryVisibilityPrivate
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Pretty LibraryVisibility where
   pretty LibraryVisibilityPublic = Disp.text "public"

--- a/Cabal-syntax/src/Distribution/Types/Mixin.hs
+++ b/Cabal-syntax/src/Distribution/Types/Mixin.hs
@@ -31,7 +31,7 @@ data Mixin = Mixin
   , mixinLibraryName :: LibraryName
   , mixinIncludeRenaming :: IncludeRenaming
   }
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Data, Generic)
 
 instance Binary Mixin
 instance Structured Mixin

--- a/Cabal-syntax/src/Distribution/Types/Module.hs
+++ b/Cabal-syntax/src/Distribution/Types/Module.hs
@@ -25,7 +25,7 @@ import qualified Text.PrettyPrint as Disp
 -- the 'InstalledPackageInfo'.
 data Module
   = Module DefUnitId ModuleName
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary Module
 instance Structured Module

--- a/Cabal-syntax/src/Distribution/Types/ModuleReexport.hs
+++ b/Cabal-syntax/src/Distribution/Types/ModuleReexport.hs
@@ -24,7 +24,7 @@ data ModuleReexport = ModuleReexport
   , moduleReexportOriginalName :: ModuleName
   , moduleReexportName :: ModuleName
   }
-  deriving (Eq, Ord, Generic, Read, Show, Typeable, Data)
+  deriving (Eq, Ord, Generic, Read, Show, Data)
 
 instance Binary ModuleReexport
 instance Structured ModuleReexport

--- a/Cabal-syntax/src/Distribution/Types/ModuleRenaming.hs
+++ b/Cabal-syntax/src/Distribution/Types/ModuleRenaming.hs
@@ -40,7 +40,7 @@ data ModuleRenaming
   | -- | Hiding renaming, e.g., @hiding (A, B)@, bringing all
     -- exported modules into scope except the hidden ones.
     HidingRenaming [ModuleName]
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Data, Generic)
 
 -- | Interpret a 'ModuleRenaming' as a partial map from 'ModuleName'
 -- to 'ModuleName'.  For efficiency, you should partially apply it

--- a/Cabal-syntax/src/Distribution/Types/MungedPackageId.hs
+++ b/Cabal-syntax/src/Distribution/Types/MungedPackageId.hs
@@ -28,7 +28,7 @@ data MungedPackageId = MungedPackageId
   , mungedVersion :: Version
   -- ^ The version of this package / component, eg 1.2
   }
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary MungedPackageId
 instance Structured MungedPackageId

--- a/Cabal-syntax/src/Distribution/Types/MungedPackageName.hs
+++ b/Cabal-syntax/src/Distribution/Types/MungedPackageName.hs
@@ -31,7 +31,7 @@ import qualified Text.PrettyPrint as Disp
 --
 -- @since 2.0.0.2
 data MungedPackageName = MungedPackageName !PackageName !LibraryName
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary MungedPackageName
 instance Structured MungedPackageName

--- a/Cabal-syntax/src/Distribution/Types/PackageDescription.hs
+++ b/Cabal-syntax/src/Distribution/Types/PackageDescription.hs
@@ -151,7 +151,7 @@ data PackageDescription = PackageDescription
   , extraDocFiles :: [RelativePath Pkg File]
   , extraFiles :: [RelativePath Pkg File]
   }
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary PackageDescription
 instance Structured PackageDescription

--- a/Cabal-syntax/src/Distribution/Types/PackageId.hs
+++ b/Cabal-syntax/src/Distribution/Types/PackageId.hs
@@ -28,7 +28,7 @@ data PackageIdentifier = PackageIdentifier
   , pkgVersion :: Version
   -- ^ the version of this package, eg 1.2
   }
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary PackageIdentifier
 instance Structured PackageIdentifier

--- a/Cabal-syntax/src/Distribution/Types/PackageName.hs
+++ b/Cabal-syntax/src/Distribution/Types/PackageName.hs
@@ -26,7 +26,7 @@ import qualified Text.PrettyPrint as Disp
 --
 -- @since 2.0.0.2
 newtype PackageName = PackageName ShortText
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 -- | Convert 'PackageName' to 'String'
 unPackageName :: PackageName -> String

--- a/Cabal-syntax/src/Distribution/Types/PackageVersionConstraint.hs
+++ b/Cabal-syntax/src/Distribution/Types/PackageVersionConstraint.hs
@@ -26,7 +26,7 @@ import qualified Distribution.Compat.CharParsing as P
 -- There are a few places in the codebase where 'Dependency' was used where
 -- 'PackageVersionConstraint' is not used instead (#5570).
 data PackageVersionConstraint = PackageVersionConstraint PackageName VersionRange
-  deriving (Generic, Read, Show, Eq, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Data)
 
 instance Binary PackageVersionConstraint
 instance Structured PackageVersionConstraint

--- a/Cabal-syntax/src/Distribution/Types/PkgconfigDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/PkgconfigDependency.hs
@@ -23,7 +23,7 @@ data PkgconfigDependency
   = PkgconfigDependency
       PkgconfigName
       PkgconfigVersionRange
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary PkgconfigDependency
 instance Structured PkgconfigDependency

--- a/Cabal-syntax/src/Distribution/Types/PkgconfigName.hs
+++ b/Cabal-syntax/src/Distribution/Types/PkgconfigName.hs
@@ -23,7 +23,7 @@ import qualified Text.PrettyPrint as Disp
 --
 -- @since 2.0.0.2
 newtype PkgconfigName = PkgconfigName ShortText
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 -- | Convert 'PkgconfigName' to 'String'
 --

--- a/Cabal-syntax/src/Distribution/Types/PkgconfigVersion.hs
+++ b/Cabal-syntax/src/Distribution/Types/PkgconfigVersion.hs
@@ -26,7 +26,7 @@ import qualified Text.PrettyPrint as PP
 --
 -- @since 3.0
 newtype PkgconfigVersion = PkgconfigVersion BS.ByteString
-  deriving (Generic, Read, Show, Typeable, Data)
+  deriving (Generic, Read, Show, Data)
 
 instance Eq PkgconfigVersion where
   PkgconfigVersion a == PkgconfigVersion b = rpmvercmp a b == EQ

--- a/Cabal-syntax/src/Distribution/Types/PkgconfigVersionRange.hs
+++ b/Cabal-syntax/src/Distribution/Types/PkgconfigVersionRange.hs
@@ -37,7 +37,7 @@ data PkgconfigVersionRange
   | PcOrEarlierVersion PkgconfigVersion -- =< version
   | PcUnionVersionRanges PkgconfigVersionRange PkgconfigVersionRange
   | PcIntersectVersionRanges PkgconfigVersionRange PkgconfigVersionRange
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+  deriving (Generic, Read, Show, Eq, Ord, Data)
 
 instance Binary PkgconfigVersionRange
 instance Structured PkgconfigVersionRange

--- a/Cabal-syntax/src/Distribution/Types/SetupBuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/SetupBuildInfo.hs
@@ -25,7 +25,7 @@ data SetupBuildInfo = SetupBuildInfo
   -- internally, and doesn't correspond to anything in the .cabal
   -- file. See #3199.
   }
-  deriving (Generic, Show, Eq, Ord, Read, Typeable, Data)
+  deriving (Generic, Show, Eq, Ord, Read, Data)
 
 instance Binary SetupBuildInfo
 instance Structured SetupBuildInfo

--- a/Cabal-syntax/src/Distribution/Types/SourceRepo.hs
+++ b/Cabal-syntax/src/Distribution/Types/SourceRepo.hs
@@ -77,7 +77,7 @@ data SourceRepo = SourceRepo
   -- relative to the root of the repository. This field is optional. If not
   -- given the default is \".\" ie no subdirectory.
   }
-  deriving (Eq, Ord, Generic, Read, Show, Typeable, Data)
+  deriving (Eq, Ord, Generic, Read, Show, Data)
 
 emptySourceRepo :: RepoKind -> SourceRepo
 emptySourceRepo kind =
@@ -106,7 +106,7 @@ data RepoKind
     -- information to re-create the exact sources.
     RepoThis
   | RepoKindUnknown String
-  deriving (Eq, Generic, Ord, Read, Show, Typeable, Data)
+  deriving (Eq, Generic, Ord, Read, Show, Data)
 
 instance Binary RepoKind
 instance Structured RepoKind
@@ -126,7 +126,7 @@ data KnownRepoType
   | Monotone
   | -- | @since 3.4.0.0
     Pijul
-  deriving (Eq, Generic, Ord, Read, Show, Typeable, Data, Enum, Bounded)
+  deriving (Eq, Generic, Ord, Read, Show, Data, Enum, Bounded)
 
 instance Binary KnownRepoType
 instance Structured KnownRepoType
@@ -146,7 +146,7 @@ instance Pretty KnownRepoType where
 data RepoType
   = KnownRepoType KnownRepoType
   | OtherRepoType String
-  deriving (Eq, Generic, Ord, Read, Show, Typeable, Data)
+  deriving (Eq, Generic, Ord, Read, Show, Data)
 
 instance Binary RepoType
 instance Structured RepoType

--- a/Cabal-syntax/src/Distribution/Types/TestSuite.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestSuite.hs
@@ -28,7 +28,7 @@ data TestSuite = TestSuite
   , testBuildInfo :: BuildInfo
   , testCodeGenerators :: [String]
   }
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance L.HasBuildInfo TestSuite where
   buildInfo f l = (\x -> l{testBuildInfo = x}) <$> f (testBuildInfo l)

--- a/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
@@ -30,7 +30,7 @@ data TestSuiteInterface
   | -- | A test suite that does not conform to one of the above interfaces for
     -- the given reason (e.g. unknown test type).
     TestSuiteUnsupported TestType
-  deriving (Eq, Ord, Generic, Read, Show, Typeable, Data)
+  deriving (Eq, Ord, Generic, Read, Show, Data)
 
 instance Binary TestSuiteInterface
 instance Structured TestSuiteInterface

--- a/Cabal-syntax/src/Distribution/Types/TestType.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestType.hs
@@ -25,7 +25,7 @@ data TestType
     TestTypeLib Version
   | -- | Some unknown test type e.g. \"type: foo\"
     TestTypeUnknown String Version
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary TestType
 instance Structured TestType

--- a/Cabal-syntax/src/Distribution/Types/UnitId.hs
+++ b/Cabal-syntax/src/Distribution/Types/UnitId.hs
@@ -64,7 +64,7 @@ import Text.PrettyPrint (text)
 -- flag, use the 'display' function, which will work on all
 -- versions of Cabal.
 newtype UnitId = UnitId ShortText
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data, NFData)
+  deriving (Generic, Read, Show, Eq, Ord, Data, NFData)
 
 instance Binary UnitId
 instance Structured UnitId
@@ -118,7 +118,7 @@ getHSLibraryName uid = "HS" ++ prettyShow uid
 -- that a 'UnitId' identified this way is definite; i.e., it has no
 -- unfilled holes.
 newtype DefUnitId = DefUnitId {unDefUnitId :: UnitId}
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data, Binary, NFData, Pretty)
+  deriving (Generic, Read, Show, Eq, Ord, Data, Binary, NFData, Pretty)
 
 instance Structured DefUnitId
 

--- a/Cabal-syntax/src/Distribution/Types/UnqualComponentName.hs
+++ b/Cabal-syntax/src/Distribution/Types/UnqualComponentName.hs
@@ -33,7 +33,6 @@ newtype UnqualComponentName = UnqualComponentName ShortText
     , Show
     , Eq
     , Ord
-    , Typeable
     , Data
     , Semigroup
     , Monoid -- TODO: bad enabler of bad monoids

--- a/Cabal-syntax/src/Distribution/Types/Version.hs
+++ b/Cabal-syntax/src/Distribution/Types/Version.hs
@@ -47,7 +47,7 @@ data Version
   -- which all fall into the [0..0xfffe] range), then PV0
   -- MUST be used. This is essential for the 'Eq' instance
   -- to work.
-  deriving (Data, Eq, Generic, Typeable)
+  deriving (Data, Eq, Generic)
 
 instance Ord Version where
   compare (PV0 x) (PV0 y) = compare x y

--- a/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 
 -- | This module implements a view of a 'VersionRange' as a finite
 -- list of separated version intervals.
@@ -65,7 +64,7 @@ import Distribution.Types.VersionRange.Internal
 -- predicates for translation into foreign packaging systems that do not
 -- support complex version range expressions.
 newtype VersionIntervals = VersionIntervals [VersionInterval]
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Show)
 
 -- | Inspect the list of version intervals.
 unVersionIntervals :: VersionIntervals -> [VersionInterval]

--- a/Cabal-syntax/src/Distribution/Types/VersionInterval/Legacy.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval/Legacy.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 -- | This module implements a view of a 'VersionRange' as a finite
 -- list of separated version intervals and provides the Boolean
 -- algebra operations union, intersection, and complement.
@@ -96,7 +94,7 @@ asVersionIntervals = versionIntervals . toVersionIntervals
 -- predicates for translation into foreign packaging systems that do not
 -- support complex version range expressions.
 newtype VersionIntervals = VersionIntervals [VersionInterval]
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Show)
 
 -- | Inspect the list of version intervals.
 versionIntervals :: VersionIntervals -> [VersionInterval]

--- a/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
@@ -56,7 +56,7 @@ data VersionRange
   | MajorBoundVersion Version -- @^>= ver@ (same as >= ver && < MAJ(ver)+1)
   | UnionVersionRanges VersionRange VersionRange
   | IntersectVersionRanges VersionRange VersionRange
-  deriving (Data, Eq, Ord, Generic, Read, Show, Typeable)
+  deriving (Data, Eq, Ord, Generic, Read, Show)
 
 instance Binary VersionRange
 instance Structured VersionRange
@@ -179,7 +179,6 @@ data VersionRangeF a
     , Generic
     , Read
     , Show
-    , Typeable
     , Functor
     , Foldable
     , Traversable

--- a/Cabal-syntax/src/Distribution/Utils/Path.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Path.hs
@@ -201,7 +201,7 @@ data AllowAbsolute
 -- until we interpret them (using e.g. 'interpretSymbolicPath').
 newtype SymbolicPathX (allowAbsolute :: AllowAbsolute) (from :: Type) (to :: FileOrDir)
   = SymbolicPath FilePath
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 type role SymbolicPathX nominal nominal nominal
 

--- a/Cabal-syntax/src/Distribution/Utils/ShortText.hs
+++ b/Cabal-syntax/src/Distribution/Utils/ShortText.hs
@@ -93,7 +93,7 @@ null :: ShortText -> Bool
 -- @since 2.0.0.2
 #if HAVE_SHORTBYTESTRING
 newtype ShortText = ST { unST :: BS.Short.ShortByteString }
-                  deriving (Eq,Ord,Generic,Data,Typeable)
+                  deriving (Eq,Ord,Generic,Data)
 
 # if MIN_VERSION_binary(0,8,1)
 instance Binary ShortText where
@@ -115,7 +115,7 @@ unsafeFromUTF8BS = ST . BS.Short.toShort
 null = BS.Short.null . unST
 #else
 newtype ShortText = ST { unST :: String }
-                  deriving (Eq,Ord,Generic,Data,Typeable)
+                  deriving (Eq,Ord,Generic,Data)
 
 instance Binary ShortText where
     put = put . encodeStringUtf8 . unST

--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -59,7 +59,7 @@ data Language
     GHC2024
   | -- | An unknown language, identified by its name.
     UnknownLanguage String
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary Language
 instance Structured Language
@@ -115,7 +115,7 @@ data Extension
   | -- | An unknown extension, identified by the name of its @LANGUAGE@
     -- pragma.
     UnknownExtension String
-  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Data)
 
 instance Binary Extension
 instance Structured Extension
@@ -556,7 +556,7 @@ data KnownExtension
   | -- | Allow use of or-pattern syntax, condensing multiple patterns
     -- into a single one.
     OrPatterns
-  deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Data)
 
 instance Binary KnownExtension
 instance Structured KnownExtension

--- a/Cabal-tests/tests/UnitTests.hs
+++ b/Cabal-tests/tests/UnitTests.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 module Main
     ( main
     ) where
@@ -7,7 +6,6 @@ import Test.Tasty
 import Test.Tasty.Options
 
 import Data.Proxy
-import Data.Typeable
 
 import Distribution.Simple.Utils
 import Distribution.Verbosity
@@ -90,7 +88,6 @@ extraOptions =
   ]
 
 newtype OptionMtimeChangeDelay = OptionMtimeChangeDelay Int
-  deriving Typeable
 
 instance IsOption OptionMtimeChangeDelay where
   defaultValue   = OptionMtimeChangeDelay 0
@@ -100,7 +97,6 @@ instance IsOption OptionMtimeChangeDelay where
                    ++ "file modification, in microseconds"
 
 newtype GhcPath = GhcPath FilePath
-  deriving Typeable
 
 instance IsOption GhcPath where
   defaultValue = GhcPath "ghc"

--- a/Cabal/src/Distribution/Backpack/ModuleShape.hs
+++ b/Cabal/src/Distribution/Backpack/ModuleShape.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 -- | See <https://github.com/ezyang/ghc-proposals/blob/backpack/proposals/0000-backpack.rst>
@@ -31,7 +30,7 @@ data ModuleShape = ModuleShape
   { modShapeProvides :: OpenModuleSubst
   , modShapeRequires :: Set ModuleName
   }
-  deriving (Eq, Show, Generic, Typeable)
+  deriving (Eq, Show, Generic)
 
 instance Binary ModuleShape
 instance Structured ModuleShape

--- a/Cabal/src/Distribution/Compat/Async.hs
+++ b/Cabal/src/Distribution/Compat/Async.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 
 -- | 'Async', yet using 'MVar's.
 --
@@ -40,7 +39,6 @@ import Control.Exception
   , uninterruptibleMask_
   )
 import Control.Monad (void)
-import Data.Typeable (Typeable)
 import GHC.Exts (inline)
 
 -- | Async, but based on 'MVar', as we don't depend on @stm@.
@@ -143,7 +141,6 @@ data AsyncCancelled = AsyncCancelled
   deriving
     ( Show
     , Eq
-    , Typeable
     )
 
 instance Exception AsyncCancelled where

--- a/Cabal/src/Distribution/Compat/Time.hs
+++ b/Cabal/src/Distribution/Compat/Time.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -55,7 +54,7 @@ import System.Posix.Files ( modificationTime )
 -- | An opaque type representing a file's modification time, represented
 -- internally as a 64-bit unsigned integer in the Windows UTC format.
 newtype ModTime = ModTime Word64
-  deriving (Binary, Generic, Bounded, Eq, Ord, Typeable)
+  deriving (Binary, Generic, Bounded, Eq, Ord)
 
 instance Structured ModTime
 

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
 
@@ -123,7 +122,7 @@ data Compiler = Compiler
   , compilerProperties :: Map String String
   -- ^ A key-value map for properties not covered by the above fields.
   }
-  deriving (Eq, Generic, Typeable, Show, Read)
+  deriving (Eq, Generic, Show, Read)
 
 instance Binary Compiler
 instance Structured Compiler
@@ -198,7 +197,7 @@ data PackageDBX fp
   | UserPackageDB
   | -- | NB: the path might be relative or it might be absolute
     SpecificPackageDB fp
-  deriving (Eq, Generic, Ord, Show, Read, Typeable, Functor, Foldable, Traversable)
+  deriving (Eq, Generic, Ord, Show, Read, Functor, Foldable, Traversable)
 
 instance Binary fp => Binary (PackageDBX fp)
 instance Structured fp => Structured (PackageDBX fp)
@@ -289,7 +288,7 @@ data OptimisationLevel
   = NoOptimisation
   | NormalOptimisation
   | MaximumOptimisation
-  deriving (Bounded, Enum, Eq, Generic, Read, Show, Typeable)
+  deriving (Bounded, Enum, Eq, Generic, Read, Show)
 
 instance Binary OptimisationLevel
 instance Structured OptimisationLevel
@@ -322,7 +321,7 @@ data DebugInfoLevel
   | MinimalDebugInfo
   | NormalDebugInfo
   | MaximalDebugInfo
-  deriving (Bounded, Enum, Eq, Generic, Read, Show, Typeable)
+  deriving (Bounded, Enum, Eq, Generic, Read, Show)
 
 instance Binary DebugInfoLevel
 instance Structured DebugInfoLevel
@@ -559,7 +558,7 @@ data ProfDetailLevel
   | ProfDetailAllFunctions
   | ProfDetailTopLate
   | ProfDetailOther String
-  deriving (Eq, Generic, Read, Show, Typeable)
+  deriving (Eq, Generic, Read, Show)
 
 instance Binary ProfDetailLevel
 instance Structured ProfDetailLevel

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -204,7 +203,6 @@ data ConfigStateFileError
       PackageIdentifier
       PackageIdentifier
       (Either ConfigStateFileError LocalBuildInfo)
-  deriving (Typeable)
 
 -- | Format a 'ConfigStateFileError' as a user-facing error message.
 dispConfigStateFileError :: ConfigStateFileError -> Doc

--- a/Cabal/src/Distribution/Simple/Errors.hs
+++ b/Cabal/src/Distribution/Simple/Errors.hs
@@ -171,7 +171,7 @@ data CabalException
   | UnknownVersionDb String VersionRange FilePath
   | MissingCoveredInstalledLibrary UnitId
   | SetupHooksException SetupHooksException
-  deriving (Show, Typeable)
+  deriving (Show)
 
 exceptionCode :: CabalException -> Int
 exceptionCode e = case e of

--- a/Cabal/src/Distribution/Simple/Flag.hs
+++ b/Cabal/src/Distribution/Simple/Flag.hs
@@ -61,7 +61,7 @@ import Prelude ()
 -- 'NoFlag' and later flags override earlier ones.
 --
 -- Isomorphic to 'Maybe' a.
-data Flag a = Flag a | NoFlag deriving (Eq, Generic, Show, Read, Typeable, Foldable, Traversable)
+data Flag a = Flag a | NoFlag deriving (Eq, Generic, Show, Read, Foldable, Traversable)
 
 instance Binary a => Binary (Flag a)
 instance Structured a => Structured (Flag a)

--- a/Cabal/src/Distribution/Simple/GHC/EnvironmentParser.hs
+++ b/Cabal/src/Distribution/Simple/GHC/EnvironmentParser.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -41,7 +40,7 @@ parseEnvironmentFileLine =
     clearDb = P.string "clear-package-db"
 
 newtype ParseErrorExc = ParseErrorExc P.ParseError
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception ParseErrorExc
 

--- a/Cabal/src/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/src/Distribution/Simple/InstallDirs.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -101,7 +100,7 @@ data InstallDirs dir = InstallDirs
   , haddockdir :: dir
   , sysconfdir :: dir
   }
-  deriving (Eq, Read, Show, Functor, Generic, Typeable)
+  deriving (Eq, Read, Show, Functor, Generic)
 
 instance Binary dir => Binary (InstallDirs dir)
 instance Structured dir => Structured (InstallDirs dir)
@@ -389,7 +388,7 @@ prefixRelativeInstallDirs pkgId libname compilerId platform dirs =
 -- | An abstract path, possibly containing variables that need to be
 -- substituted for to get a real 'FilePath'.
 newtype PathTemplate = PathTemplate [PathComponent]
-  deriving (Eq, Ord, Generic, Typeable)
+  deriving (Eq, Ord, Generic)
 
 instance Binary PathTemplate
 instance Structured PathTemplate

--- a/Cabal/src/Distribution/Simple/InstallDirs/Internal.hs
+++ b/Cabal/src/Distribution/Simple/InstallDirs/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Simple.InstallDirs.Internal
@@ -12,7 +11,7 @@ import Prelude ()
 data PathComponent
   = Ordinary FilePath
   | Variable PathTemplateVariable
-  deriving (Eq, Ord, Generic, Typeable)
+  deriving (Eq, Ord, Generic)
 
 instance Binary PathComponent
 instance Structured PathComponent
@@ -65,7 +64,7 @@ data PathTemplateVariable
     TestSuiteResultVar
   | -- | The name of the benchmark being run
     BenchmarkNameVar
-  deriving (Eq, Ord, Generic, Typeable)
+  deriving (Eq, Ord, Generic)
 
 instance Binary PathTemplateVariable
 instance Structured PathTemplateVariable

--- a/Cabal/src/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/src/Distribution/Simple/PackageIndex.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -147,7 +146,7 @@ data PackageIndex a = PackageIndex
     -- preserved. See #1463 for discussion.
     packageIdIndex :: !(Map (PackageName, LibraryName) (Map Version [a]))
   }
-  deriving (Eq, Generic, Show, Read, Typeable)
+  deriving (Eq, Generic, Show, Read)
 
 instance Binary a => Binary (PackageIndex a)
 instance Structured a => Structured (PackageIndex a)

--- a/Cabal/src/Distribution/Simple/Program/Db.hs
+++ b/Cabal/src/Distribution/Simple/Program/Db.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -106,7 +105,6 @@ data ProgramDb = ProgramDb
   , progOverrideEnv :: [(String, Maybe String)]
   , configuredProgs :: ConfiguredProgs
   }
-  deriving (Typeable)
 
 type UnconfiguredProgram = (Program, Maybe FilePath, [ProgArg])
 type UnconfiguredProgs = Map.Map String UnconfiguredProgram

--- a/Cabal/src/Distribution/Simple/Program/Types.hs
+++ b/Cabal/src/Distribution/Simple/Program/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
@@ -107,7 +106,7 @@ data ProgramSearchPathEntry
     ProgramSearchPathDir FilePath
   | -- | The system default
     ProgramSearchPathDefault
-  deriving (Show, Eq, Generic, Typeable)
+  deriving (Show, Eq, Generic)
 
 instance Binary ProgramSearchPathEntry
 instance Structured ProgramSearchPathEntry
@@ -147,7 +146,7 @@ data ConfiguredProgram = ConfiguredProgram
   -- monitor to detect when the re-configuring the program might give a
   -- different result (e.g. found in a different location).
   }
-  deriving (Eq, Generic, Read, Show, Typeable)
+  deriving (Eq, Generic, Read, Show)
 
 instance Binary ConfiguredProgram
 instance Structured ConfiguredProgram
@@ -160,7 +159,7 @@ data ProgramLocation
     UserSpecified {locationPath :: FilePath}
   | -- | The program was found automatically.
     FoundOnSystem {locationPath :: FilePath}
-  deriving (Eq, Generic, Read, Show, Typeable)
+  deriving (Eq, Generic, Read, Show)
 
 instance Binary ProgramLocation
 instance Structured ProgramLocation

--- a/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -56,7 +55,7 @@ data BenchmarkFlags = BenchmarkFlags
   { benchmarkCommonFlags :: !CommonSetupFlags
   , benchmarkOptions :: [PathTemplate]
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern BenchmarkCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Build.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Build.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -62,7 +61,7 @@ data BuildFlags = BuildFlags
   , buildNumJobs :: Flag (Maybe Int)
   , buildUseSemaphore :: Flag String
   }
-  deriving (Read, Show, Generic, Typeable)
+  deriving (Read, Show, Generic)
 
 pattern BuildCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Clean.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Clean.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -54,7 +53,7 @@ data CleanFlags = CleanFlags
   { cleanCommonFlags :: !CommonSetupFlags
   , cleanSaveConf :: Flag Bool
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern CleanCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -235,7 +234,7 @@ data ConfigFlags = ConfigFlags
   -- `build-tool-depends` will be ignored. This allows a Cabal package with
   -- build-tool-dependencies to be built even if the tool is not found.
   }
-  deriving (Generic, Read, Show, Typeable)
+  deriving (Generic, Read, Show)
 
 pattern ConfigCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Global.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Global.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
@@ -51,7 +50,7 @@ data GlobalFlags = GlobalFlags
   , globalNumericVersion :: Flag Bool
   , globalWorkingDir :: Flag (SymbolicPath CWD (Dir Pkg))
   }
-  deriving (Generic, Typeable)
+  deriving (Generic)
 
 defaultGlobalFlags :: GlobalFlags
 defaultGlobalFlags =

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -76,7 +75,7 @@ import qualified Text.PrettyPrint as Disp
 --    from documentation tarballs, and we might also want to use different
 --    flags than for development builds, so in this case we store the generated
 --    documentation in @<dist>/doc/html/<package id>-docs@.
-data HaddockTarget = ForHackage | ForDevelopment deriving (Eq, Show, Generic, Typeable)
+data HaddockTarget = ForHackage | ForDevelopment deriving (Eq, Show, Generic)
 
 instance Binary HaddockTarget
 instance Structured HaddockTarget
@@ -116,7 +115,7 @@ data HaddockFlags = HaddockFlags
   , haddockOutputDir :: Flag FilePath
   , haddockUseUnicode :: Flag Bool
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern HaddockCommonFlags
   :: Flag Verbosity
@@ -442,7 +441,7 @@ data HaddockProjectFlags = HaddockProjectFlags
     haddockProjectResourcesDir :: Flag String
   , haddockProjectUseUnicode :: Flag Bool
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 defaultHaddockProjectFlags :: HaddockProjectFlags
 defaultHaddockProjectFlags =

--- a/Cabal/src/Distribution/Simple/Setup/Hscolour.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Hscolour.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -58,7 +57,7 @@ data HscolourFlags = HscolourFlags
   , hscolourBenchmarks :: Flag Bool
   , hscolourForeignLibs :: Flag Bool
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern HscolourCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Register.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Register.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -62,7 +61,7 @@ data RegisterFlags = RegisterFlags
   , regInPlace :: Flag Bool
   , regPrintId :: Flag Bool
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern RegisterCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Repl.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Repl.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -59,7 +58,7 @@ data ReplOptions = ReplOptions
   , replOptionsNoLoad :: Flag Bool
   , replOptionsFlagOutput :: Flag FilePath
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern ReplCommonFlags
   :: Flag Verbosity
@@ -102,7 +101,7 @@ data ReplFlags = ReplFlags
   , replReload :: Flag Bool
   , replReplOptions :: ReplOptions
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 instance Binary ReplFlags
 instance Structured ReplFlags

--- a/Cabal/src/Distribution/Simple/Setup/SDist.hs
+++ b/Cabal/src/Distribution/Simple/Setup/SDist.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -57,7 +56,7 @@ data SDistFlags = SDistFlags
   , sDistDirectory :: Flag FilePath
   , sDistListSources :: Flag FilePath
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern SDistCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Test.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Test.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -61,7 +60,7 @@ import qualified Text.PrettyPrint as Disp
 -- ------------------------------------------------------------
 
 data TestShowDetails = Never | Failures | Always | Streaming | Direct
-  deriving (Eq, Ord, Enum, Bounded, Generic, Show, Typeable)
+  deriving (Eq, Ord, Enum, Bounded, Generic, Show)
 
 instance Binary TestShowDetails
 instance Structured TestShowDetails
@@ -102,7 +101,7 @@ data TestFlags = TestFlags
   , -- TODO: think about if/how options are passed to test exes
     testOptions :: [PathTemplate]
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 pattern TestCommonFlags
   :: Flag Verbosity

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -424,7 +424,7 @@ die' verbosity msg = withFrozenCallStack $ do
 
 -- Type which will be a wrapper for cabal -exceptions and cabal-install exceptions
 data VerboseException a = VerboseException CallStack POSIXTime Verbosity a
-  deriving (Show, Typeable)
+  deriving (Show)
 
 -- Function which will replace the existing die' call sites
 dieWithException :: (HasCallStack, Show a1, Typeable a1, Exception (VerboseException a1)) => Verbosity -> a1 -> IO a

--- a/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -110,7 +109,7 @@ data ComponentLocalBuildInfo
       , componentExeDeps :: [UnitId]
       , componentInternalDeps :: [UnitId]
       }
-  deriving (Generic, Read, Show, Typeable)
+  deriving (Generic, Read, Show)
 
 instance Binary ComponentLocalBuildInfo
 instance Structured ComponentLocalBuildInfo

--- a/Cabal/src/Distribution/Types/DumpBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/DumpBuildInfo.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Types.DumpBuildInfo
@@ -10,7 +9,7 @@ import Distribution.Compat.Prelude
 data DumpBuildInfo
   = NoDumpBuildInfo
   | DumpBuildInfo
-  deriving (Read, Show, Eq, Ord, Enum, Bounded, Generic, Typeable)
+  deriving (Read, Show, Eq, Ord, Enum, Bounded, Generic)
 
 instance Binary DumpBuildInfo
 instance Structured DumpBuildInfo

--- a/Cabal/src/Distribution/Types/GivenComponent.hs
+++ b/Cabal/src/Distribution/Types/GivenComponent.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Types.GivenComponent
@@ -25,7 +24,7 @@ data GivenComponent = GivenComponent
   -- only, not for any component
   , givenComponentId :: ComponentId
   }
-  deriving (Generic, Read, Show, Eq, Typeable)
+  deriving (Generic, Read, Show, Eq)
 
 instance Binary GivenComponent
 instance Structured GivenComponent
@@ -42,7 +41,7 @@ data PromisedComponent = PromisedComponent
   -- only, not for any component
   , promisedComponentId :: ComponentId
   }
-  deriving (Generic, Read, Show, Eq, Typeable)
+  deriving (Generic, Read, Show, Eq)
 
 instance Binary PromisedComponent
 instance Structured PromisedComponent

--- a/Cabal/src/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildInfo.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -144,7 +143,7 @@ data LocalBuildInfo = NewLocalBuildInfo
   -- ^ Information about a package configuration
   -- that can be modified by the user at configuration time.
   }
-  deriving (Generic, Read, Show, Typeable)
+  deriving (Generic, Read, Show)
 
 {-# COMPLETE LocalBuildInfo #-}
 

--- a/Cabal/src/Distribution/Utils/NubList.hs
+++ b/Cabal/src/Distribution/Utils/NubList.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -22,7 +21,7 @@ import qualified Text.Read as R
 
 -- | NubList : A de-duplicated list that maintains the original order.
 newtype NubList a = NubList {fromNubList :: [a]}
-  deriving (Eq, Generic, Typeable)
+  deriving (Eq, Generic)
 
 -- NubList assumes that nub retains the list order while removing duplicate
 -- elements (keeping the first occurrence). Documentation for "Data.List.nub"

--- a/Cabal/src/Distribution/Verbosity.hs
+++ b/Cabal/src/Distribution/Verbosity.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 -----------------------------------------------------------------------------
@@ -92,7 +91,7 @@ data Verbosity = Verbosity
   , vFlags :: Set VerbosityFlag
   , vQuiet :: Bool
   }
-  deriving (Generic, Show, Read, Typeable)
+  deriving (Generic, Show, Read)
 
 mkVerbosity :: VerbosityLevel -> Verbosity
 mkVerbosity l = Verbosity{vLevel = l, vFlags = Set.empty, vQuiet = False}

--- a/Cabal/src/Distribution/Verbosity/Internal.hs
+++ b/Cabal/src/Distribution/Verbosity/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Verbosity.Internal
@@ -10,7 +9,7 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 data VerbosityLevel = Silent | Normal | Verbose | Deafening
-  deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable)
+  deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded)
 
 instance Binary VerbosityLevel
 instance Structured VerbosityLevel
@@ -24,7 +23,7 @@ data VerbosityFlag
   | -- | @since 3.4.0.0
     VStderr
   | VNoWarn
-  deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable)
+  deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded)
 
 instance Binary VerbosityFlag
 instance Structured VerbosityFlag

--- a/cabal-install-solver/src/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/OptionalStanza.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 module Distribution.Solver.Types.OptionalStanza (
     -- * OptionalStanza
@@ -38,7 +37,7 @@ import Distribution.Utils.Structured (Structured (..), nominalStructure)
 data OptionalStanza
     = TestStanzas
     | BenchStanzas
-  deriving (Eq, Ord, Enum, Bounded, Show, Generic, Typeable)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic)
 
 -- | String representation of an OptionalStanza.
 showStanza :: OptionalStanza -> String

--- a/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 -----------------------------------------------------------------------------
 -- |
@@ -52,7 +51,7 @@ import Distribution.Verbosity                   (Verbosity)
 -- but we don't know the exact version (because parsing of the version number
 -- failed).
 newtype PkgConfigDb = PkgConfigDb (M.Map PkgconfigName (Maybe PkgconfigVersion))
-     deriving (Show, Generic, Typeable)
+     deriving (Show, Generic)
 
 instance Binary PkgConfigDb
 instance Structured PkgConfigDb

--- a/cabal-install-solver/src/Distribution/Solver/Types/SourcePackage.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/SourcePackage.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 module Distribution.Solver.Types.SourcePackage
     ( PackageDescriptionOverride
     , SourcePackage(..)
@@ -25,7 +24,7 @@ data SourcePackage loc = SourcePackage
   , srcpkgSource        :: loc
   , srcpkgDescrOverride :: PackageDescriptionOverride
   }
-  deriving (Eq, Show, Generic, Typeable)
+  deriving (Eq, Show, Generic)
 
 instance Binary loc => Binary (SourcePackage loc)
 instance Structured loc => Structured (SourcePackage loc)

--- a/cabal-install/src/Distribution/Client/Compat/Semaphore.hs
+++ b/cabal-install/src/Distribution/Client/Compat/Semaphore.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 
 module Distribution.Client.Compat.Semaphore
@@ -22,13 +21,12 @@ import Control.Exception (mask_, onException)
 import Control.Monad (join, unless)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
-import Data.Typeable (Typeable)
 
 -- | 'QSem' is a quantity semaphore in which the resource is acquired
 -- and released in units of one. It provides guaranteed FIFO ordering
 -- for satisfying blocked `waitQSem` calls.
 data QSem = QSem !(TVar Int) !(TVar [TVar Bool]) !(TVar [TVar Bool])
-  deriving (Eq, Typeable)
+  deriving (Eq)
 
 newQSem :: Int -> IO QSem
 newQSem i = atomically $ do

--- a/cabal-install/src/Distribution/Client/Errors.hs
+++ b/cabal-install/src/Distribution/Client/Errors.hs
@@ -184,7 +184,7 @@ data CabalInstallException
   | MissingPackageList Repo.RemoteRepo
   | CmdPathAcceptsNoTargets
   | CmdPathCommandDoesn'tSupportDryRun
-  deriving (Show, Typeable)
+  deriving (Show)
 
 exceptionCodeCabalInstall :: CabalInstallException -> Int
 exceptionCodeCabalInstall e = case e of

--- a/cabal-install/src/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/FileMonitor.hs
@@ -1121,7 +1121,7 @@ checkDirectoryModificationTime dir mtime =
 handleErrorCall :: a -> IO a -> IO a
 handleErrorCall e = handle handler
   where
-    handler (ErrorCallWithLocation _ _) = return e
+    handler (ErrorCall _) = return e
 
 -- | Run an IO computation, returning @e@ if there is any 'IOException'.
 --

--- a/cabal-install/src/Distribution/Client/HashValue.hs
+++ b/cabal-install/src/Distribution/Client/HashValue.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Distribution.Client.HashValue
@@ -38,7 +37,7 @@ import System.IO (IOMode (..), withBinaryFile)
 -- package ids.
 
 newtype HashValue = HashValue BS.ByteString
-  deriving (Eq, Generic, Show, Typeable)
+  deriving (Eq, Generic, Show)
 
 -- Cannot do any sensible validation here. Although we use SHA256
 -- for stuff we hash ourselves, we can also get hashes from TUF

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -692,7 +692,7 @@ data PreferredVersionsParseError = PreferredVersionsParseError
   , preferredVersionsOriginalDependency :: String
   -- ^ Original input that produced the parser error.
   }
-  deriving (Generic, Read, Show, Eq, Ord, Typeable)
+  deriving (Generic, Read, Show, Eq, Ord)
 
 -- | Parse `preferred-versions` file, collecting parse errors that can be shown
 -- in error messages.

--- a/cabal-install/src/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/src/Distribution/Client/InstallPlan.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -258,7 +257,6 @@ data GenericInstallPlan ipkg srcpkg = GenericInstallPlan
   { planGraph :: !(Graph (GenericPlanPackage ipkg srcpkg))
   , planIndepGoals :: !IndependentGoals
   }
-  deriving (Typeable)
 
 -- | 'GenericInstallPlan' specialised to most commonly used types.
 type InstallPlan =

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 -- | Types for the "Distribution.Client.ProjectBuilding"
 --
 -- Moved out to avoid module cycles.
@@ -156,7 +154,7 @@ data BuildFailure = BuildFailure
   { buildFailureLogFile :: Maybe FilePath
   , buildFailureReason :: BuildFailureReason
   }
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception BuildFailure
 

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -669,7 +668,7 @@ data BadProjectRoot
   | BadProjectRootAbsoluteFileNotFound FilePath
   | BadProjectRootDirFileNotFound FilePath FilePath
   | BadProjectRootFileBroken FilePath
-  deriving (Show, Typeable, Eq)
+  deriving (Show, Eq)
 
 instance Exception BadProjectRoot where
   displayException = renderBadProjectRoot
@@ -904,7 +903,7 @@ data ProjectPackageLocation
 -- | Exception thrown by 'findProjectPackages'.
 data BadPackageLocations
   = BadPackageLocations (Set ProjectConfigProvenance) [BadPackageLocation]
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception BadPackageLocations where
   displayException = renderBadPackageLocations
@@ -1579,7 +1578,6 @@ data CabalFileParseError
       -- ^ We might discover the spec version the package needs
       [PWarning]
       -- ^ warnings
-  deriving (Typeable)
 
 -- | Manual instance which skips file contents
 instance Show CabalFileParseError where
@@ -1631,7 +1629,7 @@ readSourcePackageCabalFile verbosity pkgfilename content =
 data CabalFileSearchFailure
   = NoCabalFileFound FilePath
   | MultipleCabalFilesFound FilePath
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception CabalFileSearchFailure
 
@@ -1741,7 +1739,7 @@ truncateString n s
 
 data BadPerPackageCompilerPaths
   = BadPerPackageCompilerPaths [(PackageName, String)]
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception BadPerPackageCompilerPaths where
   displayException = renderBadPerPackageCompilerPaths

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -152,7 +151,7 @@ data ProjectConfig = ProjectConfig
   -- any packages which are explicitly named in `cabal.project`.
   , projectConfigSpecificPackage :: MapMappend PackageName PackageConfig
   }
-  deriving (Eq, Show, Generic, Typeable)
+  deriving (Eq, Show, Generic)
 
 -- | That part of the project configuration that only affects /how/ we build
 -- and not the /value/ of the things we build. This means this information
@@ -338,7 +337,7 @@ instance Structured PackageConfig
 -- | Newtype wrapper for 'Map' that provides a 'Monoid' instance that takes
 -- the last value rather than the first value for overlapping keys.
 newtype MapLast k v = MapLast {getMapLast :: Map k v}
-  deriving (Eq, Show, Functor, Generic, Binary, Typeable)
+  deriving (Eq, Show, Functor, Generic, Binary)
 
 instance (Structured k, Structured v) => Structured (MapLast k v)
 
@@ -354,7 +353,7 @@ instance Ord k => Semigroup (MapLast k v) where
 -- | Newtype wrapper for 'Map' that provides a 'Monoid' instance that
 -- 'mappend's values of overlapping keys rather than taking the first.
 newtype MapMappend k v = MapMappend {getMapMappend :: Map k v}
-  deriving (Eq, Show, Functor, Generic, Binary, Typeable)
+  deriving (Eq, Show, Functor, Generic, Binary)
 
 instance (Structured k, Structured v) => Structured (MapMappend k v)
 
@@ -439,7 +438,7 @@ data SolverSettings = SolverSettings
   -- solverSettingOverrideReinstall :: Bool,
   -- solverSettingUpgradeDeps       :: Bool
   }
-  deriving (Eq, Show, Generic, Typeable)
+  deriving (Eq, Show, Generic)
 
 instance Binary SolverSettings
 instance Structured SolverSettings

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -192,7 +191,7 @@ data ElaboratedSharedConfig = ElaboratedSharedConfig
   -- used.
   , pkgConfigReplOptions :: ReplOptions
   }
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 -- TODO: [code cleanup] no Eq instance
 
@@ -337,7 +336,7 @@ data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
     elabPkgOrComp :: ElaboratedPackageOrComponent
   -- ^ Component/package specific information
   }
-  deriving (Eq, Show, Generic, Typeable)
+  deriving (Eq, Show, Generic)
 
 normaliseConfiguredPackage
   :: ElaboratedSharedConfig
@@ -933,7 +932,7 @@ data SetupScriptStyle
   | SetupCustomImplicitDeps
   | SetupNonCustomExternalLib
   | SetupNonCustomInternalLib
-  deriving (Eq, Show, Generic, Typeable)
+  deriving (Eq, Show, Generic)
 
 instance Binary SetupScriptStyle
 instance Structured SetupScriptStyle

--- a/cabal-install/src/Distribution/Client/SavedFlags.hs
+++ b/cabal-install/src/Distribution/Client/SavedFlags.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 module Distribution.Client.SavedFlags
   ( readCommandFlags
   , writeCommandFlags
@@ -67,7 +65,6 @@ data SavedArgsError
   = SavedArgsErrorHelp Args
   | SavedArgsErrorList Args
   | SavedArgsErrorOther Args [String]
-  deriving (Typeable)
 
 instance Show SavedArgsError where
   show (SavedArgsErrorHelp args) =

--- a/cabal-install/src/Distribution/Client/Security/HTTP.hs
+++ b/cabal-install/src/Distribution/Client/Security/HTTP.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -179,7 +178,6 @@ mkReqHeaders reqHeaders mRange' =
 -------------------------------------------------------------------------------}
 
 data UnexpectedResponse = UnexpectedResponse URI Int
-  deriving (Typeable)
 
 instance HC.Pretty UnexpectedResponse where
   pretty (UnexpectedResponse uri code) =

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1675,7 +1675,7 @@ data CheckFlags = CheckFlags
   { checkVerbosity :: Flag Verbosity
   , checkIgnore :: [CheckExplanationIDString]
   }
-  deriving (Show, Typeable)
+  deriving (Show)
 
 defaultCheckFlags :: CheckFlags
 defaultCheckFlags =

--- a/cabal-install/src/Distribution/Client/SolverInstallPlan.hs
+++ b/cabal-install/src/Distribution/Client/SolverInstallPlan.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -93,7 +92,7 @@ data SolverInstallPlan = SolverInstallPlan
   { planIndex :: !SolverPlanIndex
   , planIndepGoals :: !IndependentGoals
   }
-  deriving (Typeable, Generic)
+  deriving (Generic)
 
 {-
 -- | Much like 'planPkgIdOf', but mapping back to full packages.

--- a/cabal-install/src/Distribution/Client/Types/BuildResults.hs
+++ b/cabal-install/src/Distribution/Client/Types/BuildResults.hs
@@ -32,7 +32,7 @@ data BuildFailure
   | BuildFailed SomeException
   | TestsFailed SomeException
   | InstallFailed SomeException
-  deriving (Show, Typeable, Generic)
+  deriving (Show, Generic)
 
 instance Exception BuildFailure
 
@@ -48,9 +48,9 @@ data BuildResult
   deriving (Show, Generic)
 
 data DocsResult = DocsNotTried | DocsFailed | DocsOk
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 data TestsResult = TestsNotTried | TestsOk
-  deriving (Show, Generic, Typeable)
+  deriving (Show, Generic)
 
 instance Binary BuildFailure
 instance Binary BuildResult

--- a/cabal-install/src/Distribution/Client/Types/PackageLocation.hs
+++ b/cabal-install/src/Distribution/Client/Types/PackageLocation.hs
@@ -37,7 +37,7 @@ data PackageLocation local
     RepoTarballPackage Repo PackageId local
   | -- | A package available from a version control system source repository
     RemoteSourceRepoPackage SourceRepoMaybe local
-  deriving (Show, Functor, Eq, Ord, Generic, Typeable)
+  deriving (Show, Functor, Eq, Ord, Generic)
 
 instance Binary local => Binary (PackageLocation local)
 instance Structured local => Structured (PackageLocation local)

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -2287,7 +2286,6 @@ mkProjectConfig (GhcPath ghcPath) =
     maybeToFlag = maybe mempty toFlag
 
 data GhcPath = GhcPath (Maybe FilePath)
-  deriving (Typeable)
 
 instance IsOption GhcPath where
   defaultValue = GhcPath Nothing

--- a/cabal-install/tests/UnitTests/Distribution/Client/JobControl.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/JobControl.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 module UnitTests.Distribution.Client.JobControl (tests) where
 
 import Distribution.Client.JobControl
@@ -178,7 +176,7 @@ prop_cancel_parallel (Positive (Small maxJobLimit)) xs ys = do
     return $ Set.fromList (xs' ++ ys') `Set.isSubsetOf` Set.fromList (xs ++ ys)
 
 data TestException = TestException Int
-  deriving (Typeable, Show)
+  deriving (Show)
 
 instance Exception TestException
 

--- a/cabal-install/tests/UnitTests/Options.hs
+++ b/cabal-install/tests/UnitTests/Options.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 module UnitTests.Options
   ( OptionShowSolverLog (..)
   , OptionMtimeChangeDelay (..)
@@ -9,7 +7,6 @@ module UnitTests.Options
 where
 
 import Data.Proxy
-import Data.Typeable
 
 import Test.Tasty.Options
 
@@ -25,7 +22,6 @@ extraOptions =
   ]
 
 newtype OptionShowSolverLog = OptionShowSolverLog Bool
-  deriving (Typeable)
 
 instance IsOption OptionShowSolverLog where
   defaultValue = OptionShowSolverLog False
@@ -35,7 +31,6 @@ instance IsOption OptionShowSolverLog where
   optionCLParser = flagCLParser Nothing (OptionShowSolverLog True)
 
 newtype OptionMtimeChangeDelay = OptionMtimeChangeDelay Int
-  deriving (Typeable)
 
 instance IsOption OptionMtimeChangeDelay where
   defaultValue = OptionMtimeChangeDelay 0
@@ -47,7 +42,6 @@ instance IsOption OptionMtimeChangeDelay where
         ++ "file modification, in microseconds"
 
 newtype RunNetworkTests = RunNetworkTests Bool
-  deriving (Typeable)
 
 instance IsOption RunNetworkTests where
   defaultValue = RunNetworkTests True

--- a/cabal-testsuite/src/Test/Cabal/TestCode.hs
+++ b/cabal-testsuite/src/Test/Cabal/TestCode.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -17,7 +16,6 @@ module Test.Cabal.TestCode (
 ) where
 
 import Control.Exception (Exception (..))
-import Data.Typeable     (Typeable)
 
 -------------------------------------------------------------------------------
 -- TestCode
@@ -31,7 +29,7 @@ data TestCode
     | TestCodeFail
     | TestCodeFlakyFailed IssueID
     | TestCodeFlakyPassed IssueID
-  deriving (Eq, Show, Read, Typeable)
+  deriving (Eq, Show, Read)
 
 instance Exception TestCode
   where
@@ -53,7 +51,7 @@ isTestCodeSkip _                = False
 type TestPassed = Bool
 
 newtype IssueID = IssueID Int
-  deriving newtype (Eq, Typeable, Num, Show, Read)
+  deriving newtype (Eq, Num, Show, Read)
 
 data FlakyStatus
   = NotFlaky

--- a/cabal-validate/src/Cli.hs
+++ b/cabal-validate/src/Cli.hs
@@ -13,7 +13,6 @@ where
 import Control.Applicative (Alternative (many, (<|>)), (<**>))
 import Control.Exception (Exception (displayException), throw)
 import Control.Monad (forM_, when)
-import Data.Data (Typeable)
 import Data.Maybe (listToMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as T (toStrict)
@@ -136,7 +135,7 @@ data VersionParseException = VersionParseException
   , versionExecutable :: FilePath
   -- ^ The compiler which produced the string.
   }
-  deriving (Typeable, Show)
+  deriving (Show)
 
 instance Exception VersionParseException where
   displayException exception =

--- a/project-cabal/ghc-latest.config
+++ b/project-cabal/ghc-latest.config
@@ -14,11 +14,11 @@ if impl(ghc >= 9.12.0)
     -- Artem, 2024-04-21: I started and then gave up...
         *:base, *:template-haskell, text-short, *:deepseq, *:bytestring, *:ghc-prim
 
-    repository head.hackage.ghc.haskell.org
-        url: https://ghc.gitlab.haskell.org/head.hackage/
-        secure: True
-        key-threshold: 3
-        root-keys:
-            26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-            7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-            f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+--    repository head.hackage.ghc.haskell.org
+--        url: https://ghc.gitlab.haskell.org/head.hackage/
+--        secure: True
+--        key-threshold: 3
+--        root-keys:
+--            26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+--            7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+--            f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89

--- a/templates/SPDX.LicenseExceptionId.template.hs
+++ b/templates/SPDX.LicenseExceptionId.template.hs
@@ -32,7 +32,7 @@ import qualified Text.PrettyPrint as Disp
 -- | SPDX License Exceptions identifiers list v3.25
 data LicenseExceptionId
 {{ licenseIds }}
-  deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data, Generic)
+  deriving (Eq, Ord, Enum, Bounded, Show, Read, Data, Generic)
 
 instance Binary LicenseExceptionId where
     put = Binary.putWord8 . fromIntegral . fromEnum

--- a/templates/SPDX.LicenseId.template.hs
+++ b/templates/SPDX.LicenseId.template.hs
@@ -35,7 +35,7 @@ import qualified Text.PrettyPrint as Disp
 -- | SPDX License identifiers list v3.25
 data LicenseId
 {{ licenseIds }}
-  deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data)
+  deriving (Eq, Ord, Enum, Bounded, Show, Read, Data)
 
 instance Binary LicenseId where
     -- Word16 is encoded in big endianness


### PR DESCRIPTION
It still needs a bunch of allow-newer's but not head. hackage.

There were two fixups that 9.12 needs, see the commit hostory.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
