### PR TITLE
fix unix dependency correctly

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -54,7 +54,7 @@ library
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.15
   else
-    build-depends: unix  >= 2.6.0.0 && < 2.9
+    build-depends: unix  >= 2.8.6.0 && < 2.9
 
   if flag(git-rev)
     build-depends: githash ^>= 0.1.7.0

--- a/bootstrap/linux-9.0.2.json
+++ b/bootstrap/linux-9.0.2.json
@@ -63,29 +63,27 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
-            "component": "lib:data-array-byte",
-            "flags": [],
-            "package": "data-array-byte",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
-            "version": "0.1.0.1"
-        },
-        {
-            "cabal_sha256": "98e79e1c97117143e4012983509ec95f7e5e4f6adff6914d07812a39f83404b9",
+            "cabal_sha256": "3eee5d3658b657371d0f940f1f38feefc2ebdf8592a32d3d0734f28c61f80ba0",
             "component": "lib:bytestring",
-            "flags": [
-                "-pure-haskell"
-            ],
+            "flags": [],
             "package": "bytestring",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "ebc3b8a6ef74a5cd6ddbb8d447d1c9a5fd4964c7975ebcae0b8ab0bcc406cc8c",
-            "version": "0.12.1.0"
+            "src_sha256": "6bd8fa536ed6a8278bc98dfa9fdf2c91da662bea58fde929a6ba8a38bbe9d7eb",
+            "version": "0.11.5.3"
         },
         {
-            "cabal_sha256": "345cbb1afe414a09e47737e4d14cbd51891a734e67c0ef3d77a1439518bb81e8",
+            "cabal_sha256": "2efc549644dd418bad537d1601fdd437c440d807265016bd993b6996c679ad2f",
+            "component": "lib:os-string",
+            "flags": [],
+            "package": "os-string",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
+            "version": "2.0.7"
+        },
+        {
+            "cabal_sha256": "099c33e0e570dad93390e1c01c1f4bc6e4f13587de8e199df3c94a6cb62c7434",
             "component": "lib:filepath",
             "flags": [
                 "-cpphs"
@@ -93,32 +91,44 @@
             "package": "filepath",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "88d6452fd199e333e66e68d2dc5d715f5c6d361661a4a8add88320a82864b788",
-            "version": "1.4.300.2"
+            "src_sha256": "54aa86c432f593273d7b9f607c5b5e0a1628c2674c6f4e3b5a54eb0c83db5caf",
+            "version": "1.5.4.0"
         },
         {
-            "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
+            "cabal_sha256": "5b7f8afd7a879c3c8c3c636fd3c7543cdd5e0b514b7da90e76907ccd11434031",
             "component": "lib:unix",
             "flags": [
-                "-os-string"
+                "+os-string"
             ],
             "package": "unix",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
-            "version": "2.8.5.1"
+            "src_sha256": "8117599bb3e4aa1d4656710afbc85aef2a75483eddfac5338f8cc88fb505eea2",
+            "version": "2.8.6.0"
         },
         {
-            "cabal_sha256": "fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b",
-            "component": "lib:directory",
+            "cabal_sha256": "e3e1866eab82cb28f6a5f28507643da3987008b737e66a3c7398f39f16d824dc",
+            "component": "lib:file-io",
             "flags": [
-                "-os-string"
+                "+os-string"
             ],
-            "package": "directory",
+            "package": "file-io",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "e864ed54ddfc6e15d2eb02c87f4be8edd7719e1f9cea13e0f86909400b6ea768",
-            "version": "1.3.8.5"
+            "src_sha256": "e3d9113a015c57e3d8c2294550c41544f84a265291fed96cca697f91b6e86f52",
+            "version": "0.1.4"
+        },
+        {
+            "cabal_sha256": "2490137bb7738bd79392959458ef5f276219ea5ba8a9a56d3e0b06315c1bb917",
+            "component": "lib:directory",
+            "flags": [
+                "+os-string"
+            ],
+            "package": "directory",
+            "revision": 1,
+            "source": "hackage",
+            "src_sha256": "20a24846117fc5f8751d974b7de07210a161989410467e9adca525381b8e64cc",
+            "version": "1.3.9.0"
         },
         {
             "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
@@ -141,18 +151,17 @@
             "version": "0.8.9.2"
         },
         {
-            "cabal_sha256": "78c3fb91055d0607a80453327f087b9dc82168d41d0dca3ff410d21033b5e87d",
+            "cabal_sha256": "71b5fa8c64d3c1fd0a08f993463220867b08290a2256e94b0952bf0e8f5a45cc",
             "component": "lib:text",
             "flags": [
                 "-developer",
-                "-pure-haskell",
                 "+simdutf"
             ],
             "package": "text",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "e40cdda8b285f4d72476ed35dc2f5f167d524e6b38bb5ec964d00ee1ff24feab",
-            "version": "2.1.1"
+            "src_sha256": "c735be650a898606ce9f2c8642bc6ac6123eea82871d5e90f92797801f59efad",
+            "version": "2.0.2"
         },
         {
             "cabal_sha256": "8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56",
@@ -175,19 +184,21 @@
             "version": "3.15.0.0"
         },
         {
-            "cabal_sha256": "684028fb5ac3d1c7657fe516f2a442d95a53ae2fcf6f6151544f3ed5289f6320",
+            "cabal_sha256": "9a0b2ef8096517fa0e0c7a5e9a5c2ae5744ed824c3331005f9408245810df345",
             "component": "lib:process",
             "flags": [],
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a816655978c2527d8d7a6ebfd6f1ca79027f27ac4f2f28888f1581b2d558aea5",
-            "version": "1.6.23.0"
+            "src_sha256": "496fe0566c3915b112e9772ac9c967dfeb8d5ca04895e54ae0160522bee76e65",
+            "version": "1.6.25.0"
         },
         {
             "cabal_sha256": null,
             "component": "lib:Cabal",
-            "flags": [],
+            "flags": [
+                "-git-rev"
+            ],
             "package": "Cabal",
             "revision": null,
             "source": "local",
@@ -205,19 +216,19 @@
             "version": "3.16"
         },
         {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+            "cabal_sha256": "276325277350cd2c2c88916ed3ae5cd35b2b4f494ec594fbd9534081eb7fb759",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
+            "cabal_sha256": "b0fafb2834530084f6406017500ae619f9e5e2049787a6750c68e0d331fd62dc",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -225,8 +236,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
-            "version": "3.2.2.0"
+            "src_sha256": "dbd8a10456908294eb5ab9c522bf2da75444d958429a643a821464213698523e",
+            "version": "3.2.6.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -274,27 +285,27 @@
             "version": "0.9.2"
         },
         {
-            "cabal_sha256": "573f3ab242f75465a0d67ce9d84202650a1606575e6dbd6d31ffcf4767a9a379",
+            "cabal_sha256": "50b2f002c68fe67730ee7a3cd8607486197dd99b084255005ad51ecd6970a41b",
             "component": "lib:hashable",
             "flags": [
-                "-arch-native",
+                "+containers",
                 "+integer-gmp",
                 "-random-initial-seed"
             ],
             "package": "hashable",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "3baee4c9027a08830d148ec524cbc0471de645e1e8426d46780ef2758df0e8da",
-            "version": "1.4.7.0"
+            "src_sha256": "e1b305c280e66ad827edeaedd6933b9fc4174f626882877eab2a08344e665e87",
+            "version": "1.4.1.0"
         },
         {
-            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
+            "cabal_sha256": "b7648c6165729a973d95cb328f9fd874813a81c727707e8b2552b4f03399763b",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -417,16 +428,6 @@
             "version": "0.1.2"
         },
         {
-            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
-            "version": "2.0.6"
-        },
-        {
             "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar-internal",
             "flags": [],
@@ -447,7 +448,7 @@
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
+            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -455,7 +456,7 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
@@ -506,11 +507,11 @@
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+            "cabal_sha256": "3e196e1362e4d0ec9dfcd7f8d58b24fac91beafaa1c8ee34dc9dee489c362377",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
@@ -539,6 +540,7 @@
             "cabal_sha256": null,
             "component": "lib:cabal-install",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],
@@ -552,6 +554,7 @@
             "cabal_sha256": null,
             "component": "exe:cabal",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],

--- a/bootstrap/linux-9.2.8.json
+++ b/bootstrap/linux-9.2.8.json
@@ -79,17 +79,17 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
+            "cabal_sha256": "2efc549644dd418bad537d1601fdd437c440d807265016bd993b6996c679ad2f",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
-            "version": "2.0.6"
+            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
+            "version": "2.0.7"
         },
         {
-            "cabal_sha256": "0c64bc9a4f5946c86a8f0527bf40c8ba51e2c02d36eea0e20ea558c8d94166e8",
+            "cabal_sha256": "099c33e0e570dad93390e1c01c1f4bc6e4f13587de8e199df3c94a6cb62c7434",
             "component": "lib:filepath",
             "flags": [
                 "-cpphs"
@@ -97,32 +97,44 @@
             "package": "filepath",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "d807ec44fe53de7c7e0eeb41c9ee9185a09163821cf50549d73d875197931a5a",
-            "version": "1.5.3.0"
+            "src_sha256": "54aa86c432f593273d7b9f607c5b5e0a1628c2674c6f4e3b5a54eb0c83db5caf",
+            "version": "1.5.4.0"
         },
         {
-            "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
+            "cabal_sha256": "5b7f8afd7a879c3c8c3c636fd3c7543cdd5e0b514b7da90e76907ccd11434031",
             "component": "lib:unix",
             "flags": [
                 "+os-string"
             ],
             "package": "unix",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
-            "version": "2.8.5.1"
+            "src_sha256": "8117599bb3e4aa1d4656710afbc85aef2a75483eddfac5338f8cc88fb505eea2",
+            "version": "2.8.6.0"
         },
         {
-            "cabal_sha256": "fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b",
+            "cabal_sha256": "e3e1866eab82cb28f6a5f28507643da3987008b737e66a3c7398f39f16d824dc",
+            "component": "lib:file-io",
+            "flags": [
+                "+os-string"
+            ],
+            "package": "file-io",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "e3d9113a015c57e3d8c2294550c41544f84a265291fed96cca697f91b6e86f52",
+            "version": "0.1.4"
+        },
+        {
+            "cabal_sha256": "2490137bb7738bd79392959458ef5f276219ea5ba8a9a56d3e0b06315c1bb917",
             "component": "lib:directory",
             "flags": [
                 "+os-string"
             ],
             "package": "directory",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "e864ed54ddfc6e15d2eb02c87f4be8edd7719e1f9cea13e0f86909400b6ea768",
-            "version": "1.3.8.5"
+            "src_sha256": "20a24846117fc5f8751d974b7de07210a161989410467e9adca525381b8e64cc",
+            "version": "1.3.9.0"
         },
         {
             "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
@@ -145,19 +157,21 @@
             "version": "3.15.0.0"
         },
         {
-            "cabal_sha256": "684028fb5ac3d1c7657fe516f2a442d95a53ae2fcf6f6151544f3ed5289f6320",
+            "cabal_sha256": "9a0b2ef8096517fa0e0c7a5e9a5c2ae5744ed824c3331005f9408245810df345",
             "component": "lib:process",
             "flags": [],
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a816655978c2527d8d7a6ebfd6f1ca79027f27ac4f2f28888f1581b2d558aea5",
-            "version": "1.6.23.0"
+            "src_sha256": "496fe0566c3915b112e9772ac9c967dfeb8d5ca04895e54ae0160522bee76e65",
+            "version": "1.6.25.0"
         },
         {
             "cabal_sha256": null,
             "component": "lib:Cabal",
-            "flags": [],
+            "flags": [
+                "-git-rev"
+            ],
             "package": "Cabal",
             "revision": null,
             "source": "local",
@@ -175,19 +189,19 @@
             "version": "3.16"
         },
         {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+            "cabal_sha256": "276325277350cd2c2c88916ed3ae5cd35b2b4f494ec594fbd9534081eb7fb759",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
+            "cabal_sha256": "b0fafb2834530084f6406017500ae619f9e5e2049787a6750c68e0d331fd62dc",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -195,8 +209,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
-            "version": "3.2.2.0"
+            "src_sha256": "dbd8a10456908294eb5ab9c522bf2da75444d958429a643a821464213698523e",
+            "version": "3.2.6.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -234,11 +248,11 @@
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
+            "cabal_sha256": "3a4040018d8f90beef81ecd0ba37f266a9aaad3e902dd790f09056f892ba22fb",
             "component": "lib:data-array-byte",
             "flags": [],
             "package": "data-array-byte",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
             "version": "0.1.0.1"
@@ -258,13 +272,13 @@
             "version": "1.4.7.0"
         },
         {
-            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
+            "cabal_sha256": "b7648c6165729a973d95cb328f9fd874813a81c727707e8b2552b4f03399763b",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -407,7 +421,7 @@
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
+            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -415,7 +429,7 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
@@ -466,11 +480,11 @@
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+            "cabal_sha256": "3e196e1362e4d0ec9dfcd7f8d58b24fac91beafaa1c8ee34dc9dee489c362377",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
@@ -499,6 +513,7 @@
             "cabal_sha256": null,
             "component": "lib:cabal-install",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],
@@ -512,6 +527,7 @@
             "cabal_sha256": null,
             "component": "exe:cabal",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],

--- a/bootstrap/linux-9.4.8.json
+++ b/bootstrap/linux-9.4.8.json
@@ -79,17 +79,17 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
+            "cabal_sha256": "2efc549644dd418bad537d1601fdd437c440d807265016bd993b6996c679ad2f",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
-            "version": "2.0.6"
+            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
+            "version": "2.0.7"
         },
         {
-            "cabal_sha256": "0c64bc9a4f5946c86a8f0527bf40c8ba51e2c02d36eea0e20ea558c8d94166e8",
+            "cabal_sha256": "099c33e0e570dad93390e1c01c1f4bc6e4f13587de8e199df3c94a6cb62c7434",
             "component": "lib:filepath",
             "flags": [
                 "-cpphs"
@@ -97,32 +97,44 @@
             "package": "filepath",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "d807ec44fe53de7c7e0eeb41c9ee9185a09163821cf50549d73d875197931a5a",
-            "version": "1.5.3.0"
+            "src_sha256": "54aa86c432f593273d7b9f607c5b5e0a1628c2674c6f4e3b5a54eb0c83db5caf",
+            "version": "1.5.4.0"
         },
         {
-            "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
+            "cabal_sha256": "5b7f8afd7a879c3c8c3c636fd3c7543cdd5e0b514b7da90e76907ccd11434031",
             "component": "lib:unix",
             "flags": [
                 "+os-string"
             ],
             "package": "unix",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
-            "version": "2.8.5.1"
+            "src_sha256": "8117599bb3e4aa1d4656710afbc85aef2a75483eddfac5338f8cc88fb505eea2",
+            "version": "2.8.6.0"
         },
         {
-            "cabal_sha256": "fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b",
+            "cabal_sha256": "e3e1866eab82cb28f6a5f28507643da3987008b737e66a3c7398f39f16d824dc",
+            "component": "lib:file-io",
+            "flags": [
+                "+os-string"
+            ],
+            "package": "file-io",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "e3d9113a015c57e3d8c2294550c41544f84a265291fed96cca697f91b6e86f52",
+            "version": "0.1.4"
+        },
+        {
+            "cabal_sha256": "2490137bb7738bd79392959458ef5f276219ea5ba8a9a56d3e0b06315c1bb917",
             "component": "lib:directory",
             "flags": [
                 "+os-string"
             ],
             "package": "directory",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "e864ed54ddfc6e15d2eb02c87f4be8edd7719e1f9cea13e0f86909400b6ea768",
-            "version": "1.3.8.5"
+            "src_sha256": "20a24846117fc5f8751d974b7de07210a161989410467e9adca525381b8e64cc",
+            "version": "1.3.9.0"
         },
         {
             "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
@@ -145,19 +157,21 @@
             "version": "3.15.0.0"
         },
         {
-            "cabal_sha256": "684028fb5ac3d1c7657fe516f2a442d95a53ae2fcf6f6151544f3ed5289f6320",
+            "cabal_sha256": "9a0b2ef8096517fa0e0c7a5e9a5c2ae5744ed824c3331005f9408245810df345",
             "component": "lib:process",
             "flags": [],
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a816655978c2527d8d7a6ebfd6f1ca79027f27ac4f2f28888f1581b2d558aea5",
-            "version": "1.6.23.0"
+            "src_sha256": "496fe0566c3915b112e9772ac9c967dfeb8d5ca04895e54ae0160522bee76e65",
+            "version": "1.6.25.0"
         },
         {
             "cabal_sha256": null,
             "component": "lib:Cabal",
-            "flags": [],
+            "flags": [
+                "-git-rev"
+            ],
             "package": "Cabal",
             "revision": null,
             "source": "local",
@@ -175,19 +189,19 @@
             "version": "3.16"
         },
         {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+            "cabal_sha256": "276325277350cd2c2c88916ed3ae5cd35b2b4f494ec594fbd9534081eb7fb759",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
+            "cabal_sha256": "b0fafb2834530084f6406017500ae619f9e5e2049787a6750c68e0d331fd62dc",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -195,8 +209,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
-            "version": "3.2.2.0"
+            "src_sha256": "dbd8a10456908294eb5ab9c522bf2da75444d958429a643a821464213698523e",
+            "version": "3.2.6.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -248,13 +262,13 @@
             "version": "1.4.7.0"
         },
         {
-            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
+            "cabal_sha256": "b7648c6165729a973d95cb328f9fd874813a81c727707e8b2552b4f03399763b",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -397,7 +411,7 @@
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
+            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -405,7 +419,7 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
@@ -456,11 +470,11 @@
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+            "cabal_sha256": "3e196e1362e4d0ec9dfcd7f8d58b24fac91beafaa1c8ee34dc9dee489c362377",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
@@ -489,6 +503,7 @@
             "cabal_sha256": null,
             "component": "lib:cabal-install",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],
@@ -502,6 +517,7 @@
             "cabal_sha256": null,
             "component": "exe:cabal",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],

--- a/bootstrap/linux-9.6.6.json
+++ b/bootstrap/linux-9.6.6.json
@@ -69,14 +69,6 @@
             "version": "1.12.2"
         },
         {
-            "package": "unix",
-            "version": "2.8.4.0"
-        },
-        {
-            "package": "directory",
-            "version": "1.3.8.5"
-        },
-        {
             "package": "binary",
             "version": "0.8.9.1"
         },
@@ -87,13 +79,45 @@
         {
             "package": "parsec",
             "version": "3.1.16.1"
-        },
-        {
-            "package": "process",
-            "version": "1.6.19.0"
         }
     ],
     "dependencies": [
+        {
+            "cabal_sha256": "5b7f8afd7a879c3c8c3c636fd3c7543cdd5e0b514b7da90e76907ccd11434031",
+            "component": "lib:unix",
+            "flags": [
+                "-os-string"
+            ],
+            "package": "unix",
+            "revision": 1,
+            "source": "hackage",
+            "src_sha256": "8117599bb3e4aa1d4656710afbc85aef2a75483eddfac5338f8cc88fb505eea2",
+            "version": "2.8.6.0"
+        },
+        {
+            "cabal_sha256": "e3e1866eab82cb28f6a5f28507643da3987008b737e66a3c7398f39f16d824dc",
+            "component": "lib:file-io",
+            "flags": [
+                "-os-string"
+            ],
+            "package": "file-io",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "e3d9113a015c57e3d8c2294550c41544f84a265291fed96cca697f91b6e86f52",
+            "version": "0.1.4"
+        },
+        {
+            "cabal_sha256": "2490137bb7738bd79392959458ef5f276219ea5ba8a9a56d3e0b06315c1bb917",
+            "component": "lib:directory",
+            "flags": [
+                "-os-string"
+            ],
+            "package": "directory",
+            "revision": 1,
+            "source": "hackage",
+            "src_sha256": "20a24846117fc5f8751d974b7de07210a161989410467e9adca525381b8e64cc",
+            "version": "1.3.9.0"
+        },
         {
             "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
             "component": "exe:alex",
@@ -115,9 +139,21 @@
             "version": "3.15.0.0"
         },
         {
+            "cabal_sha256": "9a0b2ef8096517fa0e0c7a5e9a5c2ae5744ed824c3331005f9408245810df345",
+            "component": "lib:process",
+            "flags": [],
+            "package": "process",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "496fe0566c3915b112e9772ac9c967dfeb8d5ca04895e54ae0160522bee76e65",
+            "version": "1.6.25.0"
+        },
+        {
             "cabal_sha256": null,
             "component": "lib:Cabal",
-            "flags": [],
+            "flags": [
+                "-git-rev"
+            ],
             "package": "Cabal",
             "revision": null,
             "source": "local",
@@ -132,22 +168,22 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.16"
         },
         {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+            "cabal_sha256": "276325277350cd2c2c88916ed3ae5cd35b2b4f494ec594fbd9534081eb7fb759",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
+            "cabal_sha256": "b0fafb2834530084f6406017500ae619f9e5e2049787a6750c68e0d331fd62dc",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -155,8 +191,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
-            "version": "3.2.2.0"
+            "src_sha256": "dbd8a10456908294eb5ab9c522bf2da75444d958429a643a821464213698523e",
+            "version": "3.2.6.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -194,36 +230,36 @@
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
+            "cabal_sha256": "2efc549644dd418bad537d1601fdd437c440d807265016bd993b6996c679ad2f",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
-            "version": "2.0.6"
+            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
+            "version": "2.0.7"
         },
         {
-            "cabal_sha256": "fc68b07d957ade5a0a0beadd560a8d093ceac30b2f35c85eed3bcf7889a25975",
+            "cabal_sha256": "2f23146cbe0325029927b221647695a4c7d6e97548ff731110979e34361f58ef",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
                 "-random-initial-seed"
             ],
             "package": "hashable",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
             "version": "1.5.0.0"
         },
         {
-            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
+            "cabal_sha256": "b7648c6165729a973d95cb328f9fd874813a81c727707e8b2552b4f03399763b",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -366,7 +402,7 @@
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
+            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -374,7 +410,7 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
@@ -425,11 +461,11 @@
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+            "cabal_sha256": "3e196e1362e4d0ec9dfcd7f8d58b24fac91beafaa1c8ee34dc9dee489c362377",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
@@ -458,6 +494,7 @@
             "cabal_sha256": null,
             "component": "lib:cabal-install",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],
@@ -471,6 +508,7 @@
             "cabal_sha256": null,
             "component": "exe:cabal",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],

--- a/bootstrap/linux-9.8.2.json
+++ b/bootstrap/linux-9.8.2.json
@@ -61,20 +61,8 @@
             "version": "0.10.7"
         },
         {
-            "package": "filepath",
-            "version": "1.4.200.1"
-        },
-        {
             "package": "time",
             "version": "1.12.2"
-        },
-        {
-            "package": "unix",
-            "version": "2.8.4.0"
-        },
-        {
-            "package": "directory",
-            "version": "1.3.8.1"
         },
         {
             "package": "binary",
@@ -87,17 +75,67 @@
         {
             "package": "parsec",
             "version": "3.1.17.0"
-        },
-        {
-            "package": "process",
-            "version": "1.6.18.0"
-        },
-        {
-            "package": "semaphore-compat",
-            "version": "1.0.0"
         }
     ],
     "dependencies": [
+        {
+            "cabal_sha256": "2efc549644dd418bad537d1601fdd437c440d807265016bd993b6996c679ad2f",
+            "component": "lib:os-string",
+            "flags": [],
+            "package": "os-string",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
+            "version": "2.0.7"
+        },
+        {
+            "cabal_sha256": "099c33e0e570dad93390e1c01c1f4bc6e4f13587de8e199df3c94a6cb62c7434",
+            "component": "lib:filepath",
+            "flags": [
+                "-cpphs"
+            ],
+            "package": "filepath",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "54aa86c432f593273d7b9f607c5b5e0a1628c2674c6f4e3b5a54eb0c83db5caf",
+            "version": "1.5.4.0"
+        },
+        {
+            "cabal_sha256": "5b7f8afd7a879c3c8c3c636fd3c7543cdd5e0b514b7da90e76907ccd11434031",
+            "component": "lib:unix",
+            "flags": [
+                "+os-string"
+            ],
+            "package": "unix",
+            "revision": 1,
+            "source": "hackage",
+            "src_sha256": "8117599bb3e4aa1d4656710afbc85aef2a75483eddfac5338f8cc88fb505eea2",
+            "version": "2.8.6.0"
+        },
+        {
+            "cabal_sha256": "e3e1866eab82cb28f6a5f28507643da3987008b737e66a3c7398f39f16d824dc",
+            "component": "lib:file-io",
+            "flags": [
+                "+os-string"
+            ],
+            "package": "file-io",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "e3d9113a015c57e3d8c2294550c41544f84a265291fed96cca697f91b6e86f52",
+            "version": "0.1.4"
+        },
+        {
+            "cabal_sha256": "2490137bb7738bd79392959458ef5f276219ea5ba8a9a56d3e0b06315c1bb917",
+            "component": "lib:directory",
+            "flags": [
+                "+os-string"
+            ],
+            "package": "directory",
+            "revision": 1,
+            "source": "hackage",
+            "src_sha256": "20a24846117fc5f8751d974b7de07210a161989410467e9adca525381b8e64cc",
+            "version": "1.3.9.0"
+        },
         {
             "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
             "component": "exe:alex",
@@ -119,9 +157,21 @@
             "version": "3.15.0.0"
         },
         {
+            "cabal_sha256": "9a0b2ef8096517fa0e0c7a5e9a5c2ae5744ed824c3331005f9408245810df345",
+            "component": "lib:process",
+            "flags": [],
+            "package": "process",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "496fe0566c3915b112e9772ac9c967dfeb8d5ca04895e54ae0160522bee76e65",
+            "version": "1.6.25.0"
+        },
+        {
             "cabal_sha256": null,
             "component": "lib:Cabal",
-            "flags": [],
+            "flags": [
+                "-git-rev"
+            ],
             "package": "Cabal",
             "revision": null,
             "source": "local",
@@ -139,19 +189,19 @@
             "version": "3.16"
         },
         {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+            "cabal_sha256": "276325277350cd2c2c88916ed3ae5cd35b2b4f494ec594fbd9534081eb7fb759",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
+            "cabal_sha256": "b0fafb2834530084f6406017500ae619f9e5e2049787a6750c68e0d331fd62dc",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -159,8 +209,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
-            "version": "3.2.2.0"
+            "src_sha256": "dbd8a10456908294eb5ab9c522bf2da75444d958429a643a821464213698523e",
+            "version": "3.2.6.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -198,36 +248,26 @@
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
-            "version": "2.0.6"
-        },
-        {
-            "cabal_sha256": "fc68b07d957ade5a0a0beadd560a8d093ceac30b2f35c85eed3bcf7889a25975",
+            "cabal_sha256": "2f23146cbe0325029927b221647695a4c7d6e97548ff731110979e34361f58ef",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
                 "-random-initial-seed"
             ],
             "package": "hashable",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
             "version": "1.5.0.0"
         },
         {
-            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
+            "cabal_sha256": "b7648c6165729a973d95cb328f9fd874813a81c727707e8b2552b4f03399763b",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -370,7 +410,7 @@
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
+            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -378,7 +418,7 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
@@ -429,11 +469,11 @@
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+            "cabal_sha256": "3e196e1362e4d0ec9dfcd7f8d58b24fac91beafaa1c8ee34dc9dee489c362377",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
@@ -449,9 +489,20 @@
             "version": "0.1.7.4"
         },
         {
+            "cabal_sha256": "2de5218cef72b8ef090bd7d0fd930ffa143242a120c62e013b5cf039858f1855",
+            "component": "lib:semaphore-compat",
+            "flags": [],
+            "package": "semaphore-compat",
+            "revision": 3,
+            "source": "hackage",
+            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
+            "version": "1.0.0"
+        },
+        {
             "cabal_sha256": null,
             "component": "lib:cabal-install",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],
@@ -465,6 +516,7 @@
             "cabal_sha256": null,
             "component": "exe:cabal",
             "flags": [
+                "-git-rev",
                 "+lukko",
                 "+native-dns"
             ],

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -265,7 +265,7 @@ library
       -- newer directory for symlinks
       build-depends: Win32 >= 2.8 && < 3, directory >=1.3.1.0
     else
-      build-depends: unix >= 2.5 && < 2.9
+      build-depends: unix >= 2.5 && < 2.8 || >= 2.8.6.0 && < 2.9
 
     if flag(lukko)
       build-depends: lukko >= 0.1 && <0.2

--- a/cabal.bootstrap.project
+++ b/cabal.bootstrap.project
@@ -9,4 +9,4 @@ packages:
 tests: False
 benchmarks: False
 
-index-state: hackage.haskell.org 2024-09-06T14:16:40Z
+index-state: hackage.haskell.org 2024-11-20T00:00:00Z

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -2,7 +2,7 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
-index-state: hackage.haskell.org 2024-09-06T14:16:40Z
+index-state: hackage.haskell.org 2024-11-20T00:00:00Z
 
 -- never include this or its TH dependency in a release!
 package cabal-install
@@ -10,8 +10,3 @@ package cabal-install
 
 package Cabal
   flags: -git-rev
-
--- https://github.com/haskell/ghcup-hs/issues/1107
--- https://github.com/haskell/unix/pull/318
-if arch(arm) || arch(i386)
-  constraints: unix >= 2.8.6.0


### PR DESCRIPTION
Patching `cabal.release.project` still allows the buggy `unix` release to be installed via Hackage.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
