### PR TITLE
Add cfgVerbosity

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdBench.hs
+++ b/cabal-install/src/Distribution/Client/CmdBench.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 -- | cabal-install CLI command: bench
 module Distribution.Client.CmdBench
   ( -- * The @bench@ CLI and action
@@ -29,13 +27,13 @@ import Distribution.Client.CmdErrorMessages
 import Distribution.Client.Errors
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.Setup
-  ( ConfigFlags (..)
-  , GlobalFlags
+  ( GlobalFlags
   )
 import Distribution.Client.TargetProblem
   ( TargetProblem (..)
@@ -47,10 +45,6 @@ import Distribution.Simple.Command
   ( CommandUI (..)
   , usageAlternatives
   )
-import Distribution.Simple.Flag
-  ( fromFlagOrDefault
-  )
-import Distribution.Simple.Setup (CommonSetupFlags (..))
 import Distribution.Simple.Utils
   ( dieWithException
   , warn
@@ -111,7 +105,7 @@ benchCommand =
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 benchAction :: NixStyleFlags () -> [String] -> GlobalFlags -> IO ()
-benchAction flags@NixStyleFlags{..} targetStrings globalFlags = do
+benchAction flags targetStrings globalFlags = do
   baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
 
   targetSelectors <-
@@ -151,7 +145,7 @@ benchAction flags@NixStyleFlags{..} targetStrings globalFlags = do
   buildOutcomes <- runProjectBuildPhase verbosity baseCtx buildCtx
   runProjectPostBuildPhase verbosity baseCtx buildCtx buildOutcomes
   where
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
     cliConfig =
       commandLineFlagsToProjectConfig
         globalFlags

--- a/cabal-install/src/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/src/Distribution/Client/CmdBuild.hs
@@ -135,7 +135,7 @@ defaultBuildFlags =
 -- "Distribution.Client.ProjectOrchestration"
 buildAction :: NixStyleFlags BuildFlags -> [String] -> GlobalFlags -> IO ()
 buildAction flags@NixStyleFlags{extraFlags = buildFlags, ..} targetStrings globalFlags =
-  withContextAndSelectors RejectNoTargets Nothing flags targetStrings globalFlags BuildCommand $ \targetCtx ctx targetSelectors -> do
+  withContextAndSelectors verbosity RejectNoTargets Nothing flags targetStrings globalFlags BuildCommand $ \targetCtx ctx targetSelectors -> do
     -- TODO: This flags defaults business is ugly
     let onlyConfigure =
           fromFlag

--- a/cabal-install/src/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/src/Distribution/Client/CmdBuild.hs
@@ -47,7 +47,7 @@ import Distribution.Simple.Command
   , option
   , usageAlternatives
   )
-import Distribution.Simple.Flag (Flag (..), fromFlag, fromFlagOrDefault, toFlag)
+import Distribution.Simple.Flag (Flag, fromFlag, toFlag)
 import Distribution.Simple.Utils
   ( dieWithException
   , wrapText

--- a/cabal-install/src/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/src/Distribution/Client/CmdBuild.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 -- | cabal-install CLI command: build
 module Distribution.Client.CmdBuild
   ( -- * The @build@ CLI and action
@@ -30,6 +28,7 @@ import qualified Data.Map as Map
 import Distribution.Client.Errors
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -40,9 +39,7 @@ import Distribution.Client.ScriptUtils
   , withContextAndSelectors
   )
 import Distribution.Client.Setup
-  ( CommonSetupFlags (..)
-  , ConfigFlags (..)
-  , GlobalFlags
+  ( GlobalFlags
   , yesNoOpt
   )
 import Distribution.Simple.Command
@@ -50,7 +47,7 @@ import Distribution.Simple.Command
   , option
   , usageAlternatives
   )
-import Distribution.Simple.Flag (Flag, fromFlag, fromFlagOrDefault, toFlag)
+import Distribution.Simple.Flag (Flag (..), fromFlag, fromFlagOrDefault, toFlag)
 import Distribution.Simple.Utils
   ( dieWithException
   , wrapText
@@ -134,7 +131,7 @@ defaultBuildFlags =
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 buildAction :: NixStyleFlags BuildFlags -> [String] -> GlobalFlags -> IO ()
-buildAction flags@NixStyleFlags{extraFlags = buildFlags, ..} targetStrings globalFlags =
+buildAction flags@NixStyleFlags{extraFlags = buildFlags} targetStrings globalFlags =
   withContextAndSelectors verbosity RejectNoTargets Nothing flags targetStrings globalFlags BuildCommand $ \targetCtx ctx targetSelectors -> do
     -- TODO: This flags defaults business is ugly
     let onlyConfigure =
@@ -185,7 +182,7 @@ buildAction flags@NixStyleFlags{extraFlags = buildFlags, ..} targetStrings globa
     buildOutcomes <- runProjectBuildPhase verbosity baseCtx buildCtx
     runProjectPostBuildPhase verbosity baseCtx buildCtx buildOutcomes
   where
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
 
 -- | This defines what a 'TargetSelector' means for the @bench@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-install/src/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/src/Distribution/Client/CmdConfigure.hs
@@ -22,16 +22,15 @@ import Distribution.Client.ProjectFlags
   )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Simple.Flag
-import Distribution.Simple.Setup (CommonSetupFlags (..))
 
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
 import Distribution.Client.Setup
   ( ConfigExFlags (..)
-  , ConfigFlags (..)
   , GlobalFlags
   )
 import Distribution.Verbosity
@@ -117,14 +116,14 @@ configureCommand =
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 configureAction :: NixStyleFlags () -> [String] -> GlobalFlags -> IO ()
-configureAction flags@NixStyleFlags{..} extraArgs globalFlags = do
+configureAction flags extraArgs globalFlags = do
   (baseCtx, projConfig) <- configureAction' flags extraArgs globalFlags
 
   if shouldNotWriteFile baseCtx
     then notice v "Config file not written due to flag(s)."
     else writeProjectLocalExtraConfig (distDirLayout baseCtx) projConfig
   where
-    v = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    v = cfgVerbosity normal flags
 
 configureAction' :: NixStyleFlags () -> [String] -> GlobalFlags -> IO (ProjectBaseContext, ProjectConfig)
 configureAction' flags@NixStyleFlags{..} _extraArgs globalFlags = do
@@ -165,7 +164,7 @@ configureAction' flags@NixStyleFlags{..} _extraArgs globalFlags = do
           return (baseCtx, conf <> cliConfig)
         else return (baseCtx, cliConfig)
   where
-    v = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    v = cfgVerbosity normal flags
     cliConfig =
       commandLineFlagsToProjectConfig
         globalFlags

--- a/cabal-install/src/Distribution/Client/CmdExec.hs
+++ b/cabal-install/src/Distribution/Client/CmdExec.hs
@@ -23,6 +23,7 @@ import Distribution.Client.InstallPlan
   )
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -58,14 +59,10 @@ import Distribution.Client.ProjectPlanning.Types
   ( dataDirsEnvironmentForPlan
   )
 import Distribution.Client.Setup
-  ( ConfigFlags (configCommonFlags)
-  , GlobalFlags
+  ( GlobalFlags
   )
 import Distribution.Simple.Command
   ( CommandUI (..)
-  )
-import Distribution.Simple.Flag
-  ( fromFlagOrDefault
   )
 import Distribution.Simple.GHC
   ( GhcImplInfo (supportsPkgEnvFiles)
@@ -87,7 +84,6 @@ import Distribution.Simple.Program.Run
   ( programInvocation
   , runProgramInvocation
   )
-import Distribution.Simple.Setup (CommonSetupFlags (..))
 import Distribution.Simple.Utils
   ( createDirectoryIfMissingVerbose
   , dieWithException
@@ -144,7 +140,7 @@ execCommand =
     }
 
 execAction :: NixStyleFlags () -> [String] -> GlobalFlags -> IO ()
-execAction flags@NixStyleFlags{..} extraArgs globalFlags = do
+execAction flags extraArgs globalFlags = do
   baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
 
   -- To set up the environment, we'd like to select the libraries in our
@@ -224,7 +220,7 @@ execAction flags@NixStyleFlags{..} extraArgs globalFlags = do
             then notice verbosity "Running of executable suppressed by flag(s)"
             else runProgramInvocation verbosity invocation
   where
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
     cliConfig =
       commandLineFlagsToProjectConfig
         globalFlags

--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RecordWildCards #-}
 
 -- | cabal-install CLI command: freeze
 module Distribution.Client.CmdFreeze
@@ -18,6 +17,7 @@ import Distribution.Client.IndexUtils (ActiveRepos, TotalIndexState, filterSkipp
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -41,9 +41,7 @@ import Distribution.Solver.Types.PackageConstraint
   )
 
 import Distribution.Client.Setup
-  ( CommonSetupFlags (setupVerbosity)
-  , ConfigFlags (..)
-  , GlobalFlags
+  ( GlobalFlags
   )
 import Distribution.Package
   ( PackageName
@@ -126,7 +124,7 @@ freezeCommand =
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 freezeAction :: NixStyleFlags () -> [String] -> GlobalFlags -> IO ()
-freezeAction flags@NixStyleFlags{..} extraArgs globalFlags = do
+freezeAction flags extraArgs globalFlags = do
   unless (null extraArgs) $
     dieWithException verbosity $
       FreezeAction extraArgs
@@ -161,7 +159,7 @@ freezeAction flags@NixStyleFlags{..} extraArgs globalFlags = do
       notice verbosity $
         "Wrote freeze file: " ++ (distProjectFile distDirLayout "freeze")
   where
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
     cliConfig =
       commandLineFlagsToProjectConfig
         globalFlags

--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -52,7 +52,7 @@ import Distribution.PackageDescription
   ( FlagAssignment
   , nullFlagAssignment
   )
-import Distribution.Simple.Flag (fromFlagOrDefault, pattern Flag)
+import Distribution.Simple.Flag (pattern Flag)
 import Distribution.Simple.Utils
   ( dieWithException
   , notice

--- a/cabal-install/src/Distribution/Client/CmdGenBounds.hs
+++ b/cabal-install/src/Distribution/Client/CmdGenBounds.hs
@@ -84,7 +84,6 @@ genBoundsCommand =
 genBoundsAction :: NixStyleFlags GenBoundsFlags -> [String] -> GlobalFlags -> IO ()
 genBoundsAction flags targetStrings globalFlags =
   withContextAndSelectors verbosity RejectNoTargets Nothing flags targetStrings globalFlags OtherCommand $ \targetCtx ctx targetSelectors -> do
-
     baseCtx <- case targetCtx of
       ProjectContext -> return ctx
       GlobalContext -> return ctx
@@ -153,8 +152,8 @@ genBoundsAction flags targetStrings globalFlags =
         notice verbosity boundsNeededMsg
         mapM_ (renderBoundsResult verbosity) boundsActions
       else notice verbosity "All bounds up-to-date"
- where
-  verbosity = cfgVerbosity normal flags
+  where
+    verbosity = cfgVerbosity normal flags
 
 data GenBoundsResult = GenBoundsResult PackageIdentifier ComponentTarget (Maybe [PackageIdentifier])
 

--- a/cabal-install/src/Distribution/Client/CmdGenBounds.hs
+++ b/cabal-install/src/Distribution/Client/CmdGenBounds.hs
@@ -27,7 +27,7 @@ import Distribution.PackageDescription
 import Distribution.Simple.Utils
 import Distribution.Version
 
-import Distribution.Client.Setup (CommonSetupFlags (..), ConfigFlags (..), GlobalFlags (..))
+import Distribution.Client.Setup (GlobalFlags (..))
 
 -- Project orchestration imports
 
@@ -40,7 +40,6 @@ import Distribution.Client.ProjectOrchestration
 import Distribution.Client.ScriptUtils
 import Distribution.Client.TargetProblem
 import Distribution.Simple.Command
-import Distribution.Simple.Flag
 import Distribution.Types.Component
 import Distribution.Verbosity
 
@@ -84,8 +83,7 @@ genBoundsCommand =
 -- | The action for the @gen-bounds@ command when used in a project context.
 genBoundsAction :: NixStyleFlags GenBoundsFlags -> [String] -> GlobalFlags -> IO ()
 genBoundsAction flags targetStrings globalFlags =
-  withContextAndSelectors RejectNoTargets Nothing flags targetStrings globalFlags OtherCommand $ \targetCtx ctx targetSelectors -> do
-    let verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags $ configFlags flags)
+  withContextAndSelectors verbosity RejectNoTargets Nothing flags targetStrings globalFlags OtherCommand $ \targetCtx ctx targetSelectors -> do
 
     baseCtx <- case targetCtx of
       ProjectContext -> return ctx
@@ -155,6 +153,8 @@ genBoundsAction flags targetStrings globalFlags =
         notice verbosity boundsNeededMsg
         mapM_ (renderBoundsResult verbosity) boundsActions
       else notice verbosity "All bounds up-to-date"
+ where
+  verbosity = cfgVerbosity normal flags
 
 data GenBoundsResult = GenBoundsResult PackageIdentifier ComponentTarget (Maybe [PackageIdentifier])
 

--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -20,6 +20,7 @@ import Prelude ()
 import Distribution.Client.CmdErrorMessages
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -32,9 +33,7 @@ import Distribution.Client.ProjectPlanning
   ( ElaboratedSharedConfig (..)
   )
 import Distribution.Client.Setup
-  ( CommonSetupFlags (..)
-  , ConfigFlags (..)
-  , GlobalFlags
+  ( GlobalFlags
   , InstallFlags (..)
   )
 import Distribution.Client.TargetProblem
@@ -150,7 +149,7 @@ haddockAction relFlags targetStrings globalFlags = do
   flags@NixStyleFlags{..} <- mkFlagsAbsolute relFlags
 
   let
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
     installDoc = fromFlagOrDefault True (installDocumentation installFlags)
     flags' = flags{installFlags = installFlags{installDocumentation = Flag installDoc}}
     cliConfig = commandLineFlagsToProjectConfig globalFlags flags' mempty -- ClientInstallFlags, not needed here

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -127,6 +127,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
   --
 
   withContextAndSelectors
+    verbosity
     RejectNoTargets
     Nothing
     (commandDefaultFlags CmdBuild.buildCommand)

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -63,6 +63,7 @@ import Distribution.Client.InstallSymlink
   )
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -98,8 +99,7 @@ import Distribution.Client.RebuildMonad
   ( runRebuild
   )
 import Distribution.Client.Setup
-  ( CommonSetupFlags (..)
-  , ConfigFlags (..)
+  ( ConfigFlags (..)
   , GlobalFlags (..)
   , InstallFlags (..)
   )
@@ -546,7 +546,7 @@ installAction flags@NixStyleFlags{extraFlags, configFlags, installFlags, project
           traverseInstall (installCheckUnitExes InstallCheckInstall) installCfg
   where
     configFlags' = disableTestsBenchsByDefault . ignoreProgramAffixes $ configFlags
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags')
+    verbosity = cfgVerbosity normal flags
     ignoreProject = flagIgnoreProject projectFlags
     cliConfig =
       commandLineFlagsToProjectConfig

--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -94,7 +94,7 @@ listbinAction flags@NixStyleFlags{..} args globalFlags = do
     _ -> dieWithException verbosity OneTargetRequired
 
   -- configure and elaborate target selectors
-  withContextAndSelectors RejectNoTargets (Just ExeKind) flags [target] globalFlags OtherCommand $ \targetCtx ctx targetSelectors -> do
+  withContextAndSelectors verbosity RejectNoTargets (Just ExeKind) flags [target] globalFlags OtherCommand $ \targetCtx ctx targetSelectors -> do
     baseCtx <- case targetCtx of
       ProjectContext -> return ctx
       GlobalContext -> return ctx

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -240,6 +240,7 @@ getSourcePackages verbosity projectConfig =
 outdatedAction :: NixStyleFlags OutdatedFlags -> [String] -> GlobalFlags -> IO ()
 outdatedAction flags targetStrings globalFlags =
   withContextAndSelectors
+    verbosity
     AcceptNoTargets
     Nothing
     flags

--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -226,7 +226,7 @@ pathName ConfigPathInstallDir = "installdir"
 
 -- | Entry point for the 'path' command.
 pathAction :: NixStyleFlags PathFlags -> [String] -> GlobalFlags -> IO ()
-pathAction flags@NixStyleFlags{extraFlags = pathFlags', ..} cliTargetStrings globalFlags = withContextAndSelectors AcceptNoTargets Nothing flags [] globalFlags OtherCommand $ \_ baseCtx _ -> do
+pathAction flags@NixStyleFlags{extraFlags = pathFlags', ..} cliTargetStrings globalFlags = withContextAndSelectors verbosity AcceptNoTargets Nothing flags [] globalFlags OtherCommand $ \_ baseCtx _ -> do
   let pathFlags =
         if pathCompiler pathFlags' == NoFlag && pathDirectories pathFlags' == NoFlag
           then -- if not a single key to query is given, query everything!

--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RecordWildCards #-}
 
 -- |
 -- Module      :  Distribution.Client.CmdPath
@@ -31,6 +30,7 @@ import Distribution.Client.Errors
 import Distribution.Client.GlobalFlags
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -44,8 +44,7 @@ import Distribution.Client.ProjectPlanning
 import Distribution.Client.RebuildMonad (runRebuild)
 import Distribution.Client.ScriptUtils
 import Distribution.Client.Setup
-  ( ConfigFlags (..)
-  , yesNoOpt
+  ( yesNoOpt
   )
 import Distribution.Client.Utils.Json
   ( (.=)
@@ -226,7 +225,7 @@ pathName ConfigPathInstallDir = "installdir"
 
 -- | Entry point for the 'path' command.
 pathAction :: NixStyleFlags PathFlags -> [String] -> GlobalFlags -> IO ()
-pathAction flags@NixStyleFlags{extraFlags = pathFlags', ..} cliTargetStrings globalFlags = withContextAndSelectors verbosity AcceptNoTargets Nothing flags [] globalFlags OtherCommand $ \_ baseCtx _ -> do
+pathAction flags@NixStyleFlags{extraFlags = pathFlags'} cliTargetStrings globalFlags = withContextAndSelectors verbosity AcceptNoTargets Nothing flags [] globalFlags OtherCommand $ \_ baseCtx _ -> do
   let pathFlags =
         if pathCompiler pathFlags' == NoFlag && pathDirectories pathFlags' == NoFlag
           then -- if not a single key to query is given, query everything!
@@ -268,7 +267,7 @@ pathAction flags@NixStyleFlags{extraFlags = pathFlags', ..} cliTargetStrings glo
 
   putStr $ withOutputMarker verbosity output
   where
-    verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
+    verbosity = cfgVerbosity normal flags
 
 -- | Find the FilePath location for common configuration paths.
 --

--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -43,6 +43,7 @@ import Distribution.Client.Errors
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -105,7 +106,6 @@ import Distribution.Simple.Compiler
 import Distribution.Simple.Setup
   ( ReplOptions (..)
   , commonSetupTempFileOptions
-  , setupVerbosity
   )
 import Distribution.Simple.Utils
   ( debugNoWrap
@@ -286,7 +286,7 @@ multiReplDecision ctx compiler flags =
 -- "Distribution.Client.ProjectOrchestration"
 replAction :: NixStyleFlags ReplFlags -> [String] -> GlobalFlags -> IO ()
 replAction flags@NixStyleFlags{extraFlags = r@ReplFlags{..}, ..} targetStrings globalFlags =
-  withContextAndSelectors AcceptNoTargets (Just LibKind) flags targetStrings globalFlags ReplCommand $ \targetCtx ctx targetSelectors -> do
+  withContextAndSelectors verbosity AcceptNoTargets (Just LibKind) flags targetStrings globalFlags ReplCommand $ \targetCtx ctx targetSelectors -> do
     when (buildSettingOnlyDeps (buildSettings ctx)) $
       dieWithException verbosity ReplCommandDoesn'tSupport
     let projectRoot = distProjectRootDirectory $ distDirLayout ctx
@@ -507,7 +507,7 @@ replAction flags@NixStyleFlags{extraFlags = r@ReplFlags{..}, ..} targetStrings g
         go m ("PATH", Just s) = foldl' (\m' f -> Map.insertWith (+) f 1 m') m (splitSearchPath s)
         go m _ = m
 
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
     tempFileOptions = commonSetupTempFileOptions $ configCommonFlags configFlags
 
     validatedTargets ctx compiler elaboratedPlan targetSelectors = do

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -206,13 +206,13 @@ runCommand =
 -- "Distribution.Client.ProjectOrchestration"
 runAction :: NixStyleFlags () -> [String] -> GlobalFlags -> IO ()
 runAction flags@NixStyleFlags{..} targetAndArgs globalFlags =
-  withContextAndSelectors RejectNoTargets (Just ExeKind) flags targetStr globalFlags OtherCommand $ \targetCtx ctx targetSelectors -> do
+  withContextAndSelectors (cfgVerbosity normal) RejectNoTargets (Just ExeKind) flags targetStr globalFlags OtherCommand $ \targetCtx ctx targetSelectors -> do
     (baseCtx, defaultVerbosity) <- case targetCtx of
       ProjectContext -> return (ctx, normal)
       GlobalContext -> return (ctx, normal)
       ScriptContext path exemeta -> (,silent) <$> updateContextAndWriteProjectFile ctx path exemeta
 
-    let verbosity = fromFlagOrDefault defaultVerbosity (setupVerbosity $ configCommonFlags configFlags)
+    let verbosity = cfgVerbosity defaultVerbosity
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do
@@ -360,6 +360,7 @@ runAction flags@NixStyleFlags{..} targetAndArgs globalFlags =
                     elaboratedPlan
             }
   where
+    cfgVerbosity v = fromFlagOrDefault v (setupVerbosity $ configCommonFlags configFlags)
     (targetStr, args) = splitAt 1 targetAndArgs
 
 -- | Used by the main CLI parser as heuristic to decide whether @cabal@ was

--- a/cabal-install/src/Distribution/Client/CmdTest.hs
+++ b/cabal-install/src/Distribution/Client/CmdTest.hs
@@ -29,14 +29,13 @@ import Distribution.Client.CmdErrorMessages
   )
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.Setup
-  ( CommonSetupFlags (..)
-  , ConfigFlags (..)
-  , GlobalFlags (..)
+  ( GlobalFlags (..)
   )
 import Distribution.Client.TargetProblem
   ( TargetProblem (..)
@@ -54,7 +53,6 @@ import Distribution.Simple.Flag
   )
 import Distribution.Simple.Setup
   ( TestFlags (..)
-  , fromFlagOrDefault
   )
 import Distribution.Simple.Utils
   ( dieWithException
@@ -166,7 +164,7 @@ testAction flags@NixStyleFlags{..} targetStrings globalFlags = do
   runProjectPostBuildPhase verbosity baseCtx buildCtx buildOutcomes
   where
     failWhenNoTestSuites = testFailWhenNoTestSuites testFlags
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
     cliConfig = commandLineFlagsToProjectConfig globalFlags flags mempty -- ClientInstallFlags
 
 -- | This defines what a 'TargetSelector' means for the @test@ command.

--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -37,6 +37,7 @@ import Distribution.Client.JobControl
   )
 import Distribution.Client.NixStyleOptions
   ( NixStyleFlags (..)
+  , cfgVerbosity
   , defaultNixStyleFlags
   , nixStyleOptions
   )
@@ -52,9 +53,7 @@ import Distribution.Client.ProjectFlags
   )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.Setup
-  ( CommonSetupFlags (..)
-  , ConfigFlags (..)
-  , GlobalFlags
+  ( GlobalFlags
   , RepoContext (..)
   , UpdateFlags
   , defaultUpdateFlags
@@ -65,9 +64,6 @@ import Distribution.Client.Types
   , RepoName (..)
   , repoName
   , unRepoName
-  )
-import Distribution.Simple.Flag
-  ( fromFlagOrDefault
   )
 import Distribution.Simple.Utils
   ( dieWithException
@@ -220,7 +216,7 @@ updateAction flags@NixStyleFlags{..} extraArgs globalFlags = do
           reposToUpdate
         traverse_ (\_ -> collectJob jobCtrl) reposToUpdate
   where
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
+    verbosity = cfgVerbosity normal flags
     cliConfig = commandLineFlagsToProjectConfig globalFlags flags mempty -- ClientInstallFlags, not needed here
     globalConfigFlag = projectConfigConfigFile (projectConfigShared cliConfig)
 

--- a/cabal-install/src/Distribution/Client/NixStyleOptions.hs
+++ b/cabal-install/src/Distribution/Client/NixStyleOptions.hs
@@ -7,6 +7,7 @@ module Distribution.Client.NixStyleOptions
   , nixStyleOptions
   , defaultNixStyleFlags
   , updNixStyleCommonSetupFlags
+  , cfgVerbosity
   ) where
 
 import Distribution.Client.Compat.Prelude
@@ -18,6 +19,7 @@ import Distribution.Simple.Setup
   , CommonSetupFlags (..)
   , HaddockFlags (..)
   , TestFlags (testCommonFlags)
+  , fromFlagOrDefault
   )
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource (..))
 
@@ -154,3 +156,6 @@ updNixStyleCommonSetupFlags setFlag nixFlags =
             common = benchmarkCommonFlags flags
          in flags{benchmarkCommonFlags = setFlag common}
     }
+
+cfgVerbosity :: Verbosity -> NixStyleFlags a -> Verbosity
+cfgVerbosity v flags = fromFlagOrDefault v (setupVerbosity . configCommonFlags $ configFlags flags)

--- a/cabal-install/src/Distribution/Client/ScriptUtils.hs
+++ b/cabal-install/src/Distribution/Client/ScriptUtils.hs
@@ -76,9 +76,7 @@ import Distribution.Client.RebuildMonad
   ( runRebuild
   )
 import Distribution.Client.Setup
-  ( CommonSetupFlags (..)
-  , ConfigFlags (..)
-  , GlobalFlags (..)
+  ( GlobalFlags (..)
   )
 import Distribution.Client.TargetSelector
   ( TargetSelectorProblem (..)
@@ -176,9 +174,6 @@ import Distribution.Types.UnqualComponentName
   )
 import Distribution.Utils.NubList
   ( fromNubList
-  )
-import Distribution.Verbosity
-  ( normal
   )
 import Language.Haskell.Extension
   ( Language (..)
@@ -281,7 +276,8 @@ data TargetContext
 -- In the case that the context refers to a temporary directory,
 -- delete it after the action finishes.
 withContextAndSelectors
-  :: AcceptNoTargets
+  :: Verbosity
+  -> AcceptNoTargets
   -- ^ What your command should do when no targets are found.
   -> Maybe ComponentKind
   -- ^ A target filter
@@ -296,7 +292,7 @@ withContextAndSelectors
   -> (TargetContext -> ProjectBaseContext -> [TargetSelector] -> IO b)
   -- ^ The body of your command action.
   -> IO b
-withContextAndSelectors noTargets kind flags@NixStyleFlags{..} targetStrings globalFlags cmd act =
+withContextAndSelectors verbosity noTargets kind flags@NixStyleFlags{..} targetStrings globalFlags cmd act =
   withTemporaryTempDirectory $ \mkTmpDir -> do
     (tc, ctx) <-
       withProjectOrGlobalConfig
@@ -337,7 +333,6 @@ withContextAndSelectors noTargets kind flags@NixStyleFlags{..} targetStrings glo
 
     act tc' ctx' sels
   where
-    verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
     ignoreProject = flagIgnoreProject projectFlags
     cliConfig = commandLineFlagsToProjectConfig globalFlags flags mempty
     globalConfigFlag = projectConfigConfigFile (projectConfigShared cliConfig)

--- a/cabal-testsuite/PackageTests/HaddockProject/haddock-project.out
+++ b/cabal-testsuite/PackageTests/HaddockProject/haddock-project.out
@@ -2,6 +2,8 @@
 Downloading the latest package list from test-local-repo
 # cabal haddock-project
 Warning: haddock-project command is experimental, it might break in the future
+Configuration is affected by the following files:
+- cabal.project
 Resolving dependencies...
 Configuration is affected by the following files:
 - cabal.project


### PR DESCRIPTION
I was working on a fix for #10527 and noticed that all but one of the callers of `withContextAndSelectors` had already accessed verbosity in the same way that `withContextAndSelectors` does (`Cmd*.hs` modules do this):

https://github.com/haskell/cabal/blob/62073c99833111dc7369dd22524f3b2a250a5f1d/cabal-install/src/Distribution/Client/CmdRepl.hs#L509

https://github.com/haskell/cabal/blob/62073c99833111dc7369dd22524f3b2a250a5f1d/cabal-install/src/Distribution/Client/ScriptUtils.hs#L340

This is a refactor that adds a verbosity argument to `withContextAndSelectors` and a function `cfgVerbosity` that simplifies grabbing the verbosity from the configuration or using a default value.

With this a lot of `-XRecordWildCards` can be removed as can a lot of imports from `Distribution.Client.Setup`.

This will help with my fix for #10527 too as I may have to call `withContextAndSelectors` twice[^1] and don't want repeated messaging so would silence the verbosity of the first call.

```
Configuration is affected by the following files:
- cabal.project
Configuration is affected by the following files:
- cabal.project
```

[^1]: Depending on whether `cabal repl` should pick the one target, #10689.
---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
