### PR TITLE
fix static builds lacking git info

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -336,7 +336,11 @@ jobs:
           apk add bash curl sudo jq pkgconfig \
           zlib-dev zlib-static binutils-gold curl \
           gcc g++ gmp-dev libc-dev libffi-dev make \
-          musl-dev ncurses-dev perl tar xz
+          musl-dev ncurses-dev perl tar xz git
+
+      # Apparently there's some permissions thing inside vs. outside the container
+      # that Alpine's git doesn't like. Hack around it.
+      - run: git config --global --add safe.directory $(pwd)
 
       - uses: actions/checkout@v4
 

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -311,16 +311,18 @@ cabalVersion = mkVersion [3,0]  --used when bootstrapping
 
 -- |
 -- `Cabal` Git information. Only filled in if built in a Git tree in
--- developmnent mode and Template Haskell is available.
+-- development mode and Template Haskell is available.
 cabalGitInfo :: String
 #ifdef GIT_REV
-cabalGitInfo = concat [ "(commit "
-                      , giHash'
-                      , branchInfo
-                      , ", "
-                      , either (const "") giCommitDate gi'
-                      , ")"
-                      ]
+cabalGitInfo = if giHash' == ""
+                 then ""
+                 else concat [ "(commit "
+                             , giHash'
+                             , branchInfo
+                             , ", "
+                             , either (const "") giCommitDate gi'
+                             , ")"
+                             ]
   where
     gi' = $$tGitInfoCwdTry
     giHash' = take 7 . either (const "") giHash $ gi'

--- a/cabal-install/src/Distribution/Client/Version.hs
+++ b/cabal-install/src/Distribution/Client/Version.hs
@@ -33,13 +33,15 @@ cabalInstallVersion = mkVersion' PackageInfo.version
 -- developmnent mode and Template Haskell is available.
 cabalInstallGitInfo :: String
 #ifdef GIT_REV
-cabalInstallGitInfo = concat [ "(commit "
-                             , giHash'
-                             , branchInfo
-                             , ", "
-                             , either (const "") giCommitDate gi'
-                             , ")"
-                             ]
+cabalInstallGitInfo = if giHash' == ""
+                        then ""
+                        else concat [ "(commit "
+                                    , giHash'
+                                    , branchInfo
+                                    , ", "
+                                    , either (const "") giCommitDate gi'
+                                    , ")"
+                                    ]
   where
     gi' = $$tGitInfoCwdTry
     giHash' = take 7 . either (const "") giHash $ gi'


### PR DESCRIPTION
Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
