### PR TITLE
WIP: Use default Cabal spec version for cabal init -n

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
@@ -262,7 +262,7 @@ packageDirHeuristics = getPackageDir
 --   The spec version can be specified by the InitFlags cabalVersion field. If
 --   none is specified then the default version is used.
 cabalVersionHeuristics :: Interactive m => InitFlags -> m CabalSpecVersion
-cabalVersionHeuristics flags = getCabalVersion flags guessCabalSpecVersion
+cabalVersionHeuristics flags = getCabalVersion flags $ return defaultCabalVersion
 
 -- | Get the package name: use the package directory (supplied, or the current
 --   directory by default) as a guess. It looks at the SourcePackageDb to avoid

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -21,7 +21,6 @@ module Distribution.Client.Init.NonInteractive.Heuristics
   , guessExtraDocFiles
   , guessAuthorName
   , guessAuthorEmail
-  , guessCabalSpecVersion
   , guessLanguage
   , guessPackageType
   , guessSourceDirectories
@@ -34,7 +33,6 @@ import Distribution.Simple.Setup (fromFlagOrDefault)
 
 import qualified Data.List as L
 import qualified Data.Set as Set
-import Distribution.CabalSpecVersion
 import Distribution.Client.Init.Defaults
 import Distribution.Client.Init.FlagExtractors (getCabalVersionNoPrompt)
 import Distribution.Client.Init.Types
@@ -58,18 +56,6 @@ guessMainFile pkgDir = do
           [] -> defaultMainIs
           (f : _) -> toHsFilePath f
     else return defaultMainIs
-
--- | Juggling characters around to guess the desired cabal version based on
---   the system's cabal version.
-guessCabalSpecVersion :: Interactive m => m CabalSpecVersion
-guessCabalSpecVersion = do
-  (_, verString, _) <- readProcessWithExitCode "cabal" ["--version"] ""
-  case simpleParsec $ takeWhile (not . isSpace) $ dropWhile (not . isDigit) verString of
-    Just v -> pure $ fromMaybe defaultCabalVersion $ case versionNumbers v of
-      [x, y, _, _] -> cabalSpecFromVersionDigits [x, y]
-      [x, y, _] -> cabalSpecFromVersionDigits [x, y]
-      _ -> Just defaultCabalVersion
-    Nothing -> pure defaultCabalVersion
 
 -- | Guess the language specification based on the GHC version
 guessLanguage :: Interactive m => Compiler -> m Language

--- a/cabal-testsuite/PackageTests/Init/init-without-cabal-in-path.out
+++ b/cabal-testsuite/PackageTests/Init/init-without-cabal-in-path.out
@@ -1,0 +1,1 @@
+# cabal init

--- a/cabal-testsuite/PackageTests/Init/init-without-cabal-in-path.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-without-cabal-in-path.test.hs
@@ -1,0 +1,18 @@
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+import System.Directory
+import System.FilePath
+import Test.Cabal.Prelude
+
+-- Test $cabal init -n when `cabal` executable is not in PATH
+main = do
+  tmp <- getTemporaryDirectory
+  withTempDirectory normal tmp "bin" $ \bin -> cabalTest $ do
+    ghc_path <- programPathM ghcProgram
+    cabal_path <- programPathM cabalProgram
+    withSymlink ghc_path (bin </> "ghc")
+      . withSymlink cabal_path (bin </> "custom-cabal")
+      . withEnv [("PATH", Just bin)]
+      $ do
+        cwd <- fmap testSourceCopyDir getTestEnv
+        void . withDirectory cwd $ cabal "init" ["-n"]


### PR DESCRIPTION
Fixes #9687. This PR will make cabal-install use the default cabal spec version for `cabal init -n` when no `--cabal-version=spec_ver` is passed. Previously, the version was retrieved at runtime by calling `cabal --version` and it was assumed that the `cabal` executable exists in `PATH` for it to work without returning an error.

---

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

## QA Notes
Calling `/path/to/cabal init -n` whenever the `cabal` executable is not in `PATH` should correctly initialize a cabal project in the current directory without throwing an exception or returning an error.
* In the generated .cabal file, the `cabal-version` key value must be the default Cabal specification version, similar to that if `cabal init -n --simple` was used instead. Currently, the current default spec version is `3.0`.