### PR TITLE
Move cabal path to project configuration group

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -285,68 +285,6 @@ cabal preferences. It is very useful when you are e.g. first configuring
       Note how ``--augment`` syntax follows ``cabal user-config diff``
       output.
 
-cabal path
-^^^^^^^^^^
-
-``cabal path`` allows to query for paths used by ``cabal``.
-For example, it allows to query for the directories of the cache, store,
-installed binaries, and so on.
-
-::
-
-    $ whoami
-    alice
-
-    $ cabal path
-    compiler-flavour: ghc
-    compiler-id: ghc-9.8.2
-    compiler-path: /home/alice/.ghcup/bin/ghc
-    cache-home: /home/alice/.cabal
-    remote-repo-cache: /home/alice/.cabal/packages
-    logs-dir: /home/alice/.cabal/logs
-    store-dir: /home/alice/.cabal/store
-    config-file: /home/alice/.cabal/config
-    installdir: /home/alice/.cabal/bin
-
-Or using the json output:
-
-::
-
-    $ cabal path --output-format=json | jq
-
-.. code-block:: json
-
-    {
-      "cabal-version": "3.13.0.0",
-      "compiler": {
-        "flavour": "ghc",
-        "id": "ghc-9.8.2",
-        "path": "/home/alice/.ghcup/bin/ghc"
-      },
-      "cache-home": "/home/alice/.cabal",
-      "remote-repo-cache": "/home/alice/.cabal/packages",
-      "logs-dir": "/home/alice/.cabal/logs",
-      "store-dir": "/home/alice/.cabal/store",
-      "config-file": "/home/alice/.cabal/config",
-      "installdir": "/home/alice/.cabal/bin"
-    }
-
-If ``cabal path`` is passed a single option naming a path, then that
-path will be printed *without* any label:
-
-::
-
-   $ cabal path --installdir
-   /home/alice/.cabal/bin
-
-While this interface is intended to be used for scripting, it is an experimental command.
-Scripting example:
-
-::
-
-   $ ls $(cabal path --installdir)
-   ...
-
 .. _command-group-database:
 
 Package database commands
@@ -733,6 +671,68 @@ Examples:
     of ``pkg`` on Hackage satisfying ``pkg > 1.9 && < 2.0``. ``--minor`` can also
     be used without arguments, in that case major version bumps are ignored for
     all packages.
+
+cabal path
+^^^^^^^^^^
+
+``cabal path`` allows to query for paths used by ``cabal``.
+For example, it allows to query for the directories of the cache, store,
+installed binaries, and so on.
+
+::
+
+    $ whoami
+    alice
+
+    $ cabal path
+    compiler-flavour: ghc
+    compiler-id: ghc-9.8.2
+    compiler-path: /home/alice/.ghcup/bin/ghc
+    cache-home: /home/alice/.cabal
+    remote-repo-cache: /home/alice/.cabal/packages
+    logs-dir: /home/alice/.cabal/logs
+    store-dir: /home/alice/.cabal/store
+    config-file: /home/alice/.cabal/config
+    installdir: /home/alice/.cabal/bin
+
+Or using the json output:
+
+::
+
+    $ cabal path --output-format=json | jq
+
+.. code-block:: json
+
+    {
+      "cabal-version": "3.13.0.0",
+      "compiler": {
+        "flavour": "ghc",
+        "id": "ghc-9.8.2",
+        "path": "/home/alice/.ghcup/bin/ghc"
+      },
+      "cache-home": "/home/alice/.cabal",
+      "remote-repo-cache": "/home/alice/.cabal/packages",
+      "logs-dir": "/home/alice/.cabal/logs",
+      "store-dir": "/home/alice/.cabal/store",
+      "config-file": "/home/alice/.cabal/config",
+      "installdir": "/home/alice/.cabal/bin"
+    }
+
+If ``cabal path`` is passed a single option naming a path, then that
+path will be printed *without* any label:
+
+::
+
+   $ cabal path --installdir
+   /home/alice/.cabal/bin
+
+While this interface is intended to be used for scripting, it is an experimental command.
+Scripting example:
+
+::
+
+   $ ls $(cabal path --installdir)
+   ...
 
 .. _command-group-build:
 


### PR DESCRIPTION
Fixes #10698, a follow on from #9583.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI?