### PR TITLE
bump upper limit on `unix` dependency

### DIFF
--- a/Cabal-tests/tests/ParserTests/errors/libpq1.cabal
+++ b/Cabal-tests/tests/ParserTests/errors/libpq1.cabal
@@ -55,7 +55,7 @@ Library
                      , bytestring >=0.9.1.0 && <0.11
 
   if !os(windows)
-    Build-depends:     unix  >=2.4.2.0 && <2.8
+    Build-depends:     unix  >=2.4.2.0
 
   if os(windows)
     Build-depends:     Win32 >=2.2.0.2 && <2.7

--- a/Cabal-tests/tests/ParserTests/errors/libpq2.cabal
+++ b/Cabal-tests/tests/ParserTests/errors/libpq2.cabal
@@ -55,7 +55,7 @@ Library
                      , bytestring >=0.9.1.0 && <0.11
 
   if !os(windows)
-    Build-depends:     unix  >=2.4.2.0 && <2.8
+    Build-depends:     unix  >=2.4.2.0
 
   if os(windows)
     Build-depends:     Win32 >=2.2.0.2 && <2.7

--- a/Cabal-tests/tests/ParserTests/regressions/libpq1.cabal
+++ b/Cabal-tests/tests/ParserTests/regressions/libpq1.cabal
@@ -55,7 +55,7 @@ Library
                      , bytestring >=0.9.1.0 && <0.11
 
   if !os(windows)
-    Build-depends:     unix  >=2.4.2.0 && <2.8
+    Build-depends:     unix  >=2.4.2.0
 
   if os(windows)
     Build-depends:     Win32 >=2.2.0.2 && <2.7


### PR DESCRIPTION
Currently, certain `Cabal` packages allow `unix` 2.8.6.*, and others do not.

This PR changes the latter so all can use `unix` 2.8.6.*. The test:

```
cabal build all --enable-tests --constraint 'unix==2.8.6.0'
```
succeeds

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
