### PR TITLE
Add support for Windows Aarch64

### DIFF
--- a/Cabal/src/Distribution/Compat/Environment.hs
+++ b/Cabal/src/Distribution/Compat/Environment.hs
@@ -63,7 +63,7 @@ setEnv_ key value = withCWString key $ \k -> withCWString value $ \v -> do
 {- FOURMOLU_DISABLE -}
 # if defined(i386_HOST_ARCH)
 #  define WINDOWS_CCONV stdcall
-# elif defined(x86_64_HOST_ARCH)
+# elif defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
 #  define WINDOWS_CCONV ccall
 # else
 #  error Unknown mingw32 arch

--- a/Cabal/src/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule.hs
@@ -51,6 +51,7 @@ generatePathsModule pkg_descr lbi clbi =
       , Z.zIsWindows = isWindows
       , Z.zIsI386 = buildArch == I386
       , Z.zIsX8664 = buildArch == X86_64
+      , Z.zIsAarch64 = buildArch == AArch64
       , Z.zNot = not
       , Z.zManglePkgName = showPkgName
       , Z.zPrefix = show flat_prefix

--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -12,6 +12,7 @@ data Z
          zIsWindows :: Bool,
          zIsI386 :: Bool,
          zIsX8664 :: Bool,
+         zIsAarch64 :: Bool,
          zPrefix :: FilePath,
          zBindir :: FilePath,
          zLibdir :: FilePath,
@@ -284,9 +285,16 @@ render z_root = execWriter $ do
             tell "  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
             return ()
           else do
-            tell "-- win32 supported only with I386, X86_64\n"
-            tell "c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
-            tell "c_GetModuleFileName  = _\n"
+            if (zIsAarch64 z_root)
+            then do
+              tell "foreign import ccall unsafe \"windows.h GetModuleFileNameW\"\n"
+              tell "  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
+              return ()
+            else do
+              tell "-- win32 supported only with I386, X86_64, Aarch64\n"
+              tell "c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
+              tell "c_GetModuleFileName  = _\n"
+              return ()
             return ()
           return ()
         tell "\n"

--- a/cabal-dev-scripts/src/GenPathsModule.hs
+++ b/cabal-dev-scripts/src/GenPathsModule.hs
@@ -32,6 +32,7 @@ $(capture "decls" [d|
         , zIsWindows                  :: Bool
         , zIsI386                     :: Bool
         , zIsX8664                    :: Bool
+        , zIsAarch64                  :: Bool
 
         , zPrefix     :: FilePath
         , zBindir     :: FilePath

--- a/cabal-install/src/Distribution/Client/Compat/ExecutablePath.hs
+++ b/cabal-install/src/Distribution/Client/Compat/ExecutablePath.hs
@@ -123,7 +123,7 @@ getExecutablePath = readSymbolicLink $ "/proc/self/exe"
 
 # if defined(i386_HOST_ARCH)
 #  define WINDOWS_CCONV stdcall
-# elif defined(x86_64_HOST_ARCH)
+# elif defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
 #  define WINDOWS_CCONV ccall
 # else
 #  error Unknown mingw32 arch

--- a/changelog.d/pr-10705
+++ b/changelog.d/pr-10705
@@ -1,0 +1,8 @@
+---
+synopsis: 'Add support for Windows Aarch64'
+packages: [Cabal, cabal-install]
+prs: 10705
+---
+
+Adds to preprocessor branches the option to support `aarch64_HOST_ARCH` platform on Windows Aarch64 target.
+`ccall` convention is used at Aarch64, same as for `x86_64_HOST_ARCH`. Introduce `zIsAarch64` to make paths generation support Windows Aarch64 target.

--- a/templates/Paths_pkg.template.hs
+++ b/templates/Paths_pkg.template.hs
@@ -154,8 +154,11 @@ foreign import stdcall unsafe "windows.h GetModuleFileNameW"
 {% elif isX8664 %}
 foreign import ccall unsafe "windows.h GetModuleFileNameW"
   c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
+{% elif isAarch64 %}
+foreign import ccall unsafe "windows.h GetModuleFileNameW"
+  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
 {% else %}
--- win32 supported only with I386, X86_64
+-- win32 supported only with I386, X86_64, Aarch64
 c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
 c_GetModuleFileName  = _
 {% endif %}


### PR DESCRIPTION
See details: https://gitlab.haskell.org/ghc/ghc/-/issues/24603#note_565835

The patch adds support Aarch64 builds at Windows platform.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Asking for an exemption** for tests.
I am not sure about `QA notes`. Should I add a link to the compiler which can be used to test it? Temporal link is [here](https://gitlab.haskell.org/ghc/ghc/-/issues/24603#note_602054).