### PR TITLE
Add since annotation for MHS

### DIFF
--- a/Cabal-syntax/src/Distribution/Compiler.hs
+++ b/Cabal-syntax/src/Distribution/Compiler.hs
@@ -73,7 +73,9 @@ data CompilerFlavor
   | LHC
   | UHC
   | Eta
-  | MHS -- MicroHS, see https://github.com/augustss/MicroHs
+  | -- | @since 3.12.1.0
+    -- MicroHS, see https://github.com/augustss/MicroHs
+    MHS
   | HaskellSuite String -- string is the id of the actual compiler
   | OtherCompiler String
   deriving (Generic, Show, Read, Eq, Ord, Data)


### PR DESCRIPTION
**Template B: This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
