### PR TITLE
Follow HLint suggestion: use fewer imports

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,7 +1,7 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
 - ignore: {name: "Avoid lambda"} # 47 hints
-- ignore: {name: "Avoid lambda using `infix`"} # 22 hints
+- ignore: {name: "Avoid lambda using `infix`"} # 23 hints
 - ignore: {name: "Eta reduce"} # 124 hints
 - ignore: {name: "Evaluate"} # 10 hints
 - ignore: {name: "Functor law"} # 10 hints
@@ -16,11 +16,11 @@
 - ignore: {name: "Monoid law, right identity"} # 3 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Move guards forward"} # 4 hints
-- ignore: {name: "Redundant $"} # 179 hints
+- ignore: {name: "Redundant $"} # 178 hints
 - ignore: {name: "Redundant $!"} # 1 hint
 - ignore: {name: "Redundant <$>"} # 16 hints
 - ignore: {name: "Redundant =="} # 1 hint
-- ignore: {name: "Redundant bracket"} # 239 hints
+- ignore: {name: "Redundant bracket"} # 240 hints
 - ignore: {name: "Redundant fmap"} # 1 hint
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
@@ -49,7 +49,7 @@
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use elem"} # 2 hints
 - ignore: {name: "Use first"} # 4 hints
-- ignore: {name: "Use fmap"} # 26 hints
+- ignore: {name: "Use fmap"} # 25 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use for"} # 1 hint
 - ignore: {name: "Use forM_"} # 1 hint
@@ -65,7 +65,7 @@
 - ignore: {name: "Use isNothing"} # 1 hint
 - ignore: {name: "Use lambda-case"} # 55 hints
 - ignore: {name: "Use lefts"} # 1 hint
-- ignore: {name: "Use list comprehension"} # 18 hints
+- ignore: {name: "Use list comprehension"} # 19 hints
 - ignore: {name: "Use list literal"} # 3 hints
 - ignore: {name: "Use list literal pattern"} # 11 hints
 - ignore: {name: "Use map once"} # 7 hints

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -48,7 +48,6 @@
 - ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use elem"} # 2 hints
-- ignore: {name: "Use fewer imports"} # 13 hints
 - ignore: {name: "Use first"} # 4 hints
 - ignore: {name: "Use fmap"} # 26 hints
 - ignore: {name: "Use fold"} # 1 hint
@@ -95,6 +94,8 @@
 
 - arguments:
     - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs
+    - --ignore-glob=Cabal-tests/tests/custom-setup/CabalDoctestSetup.hs
+    - --ignore-glob=Cabal-tests/tests/custom-setup/IdrisSetup.hs
     - --ignore-glob=cabal-testsuite/PackageTests/BuildWays/q/app/Main.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSources/src/Demo.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSourcesDyn/src/Demo.hs

--- a/Cabal/src/Distribution/Compat/Internal/TempFile.hs
+++ b/Cabal/src/Distribution/Compat/Internal/TempFile.hs
@@ -15,17 +15,17 @@ import System.FilePath ((</>))
 import System.IO (Handle, openBinaryTempFile, openTempFile)
 #if defined(__IO_MANAGER_WINIO__)
 import System.IO              (openBinaryTempFileWithDefaultPermissions)
+import System.Posix.Internals (c_getpid)
 #else
 import Control.Exception      (onException)
 import Data.Bits              ((.|.))
 import Foreign.C              (CInt, eEXIST, getErrno, errnoToIOError)
 import GHC.IO.Handle.FD       (fdToHandle)
-import System.Posix.Internals (c_open, c_close, o_EXCL, o_BINARY, withFilePath,
+import System.Posix.Internals (c_getpid, c_open, c_close, o_EXCL, o_BINARY, withFilePath,
                                o_CREAT, o_RDWR, o_NONBLOCK, o_NOCTTY)
 #endif
 
 import System.IO.Error (isAlreadyExistsError)
-import System.Posix.Internals (c_getpid)
 
 #if defined(mingw32_HOST_OS) || defined(ghcjs_HOST_OS)
 import System.Directory       ( createDirectory )

--- a/Cabal/src/Distribution/Compat/Time.hs
+++ b/Cabal/src/Distribution/Compat/Time.hs
@@ -41,13 +41,14 @@ import System.Win32.Types ( BOOL, DWORD, LPCTSTR, LPVOID, withTString )
 
 #else
 
-import System.Posix.Files ( FileStatus, getFileStatus )
-
+import System.Posix.Files
+  ( FileStatus, getFileStatus
 #if MIN_VERSION_unix(2,6,0)
-import System.Posix.Files ( modificationTimeHiRes )
+  , modificationTimeHiRes
 #else
-import System.Posix.Files ( modificationTime )
+  , modificationTime
 #endif
+  )
 
 #endif
 

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -124,6 +124,16 @@ import Distribution.Utils.Path
 import Distribution.Verbosity
 import Distribution.Version
 import Language.Haskell.Extension
+import System.FilePath
+  ( isRelative
+  , takeDirectory
+  )
+import qualified System.Info
+#ifndef mingw32_HOST_OS
+import System.Posix (createSymbolicLink)
+#endif /* mingw32_HOST_OS */
+
+{- FOURMOLU_DISABLE -}
 import System.Directory
   ( canonicalizePath
   , createDirectoryIfMissing
@@ -131,16 +141,11 @@ import System.Directory
   , doesFileExist
   , getAppUserDataDirectory
   , getDirectoryContents
-  )
-import System.FilePath
-  ( isRelative
-  , takeDirectory
-  )
-import qualified System.Info
 #ifndef mingw32_HOST_OS
-import System.Directory (renameFile)
-import System.Posix (createSymbolicLink)
-#endif /* mingw32_HOST_OS */
+  , renameFile
+#endif
+  )
+{- FOURMOLU_ENABLE -}
 
 import Distribution.Simple.Setup (BuildingWhat (..))
 import Distribution.Simple.Setup.Build

--- a/cabal-install/src/Distribution/Client/CmdTest.hs
+++ b/cabal-install/src/Distribution/Client/CmdTest.hs
@@ -33,7 +33,8 @@ import Distribution.Client.NixStyleOptions
   )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.Setup
-  ( ConfigFlags (..)
+  ( CommonSetupFlags (..)
+  , ConfigFlags (..)
   , GlobalFlags (..)
   )
 import Distribution.Client.TargetProblem
@@ -66,7 +67,6 @@ import Distribution.Verbosity
 import qualified System.Exit (exitSuccess)
 
 import Distribution.Client.Errors
-import Distribution.Client.Setup (CommonSetupFlags (..))
 import GHC.Environment
   ( getFullArgs
   )

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -49,7 +49,10 @@ module Distribution.Client.Config
   ) where
 
 import Distribution.Client.Compat.Prelude
-import Distribution.Compat.Environment (lookupEnv)
+import Distribution.Compat.Environment
+  ( getEnvironment
+  , lookupEnv
+  )
 import Prelude ()
 
 import Language.Haskell.Extension (Language (Haskell2010))
@@ -126,9 +129,6 @@ import Distribution.Client.Version
   ( cabalInstallVersion
   )
 import qualified Distribution.Compat.CharParsing as P
-import Distribution.Compat.Environment
-  ( getEnvironment
-  )
 import Distribution.Compiler
   ( CompilerFlavor (..)
   , defaultCompilerFlavor

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE LambdaCase #-}
@@ -99,7 +98,18 @@ module Distribution.Client.ProjectPlanning
   ) where
 
 import Distribution.Client.Compat.Prelude
-import Text.PrettyPrint (render)
+import Text.PrettyPrint
+  ( colon
+  , comma
+  , fsep
+  , hang
+  , punctuate
+  , quotes
+  , render
+  , text
+  , vcat
+  , ($$)
+  )
 import Prelude ()
 
 import Distribution.Client.Config
@@ -222,7 +232,6 @@ import qualified Data.Set as Set
 import Distribution.Client.Errors
 import Distribution.Solver.Types.ProjectConfigPath
 import System.FilePath
-import Text.PrettyPrint (colon, comma, fsep, hang, punctuate, quotes, text, vcat, ($$))
 import qualified Text.PrettyPrint as Disp
 
 -- | Check that an 'ElaboratedConfiguredPackage' actually makes

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -143,7 +143,10 @@ import Distribution.Simple.Program.GHC
   , renderGhcOptions
   )
 import Distribution.Simple.Setup
-  ( Flag (..), CommonSetupFlags (..), GlobalFlags (..)
+  ( CommonSetupFlags (..)
+  , Flag (..)
+  , GlobalFlags (..)
+  , globalCommand
   )
 import Distribution.Simple.Utils
   ( cabalVersion
@@ -175,7 +178,6 @@ import Distribution.Verbosity
 
 import Data.List (foldl1')
 import qualified Data.Map.Lazy as Map
-import Distribution.Simple.Setup (globalCommand)
 import Distribution.Client.Compat.ExecutablePath (getExecutablePath)
 import Distribution.Compat.Process (proc)
 import System.Directory (doesFileExist)

--- a/cabal-install/src/Distribution/Client/Store.hs
+++ b/cabal-install/src/Distribution/Client/Store.hs
@@ -47,8 +47,7 @@ import System.FilePath
 import Lukko
 #else
 import System.IO (openFile, IOMode(ReadWriteMode), hClose)
-import GHC.IO.Handle.Lock (hLock, hTryLock, LockMode(ExclusiveLock))
-import GHC.IO.Handle.Lock (hUnlock)
+import GHC.IO.Handle.Lock (LockMode (ExclusiveLock), hLock, hTryLock, hUnlock)
 #endif
 
 -- $concurrency

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -54,7 +54,11 @@ import qualified Distribution.Client.CmdTest as CmdTest
 
 import qualified Distribution.Client.CmdHaddockProject as CmdHaddockProject
 import Distribution.Client.Config (SavedConfig (savedGlobalFlags), createDefaultConfigFile, loadConfig)
-import Distribution.Client.GlobalFlags (defaultGlobalFlags)
+import Distribution.Client.GlobalFlags
+  ( GlobalFlags
+  , defaultGlobalFlags
+  , globalNix
+  )
 import Distribution.Client.Setup (globalCommand, globalStoreDir)
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import Distribution.ModuleName (ModuleName)
@@ -90,7 +94,6 @@ import Test.Tasty.Options
 
 import qualified Data.ByteString as BS
 import Data.Maybe (fromJust)
-import Distribution.Client.GlobalFlags (GlobalFlags, globalNix)
 import Distribution.Simple.Flag (Flag (Flag, NoFlag))
 import Distribution.Types.ParStrat
 

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | The test monad
@@ -88,9 +87,6 @@ import Distribution.Verbosity
 import Distribution.Version
 
 import Control.Concurrent.Async
-#if !MIN_VERSION_base(4,11,0)
-import Data.Monoid ((<>))
-#endif
 import Data.Monoid (mempty)
 import qualified Control.Exception as E
 import Control.Monad

--- a/cabal-testsuite/src/Test/Cabal/NeedleHaystack.hs
+++ b/cabal-testsuite/src/Test/Cabal/NeedleHaystack.hs
@@ -20,11 +20,10 @@ module Test.Cabal.NeedleHaystack
 
 import Prelude hiding (unlines)
 import qualified Prelude (unlines)
-import Data.List (tails)
 import Data.Maybe (isJust)
 import Distribution.System
 import Distribution.Utils.Generic (unsnoc)
-import Data.List (isPrefixOf)
+import Data.List (isPrefixOf, tails)
 import qualified System.FilePath.Posix as Posix
 import qualified System.FilePath.Windows as Windows
 import Network.URI (parseURI)


### PR DESCRIPTION
See #9110. The HLint "use fewer imports" suggestion was too much trouble to enable before most of the base CPP conditionals, "base 4.13 and older", were removed in #10092.

We're using fourmolu but this doesn't merge multiple imports from the same module.

The removal of `MIN_VERSION_base(4,11,0)` is permitted by https://github.com/haskell/cabal/issues/8998#issuecomment-2564815577 and https://github.com/haskell/cabal/issues/8998#issuecomment-2565296765.

Two files used for our tests taken from other projects are now ignored for linting, in `.hlint.yaml`:

```diff
 - arguments:
+    - --ignore-glob=Cabal-tests/tests/custom-setup/CabalDoctestSetup.hs
+    - --ignore-glob=Cabal-tests/tests/custom-setup/IdrisSetup.hs
```

The first of these, `CabalDoctestSetup.hs`, was mentioned by @Kleidukos in https://github.com/haskell/cabal/issues/8998#issue-1739264359.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
