### PR TITLE
Fix file+noindex URI usage on Windows

### DIFF
--- a/Cabal-syntax/src/Distribution/Utils/Path.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Path.hs
@@ -67,6 +67,9 @@ module Distribution.Utils.Path
 
     -- ** Module names
   , moduleNameSymbolicPath
+
+    -- * Windows
+  , asPosixPath
   ) where
 
 import Distribution.Compat.Prelude
@@ -86,6 +89,8 @@ import qualified Distribution.Compat.CharParsing as P
 
 import qualified System.Directory as Directory
 import qualified System.FilePath as FilePath
+import qualified System.FilePath.Posix as Posix
+import qualified System.FilePath.Windows as Windows
 
 import Data.Kind
   ( Type
@@ -531,3 +536,38 @@ data Response
 --
 -- See Note [Symbolic paths] in Distribution.Utils.Path.
 data PkgConf
+
+-------------------------------------------------------------------------------
+
+-- * Windows utils
+
+-------------------------------------------------------------------------------
+
+-- | Sometimes we need to represent a Windows path (that might have been
+-- normalized) as a POSIX path, for example in URIs, as that is what
+-- @network-uri@ understands. Furthermore they need to use the @\\\\.\\@ DOS
+-- device syntax or otherwise the filepath will be unusable.
+--
+-- >>> import Network.URI
+-- >>> uriPath <$> parseURI "file+noindex://C:/foo.txt"
+-- Just "/foo.txt"
+-- >>> parseURI "file+noindex://C:\foo.txt"
+-- Nothing
+-- >>> uriPath <$> parseURI "file+noindex:///C:/foo.txt"
+-- Just "/C:/foo.txt"
+-- >>> uriPath <$> parseURI "file+noindex:////./C:/foo.txt"
+-- Just "//./C:/foo.txt"
+--
+-- Out of the ones above, only the last one can be used from anywhere in the
+-- system, after normalization into @"\\\\.\\C:/foo.txt"@ (see filepath#247 for
+-- why there is a forward slash there):
+--
+-- >>> import Network.URI
+-- >>> import qualified System.FilePath.Windows as Windows
+-- >>> Windows.normalise . uriPath <$> parseURI "file+noindex:////./C:/foo.txt"
+-- Just "\\\\.\\C:/foo.txt"
+asPosixPath :: FilePath -> FilePath
+asPosixPath p =
+  -- We don't use 'isPathSeparator' because @Windows.isPathSeparator
+  -- Posix.pathSeparator == True@.
+  [if x == Windows.pathSeparator then Posix.pathSeparator else x | x <- p]

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ ghcid-cli: ## Run ghcid for the cabal-install executable.
 
 .PHONY: doctest
 doctest: ## Run doctests.
-	cd Cabal-syntax && $(DOCTEST)
+	cd Cabal-syntax && $(DOCTEST) --build-depends=network-uri
 	cd Cabal-described && $(DOCTEST)
 	cd Cabal && $(DOCTEST)
 	cd cabal-install-solver && $(DOCTEST)

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -227,7 +227,8 @@ import System.Directory
   , renameFile
   )
 import System.FilePath
-  ( takeDirectory
+  ( normalise
+  , takeDirectory
   , (<.>)
   , (</>)
   )
@@ -1693,7 +1694,14 @@ postProcessRepo lineno reponameStr repo0 = do
     -- Note: the trailing colon is important
     "file+noindex:" -> do
       let uri = remoteRepoURI repo0
-      return $ Left $ LocalRepo reponame (uriPath uri) (uriFragment uri == "#shared-cache")
+      return $
+        Left $
+          LocalRepo
+            reponame
+            -- Normalization of Windows paths that use @//./@ does not fully
+            -- normalize the path (see filepath#247), but it is still usable.
+            (normalise (uriPath uri))
+            (uriFragment uri == "#shared-cache")
     _ -> do
       let repo = repo0{remoteRepoName = reponame}
 

--- a/cabal-install/src/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/src/Distribution/Client/GlobalFlags.hs
@@ -57,7 +57,8 @@ import Network.URI
   , uriScheme
   )
 import System.FilePath
-  ( (</>)
+  ( isAbsolute
+  , (</>)
   )
 
 import qualified Distribution.Client.Security.DNS as Sec.DNS
@@ -68,8 +69,6 @@ import qualified Hackage.Security.Client.Repository.Local as Sec.Local
 import qualified Hackage.Security.Client.Repository.Remote as Sec.Remote
 import qualified Hackage.Security.Util.Path as Sec
 import qualified Hackage.Security.Util.Pretty as Sec
-
-import qualified System.FilePath.Posix as FilePath.Posix
 
 -- ------------------------------------------------------------
 
@@ -192,7 +191,7 @@ withRepoContext'
   ignoreExpiry
   extraPaths = \callback -> do
     for_ localNoIndexRepos $ \local ->
-      unless (FilePath.Posix.isAbsolute (localRepoPath local)) $
+      unless (isAbsolute (localRepoPath local)) $
         warn verbosity $
           "file+noindex " ++ unRepoName (localRepoName local) ++ " repository path is not absolute; this is fragile, and not recommended"
 

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -466,7 +466,7 @@ readRepoIndex verbosity repoCtxt repo idxState =
             RepoSecure{..} -> warn verbosity $ exceptionMessageCabalInstall $ MissingPackageList repoRemote
             RepoLocalNoIndex local _ ->
               warn verbosity $
-                "Error during construction of local+noindex "
+                "Error during construction of file+noindex "
                   ++ unRepoName (localRepoName local)
                   ++ " repository index: "
                   ++ show e
@@ -526,7 +526,7 @@ whenCacheOutOfDate index action = do
     then action
     else
       if localNoIndex index
-        then return () -- TODO: don't update cache for local+noindex repositories
+        then return () -- TODO: don't update cache for file+noindex repositories
         else do
           indexTime <- getModTime $ indexFile index
           cacheTime <- getModTime $ cacheFile index

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -33,6 +33,7 @@ import qualified Distribution.Simple.InstallDirs as InstallDirs
 import Distribution.Simple.Program.Db
 import Distribution.Simple.Program.Types
 import Distribution.Simple.Utils (toUTF8BS)
+import Distribution.System (OS (Windows), buildOS)
 import Distribution.Types.PackageVersionConstraint
 import Distribution.Version
 
@@ -1016,7 +1017,10 @@ instance Arbitrary LocalRepo where
   arbitrary =
     LocalRepo
       <$> arbitrary
-      <*> elements ["/tmp/foo", "/tmp/bar"] -- TODO: generate valid absolute paths
+      <*> elements
+        ( (if buildOS == Windows then map (normalise . ("//./C:" ++)) else id)
+            ["/tmp/foo", "/tmp/bar"]
+        ) -- TODO: generate valid absolute paths
       <*> arbitrary
 
 instance Arbitrary PreSolver where

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -48,7 +48,7 @@ import Distribution.PackageDescription
 import Test.Utils.TempTestDir (withTestDir)
 import Distribution.Verbosity (normal)
 import Distribution.Utils.Path
-  ( makeSymbolicPath, relativeSymbolicPath, interpretSymbolicPathCWD )
+  ( asPosixPath, makeSymbolicPath, relativeSymbolicPath, interpretSymbolicPathCWD )
 
 import Distribution.Compat.Stack
 
@@ -613,9 +613,7 @@ withRepoNoUpdate repo_dir m = do
     -- TODO: Arguably should undo everything when we're done...
   where
     repoUri env ="file+noindex://" ++ (if isWindows
-                                        then map (\x -> case x of
-                                            '\\' -> '/'
-                                            _ -> x)
+                                        then joinDrive "//./" . asPosixPath
                                         else id) (testRepoDir env)
 
 -- | Given a directory (relative to the 'testCurrentDir') containing

--- a/changelog.d/pr-10728
+++ b/changelog.d/pr-10728
@@ -1,0 +1,14 @@
+synopsis: Fix `file+noindex` URI usage on Windows
+packages: cabal-install
+prs: #10728
+issues: #10703
+significance:
+
+description: {
+
+- `file+noindex` repositories in Windows systems must use the format `file+noindex:////./C:/path/to/repo`.
+  This syntax comes from https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths,
+  and is the only syntax for DOS paths fully supported by the `network-uri` package, which Cabal uses to
+  interpret URIs in repository stanzas.
+
+}

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -200,6 +200,10 @@ repository.
 ``package-name-version.tar.gz`` files in the directory, and will use optional
 corresponding ``package-name-version.cabal`` files as new revisions.
 
+.. note::
+   On Windows systems, the path has to be prefixed by ``//./`` as in
+   ``url: file+noindex:////./C:/absolute/path/to/directory``.
+
 For example, if ``/absolute/path/to/directory`` looks like
 ::
 


### PR DESCRIPTION
This PR fixes the parsing of URIs for file+noindex repositories when using Windows paths. As suggested by @phadej in #10703 we now use (and specify in the docs) `//./C:/...` paths on Windows.

### QA

In Windows, one can now specify `//./` paths in file+noindex repositories. To check, create a simple package, then `cabal sdist`, move the tar.gz to some directory and in a different project declare the following stanza:

```
repository my-local-repo
  url: file+noindex:////./C:/path/to/repo
```

It might still fail because of https://github.com/haskell/cabal/issues/9891

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [X] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*) _fixing other tests failures seems like a good enough test for me_