### PR TITLE
Create `noindex.cache` if missing

### DIFF
--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -1167,12 +1167,14 @@ readIndexCache verbosity index = do
 -- 'dieWithException's if it fails again). Throws IOException if any arise.
 readNoIndexCache :: Verbosity -> Index -> IO NoIndexCache
 readNoIndexCache verbosity index = do
-  cacheOrFail <- readNoIndexCache' index
+  cacheOrFail <- readNoIndexCache' verbosity index
   case cacheOrFail of
     Left msg -> do
       warn verbosity $
         concat
-          [ "Parsing the index cache failed ("
+          [ "Parsing the index cache for repo \""
+          , unRepoName (repoName repo)
+          , "\" failed ("
           , msg
           , "). "
           , "Trying to regenerate the index cache..."
@@ -1180,10 +1182,12 @@ readNoIndexCache verbosity index = do
 
       updatePackageIndexCacheFile verbosity index
 
-      either (dieWithException verbosity . CorruptedIndexCache) return =<< readNoIndexCache' index
+      either (dieWithException verbosity . CorruptedIndexCache) return =<< readNoIndexCache' verbosity index
 
     -- we don't hash cons local repository cache, they are hopefully small
     Right res -> return res
+  where
+    RepoIndex _ctxt repo = index
 
 -- | Read the 'Index' cache from the filesystem. Throws IO exceptions
 -- if any arise and returns Left on invalid input.
@@ -1194,8 +1198,12 @@ readIndexCache' index
   | otherwise =
       Right . read00IndexCache <$> BSS.readFile (cacheFile index)
 
-readNoIndexCache' :: Index -> IO (Either String NoIndexCache)
-readNoIndexCache' index = structuredDecodeFileOrFail (cacheFile index)
+readNoIndexCache' :: Verbosity -> Index -> IO (Either String NoIndexCache)
+readNoIndexCache' verbosity index = do
+  exists <- doesFileExist (cacheFile index)
+  if exists
+    then structuredDecodeFileOrFail (cacheFile index)
+    else updatePackageIndexCacheFile verbosity index >> readNoIndexCache' verbosity index
 
 -- | Write the 'Index' cache to the filesystem
 writeIndexCache :: Index -> Cache -> IO ()

--- a/changelog.d/pr-10730
+++ b/changelog.d/pr-10730
@@ -1,0 +1,11 @@
+synopsis: Create `noindex.cache` file if missing
+packages: cabal-install
+prs: #10730
+issues: #9891
+significance:
+
+description: {
+
+- Local+noindex repositories will have their `noindex.cache` file created the first time they are accessed.
+
+}


### PR DESCRIPTION
Fixes #9891 by creating the file if it is missing. 

Depends on #10728

## QA

This will work on Linux:
```
cabal init -m -n --simple --lib
mkdir repo
echo "packages: ." > cabal.project
echo "repository local" >> cabal.project
echo "  url: file+noindex://$(pwd)/repo" >> cabal.project
cabal build
```

For Windows, the path has to be un-cygwinize and prepended by `//./` as described in #10728.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [X] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] ~Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~