### PR TITLE
Ignore haddocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ register.sh
 ./cabal.config
 cabal-tests.log
 bootstrap/*.plan.json
+haddocks
 
 /Cabal/dist/
 /Cabal/tests/Setup


### PR DESCRIPTION
I tried the `cabal haddock-project` command. It dumped thousands of untracked files into the source tree for haskell/cabal. This PR ignores that folder.

```
$ tree haddocks
haddocks
├── array
│   ├── array.haddock
│   ├── array.txt
│   ├── Data-Array-Base.html
...
    ├── synopsis.png
    ├── transformers.haddock
    └── transformers.txt

67 directories, 3487 files
```

There's the `--output[=DIRECTORY]` option but `haddocks` is the default directory for the output.

```
$ cabal haddock-project --help
Generate Haddocks HTML documentation for the cabal project.

Usage: cabal haddock-project [FLAGS]
   or: cabal haddock-project COMPONENTS [FLAGS]

Flags for haddock-project:
...
 --output[=DIRECTORY]           Output directory
...
```

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
