### PR TITLE
Add a workflow to dry run cabal-install

### DIFF
--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -7,19 +7,29 @@ concurrency:
 
 on:
   push:
-    paths-ignore:
-      - 'CONTRIBUTING.md'
-      - 'doc/**'
-      - 'release-notes/**'
-      - 'Cabal-tests/test/**'
-      - 'cabal-testsuite/PackageTests/**'
+    paths:
+      - 'Cabal-QuickCheck/**'
+      - 'Cabal-described/**'
+      - 'Cabal-syntax/**'
+      - 'Cabal-tests/**'
+      - 'Cabal-tree-diff/**'
+      - 'Cabal/**'
+      - 'cabal-install-solver/**'
+      - 'cabal-install/**'
+      - '!Cabal-tests/test/**'
+      - '!cabal-testsuite/PackageTests/**'
   pull_request:
-    paths-ignore:
-      - 'CONTRIBUTING.md'
-      - 'doc/**'
-      - 'release-notes/**'
-      - 'Cabal-tests/test/**'
-      - 'cabal-testsuite/PackageTests/**'
+    paths:
+      - 'Cabal-QuickCheck/**'
+      - 'Cabal-described/**'
+      - 'Cabal-syntax/**'
+      - 'Cabal-tests/**'
+      - 'Cabal-tree-diff/**'
+      - 'Cabal/**'
+      - 'cabal-install-solver/**'
+      - 'cabal-install/**'
+      - '!Cabal-tests/test/**'
+      - '!cabal-testsuite/PackageTests/**'
   release:
     types:
       - created

--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -1,0 +1,47 @@
+name: Check install
+
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths-ignore:
+      - 'CONTRIBUTING.md'
+      - 'doc/**'
+      - 'release-notes/**'
+      - 'Cabal-tests/test/**'
+      - 'cabal-testsuite/PackageTests/**'
+  pull_request:
+    paths-ignore:
+      - 'CONTRIBUTING.md'
+      - 'doc/**'
+      - 'release-notes/**'
+      - 'Cabal-tests/test/**'
+      - 'cabal-testsuite/PackageTests/**'
+  release:
+    types:
+      - created
+
+jobs:
+
+  cabal-install-dry-run:
+    name: cabal install with ghc-${{ matrix.ghc }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc:
+          ["9.12.1"]
+
+    steps:
+
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
+      - uses: actions/checkout@v4
+
+      - run: cabal install cabal-install --dry-run

--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -1,4 +1,4 @@
-name: Check install
+name: Check sdist
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
@@ -10,6 +10,7 @@ on:
     paths:
       - 'Cabal-QuickCheck/**'
       - 'Cabal-described/**'
+      - 'Cabal-hooks/**'
       - 'Cabal-syntax/**'
       - 'Cabal-tests/**'
       - 'Cabal-tree-diff/**'
@@ -22,6 +23,7 @@ on:
     paths:
       - 'Cabal-QuickCheck/**'
       - 'Cabal-described/**'
+      - 'Cabal-hooks/**'
       - 'Cabal-syntax/**'
       - 'Cabal-tests/**'
       - 'Cabal-tree-diff/**'
@@ -54,4 +56,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - run: cabal install cabal-install --dry-run
+      - run: cabal sdist Cabal
+      - run: cabal sdist Cabal-QuickCheck
+      - run: cabal sdist Cabal-described
+      - run: cabal sdist Cabal-hooks
+      - run: cabal sdist Cabal-syntax
+      - run: cabal sdist Cabal-tests
+      - run: cabal sdist Cabal-tree-diff
+      - run: cabal sdist cabal-install
+      - run: cabal sdist cabal-install-solver

--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -15,7 +15,7 @@ category:       Distribution
 build-type:     Simple
 
 extra-source-files:
-  README.md CHANGELOG.md
+  readme.md changelog.md
 
 source-repository head
   type:     git


### PR DESCRIPTION
Fixes #10738. Adds a dry run check of `cabal install cabal-install` and then fixes the casing of `extra-source-files` in `Cabal-hooks`.

> [!NOTE]
> Now updated to fix #10777 too.

Here's a failing run, https://github.com/haskell/cabal/actions/runs/12736390756/job/35496224194.

Excluding `.cabal` files that are test packages, only 4 of our packages use `extra-source-files`:

```
$ find . -type f -name '*.cabal' | grep -v -E 'dist- \
  |cabal-testsuite/PackageTests|Cabal-tests/tests' | xargs grep -P -A 1 'extra-source-files'
./cabal-benchmarks/cabal-benchmarks.cabal:extra-source-files: README.md
./cabal-benchmarks/cabal-benchmarks.cabal-
--
./cabal-testsuite/cabal-testsuite.cabal:extra-source-files:
./cabal-testsuite/cabal-testsuite.cabal-  README.md
--
./solver-benchmarks/solver-benchmarks.cabal:extra-source-files:
./solver-benchmarks/solver-benchmarks.cabal-  README.md
--
./Cabal-hooks/Cabal-hooks.cabal:extra-source-files:
./Cabal-hooks/Cabal-hooks.cabal-  readme.md changelog.md
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
