### PR TITLE
Fix/build tool depends repeats

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -184,7 +184,9 @@ import Text.PrettyPrint
   , char
   , colon
   , hsep
+  , int
   , nest
+  , parens
   , quotes
   , renderStyle
   , text
@@ -1121,10 +1123,11 @@ configurePackage verbHandles cfg lbc0 pkg_descr00 flags enabled comp platform pa
     (merged, ds@(dup : _)) ->
       noticeDoc verbosity $
         vcat
-          [ (text "The build tool" <+> quotes (text $ nameOf dup) <+> "has multiple versions specified") <> colon
-          , nest 2 $ vcat [char '-' <+> text (prettyShow $ versionOf d) | d <- ds]
-          , text "These versions have been combined as" <> colon
-          , nest 2 $ quotes (text $ prettyShow merged)
+          [ (text "As the build tool" <+> quotes (text $ nameOf dup) <+> "was specified more than once") <> colon
+          , nest 2 $ vcat [char '-' <+> versionOfDoc d | d <- ds]
+          , (text "We'll use the effective intersection of these" <+> int (length ds) <+> "version ranges") <> colon
+          , nest 2 $ char '-' <+> versionOfDoc merged
+          , text "Please specify build tool dependencies only once."
           ]
 
   programDb1 <-
@@ -1181,6 +1184,12 @@ nameOf (LegacyExeDependency n _) = n
 
 versionOf :: LegacyExeDependency -> VersionRange
 versionOf (LegacyExeDependency _ v) = v
+
+versionOfDoc :: LegacyExeDependency -> Doc
+versionOfDoc (LegacyExeDependency _ v) =
+  if v == anyVersion
+    then text (prettyShow v) <+> parens (text "any version")
+    else text $ prettyShow v
 
 -- | Any duplicates in the list has their version range merged by intersection.
 -- The second list has the build tool with its merged version range and its list

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -140,7 +141,8 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as BLC8
 import Data.List
-  ( intersect
+  ( groupBy
+  , intersect
   , stripPrefix
   , (\\)
   )
@@ -180,10 +182,13 @@ import qualified System.Info
 import Text.PrettyPrint
   ( Doc
   , char
+  , colon
   , hsep
+  , nest
   , quotes
   , renderStyle
   , text
+  , vcat
   , ($+$)
   )
 
@@ -1081,7 +1086,7 @@ configurePackage verbHandles cfg lbc0 pkg_descr00 flags enabled comp platform pa
   -- right before calling configurePackage?
 
   -- Configure certain external build tools, see below for which ones.
-  let requiredBuildTools
+  let rawRequiredBuildTools
         -- If --ignore-build-tools is set, no build tool is required:
         | fromFlagOrDefault False $ configIgnoreBuildTools cfg =
             []
@@ -1108,6 +1113,19 @@ configurePackage verbHandles cfg lbc0 pkg_descr00 flags enabled comp platform pa
                   , isNothing (desugarBuildTool pkg_descr0 buildTool)
                   ]
             externBuildToolDeps ++ unknownBuildTools
+
+  let (requiredBuildTools, dups) = deduplicateBuildTools rawRequiredBuildTools
+
+  for_ dups $ \case
+    (_, []) -> return ()
+    (merged, ds@(dup : _)) ->
+      noticeDoc verbosity $
+        vcat
+          [ (text "The build tool" <+> quotes (text $ nameOf dup) <+> "has multiple versions specified") <> colon
+          , nest 2 $ vcat [char '-' <+> text (prettyShow $ versionOf d) | d <- ds]
+          , text "These versions have been combined as" <> colon
+          , nest 2 $ quotes (text $ prettyShow merged)
+          ]
 
   programDb1 <-
     configureAllKnownPrograms (modifyVerbosityFlags lessVerbose verbosity) programDb0
@@ -1157,6 +1175,28 @@ configurePackage verbHandles cfg lbc0 pkg_descr00 flags enabled comp platform pa
       ++ showPackageDescription pkg_descr2
 
   return (lbc, pbd)
+
+nameOf :: LegacyExeDependency -> String
+nameOf (LegacyExeDependency n _) = n
+
+versionOf :: LegacyExeDependency -> VersionRange
+versionOf (LegacyExeDependency _ v) = v
+
+-- | Any duplicates in the list has their version range merged by intersection.
+-- The second list has the build tool with its merged version range and its list
+-- of duplicates.
+deduplicateBuildTools :: [LegacyExeDependency] -> ([LegacyExeDependency], [(LegacyExeDependency, [LegacyExeDependency])])
+deduplicateBuildTools xs =
+  catMaybes
+    <$> unzip
+      [ (merged, if length gs == 1 then Nothing else Just (merged, gs))
+      | gs@(g : _) <- groupBy ((==) `on` nameOf) (sortBy (comparing nameOf) xs)
+      , let merged = LegacyExeDependency (nameOf g) (mergeVersions (ordNub . filter (/= anyVersion) $ versionOf <$> gs))
+      ]
+  where
+    mergeVersions :: [VersionRange] -> VersionRange
+    mergeVersions [] = anyVersion
+    mergeVersions (v : vs) = foldr intersectVersionRanges v vs
 
 computePackageInfo
   :: VerbosityHandles


### PR DESCRIPTION
Fixes #10758.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added.

## QA Notes

Use `cabal init` to create a package with components of your choosing and then add a `build-tool-depends` stanza that builds. The one from the docs is `markdown-unlit:markdown-unlit >= 0.5.0 && < 0.6`. When repeated, there should be a message asking that each build tool dependency is specified only once. The package should still build unless the effective intersection of version ranges is impossible to satisfy.

```
$ cabal build all --enable-tests --enable-benchmarks
...
Resolving dependencies...
...
As the build tool 'markdown-unlit' was specified more than once:
  - >0.5.0 && <=0.6
  - >=0 (any version)
We'll use the effective intersection of these 2 version ranges:
  - >0.5.0 && <=0.6
Please specify build tool dependencies only once.
...
```
