### PR TITLE
Add a `--lock` flag to `cabal freeze` to promote a freeze file to a lock file

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -5,7 +5,7 @@
 module Distribution.Client.CmdFreeze
   ( freezeCommand
   , freezeAction
-  , ClientFreezeFlags(..),
+  , ClientFreezeFlags (..)
   ) where
 
 import Distribution.Client.Compat.Prelude
@@ -28,22 +28,15 @@ import Distribution.Client.ProjectConfig
   )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.ProjectPlanning
-import Distribution.Client.Targets
-  ( UserConstraint (..)
-  , UserConstraintScope (..)
-  , UserQualifier (..)
-  )
-import Distribution.Solver.Types.ConstraintSource
-  ( ConstraintSource (..)
-  )
-import Distribution.Solver.Types.PackageConstraint
-  ( PackageProperty (..)
-  )
-import Distribution.Solver.Types.Settings (OnlyConstrained(..))
 import Distribution.Client.Setup
   ( CommonSetupFlags (setupVerbosity)
   , ConfigFlags (..)
   , GlobalFlags
+  )
+import Distribution.Client.Targets
+  ( UserConstraint (..)
+  , UserConstraintScope (..)
+  , UserQualifier (..)
   )
 import Distribution.Package
   ( PackageName
@@ -55,12 +48,19 @@ import Distribution.PackageDescription
   , nullFlagAssignment
   )
 import Distribution.Simple.Flag (Flag (..), fromFlagOrDefault)
+import Distribution.Simple.Setup (trueArg)
 import Distribution.Simple.Utils
   ( dieWithException
   , notice
   , wrapText
   )
-import Distribution.Simple.Setup (trueArg)
+import Distribution.Solver.Types.ConstraintSource
+  ( ConstraintSource (..)
+  )
+import Distribution.Solver.Types.PackageConstraint
+  ( PackageProperty (..)
+  )
+import Distribution.Solver.Types.Settings (OnlyConstrained (..))
 import Distribution.Verbosity
   ( normal
   )
@@ -78,7 +78,6 @@ import Distribution.Simple.Command
   ( CommandUI (..)
   , OptionField
   , ShowOrParseArgs
-  , usageAlternatives
   , option
   , usageAlternatives
   )
@@ -217,8 +216,8 @@ projectFreezeConfig freezeFlags elaboratedPlan totalIndexState activeRepos0 =
     activeRepos = filterSkippedActiveRepos activeRepos0
 
     onlyConstrainedFlag :: ClientFreezeFlags -> Flag OnlyConstrained
-    onlyConstrainedFlag ClientFreezeFlags{lockDependencies=Flag True} = Flag OnlyConstrainedAll
-    onlyConstrainedFlag ClientFreezeFlags{lockDependencies=_} = NoFlag
+    onlyConstrainedFlag ClientFreezeFlags{lockDependencies = Flag True} = Flag OnlyConstrainedAll
+    onlyConstrainedFlag ClientFreezeFlags{lockDependencies = _} = NoFlag
 
 -- | Given the install plan, produce solver constraints that will ensure the
 -- solver picks the same solution again in future in different environments.

--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -217,7 +217,7 @@ projectFreezeConfig freezeFlags elaboratedPlan totalIndexState activeRepos0 =
     activeRepos = filterSkippedActiveRepos activeRepos0
 
     onlyConstrainedFlag :: ClientFreezeFlags -> Flag OnlyConstrained
-    onlyConstrainedFlag ClientFreezeFlags{lockDependencies=Flag True} = Flag OnlyConstrainedAll 
+    onlyConstrainedFlag ClientFreezeFlags{lockDependencies=Flag True} = Flag OnlyConstrainedAll
     onlyConstrainedFlag ClientFreezeFlags{lockDependencies=_} = NoFlag
 
 -- | Given the install plan, produce solver constraints that will ensure the

--- a/cabal-testsuite/PackageTests/Freeze/freeze-lock.out
+++ b/cabal-testsuite/PackageTests/Freeze/freeze-lock.out
@@ -1,0 +1,5 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal v2-freeze
+Resolving dependencies...
+Wrote freeze file: <ROOT>/cabal.project.freeze

--- a/cabal-testsuite/PackageTests/Freeze/freeze-lock.test.hs
+++ b/cabal-testsuite/PackageTests/Freeze/freeze-lock.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    withRepo "repo" $ do
+        cabal "v2-freeze" ["--lock"]
+        cwd <- fmap testCurrentDir getTestEnv
+        assertFileDoesContain (cwd </> "cabal.project.freeze") "reject-unconstrained-dependencies: all"

--- a/changelog.d/pr-10785.md
+++ b/changelog.d/pr-10785.md
@@ -6,3 +6,5 @@ issues: 10784
 ---
 
 Added a `--lock` flag to `cabal freeze`, to promote a freeze file to a lock file. By calling `cabal freeze --lock`, the resulting freeze file will ensure that only dependencies whose constraints are specified, will be accepted by future build plans. This flag can be used to ensure that no unaudited packages are added to the build plan.
+
+This new `--lock` flag reuses the mechanism behind `--reject-unconstrained-dependencies`, by writing the equivalent of `--reject-unconstrained-dependencies=all` to the freeze file.

--- a/changelog.d/pr-10785.md
+++ b/changelog.d/pr-10785.md
@@ -1,0 +1,8 @@
+---
+synopsis: Added a `--lock` flag to `cabal freeze` to promote a freeze file to a lock file
+packages: [cabal-install]
+prs: 10785
+issues: 10784
+---
+
+Added a `--lock` flag to `cabal freeze`, to promote a freeze file to a lock file. By calling `cabal freeze --lock`, the resulting freeze file will ensure that only dependencies whose constraints are specified, will be accepted by future build plans. This flag can be used to ensure that no unaudited packages are added to the build plan.

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -532,6 +532,13 @@ users see a consistent set of dependencies. For libraries, this is not
 recommended: users often need to build against different versions of
 libraries than what you developed against.
 
+A freeze file is really a set of constraint; by default, such files do not
+prevent new dependencies from being included in the build plan. In this sense,
+a freeze file is not, by default, a **lockfile**. To turn a freeze file into a lockfile,
+use the ``--lock`` flag when invocating ``cabal freeze``. This will prevent future
+builds from including new dependencies. This can be helpful in situations where
+every dependency must be explicitly audited and approved, for example.
+
 cabal gen-bounds
 ^^^^^^^^^^^^^^^^
 

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -538,6 +538,9 @@ a freeze file is not, by default, a **lockfile**. To turn a freeze file into a l
 use the ``--lock`` flag when invocating ``cabal freeze``. This will prevent future
 builds from including new dependencies. This can be helpful in situations where
 every dependency must be explicitly audited and approved, for example.
+Under the hood, the ``--lock`` flag reuses the mechanism behind
+``--reject-unconstrained-dependencies``, by writing the equivalent of
+``--reject-unconstrained-dependencies=all`` to the freeze file.
 
 cabal gen-bounds
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This pull request adds a `--lock` flag to `cabal freeze`, promoting a freeze file to a lock file.

Fixes #10784 .

## QA Notes

Calling `cabal freeze --lock` should produce a freeze file, with one added line compared to `cabal freeze`:

```txt
reject-unconstrained-dependencies: all
```

## Checklist

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
