### PR TITLE
Clarify splitting/passing behaviour for --*-option(s) arguments

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
@@ -118,7 +118,8 @@ benchmarkOptions' showOrParseArgs =
         []
         ["benchmark-options"]
         ( "give extra options to benchmark executables "
-            ++ "(name templates can use $pkgid, $compiler, "
+            ++ "(split on spaces, \"quotes\" prevent splitting; "
+            ++ "name templates can use $pkgid, $compiler, "
             ++ "$os, $arch, $benchmark)"
         )
         benchmarkOptions
@@ -132,7 +133,7 @@ benchmarkOptions' showOrParseArgs =
         []
         ["benchmark-option"]
         ( "give extra option to benchmark executables "
-            ++ "(no need to quote options containing spaces, "
+            ++ "(passed directly as a single argument; "
             ++ "name template can use $pkgid, $compiler, "
             ++ "$os, $arch, $benchmark)"
         )

--- a/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
@@ -118,7 +118,7 @@ benchmarkOptions' showOrParseArgs =
         []
         ["benchmark-options"]
         ( "give extra options to benchmark executables "
-            ++ "(split on spaces, \"quotes\" prevent splitting; "
+            ++ "(split on spaces, use \"\" to prevent splitting; "
             ++ "name templates can use $pkgid, $compiler, "
             ++ "$os, $arch, $benchmark)"
         )

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -275,7 +275,9 @@ programDbOption progDb showOrParseArgs get set =
         [prog ++ "-option"]
         ( "give an extra option to "
             ++ prog
-            ++ " (passed directly to " ++ prog ++ " as a single argument)"
+            ++ " (passed directly to "
+            ++ prog
+            ++ " as a single argument)"
         )
         get
         set
@@ -314,7 +316,8 @@ programDbOptions progDb showOrParseArgs get set =
         [prog ++ "-options"]
         ( "give extra options to "
             ++ prog
-            ++ " (split on spaces, \"quotes\" prevent splitting)")
+            ++ " (split on spaces, \"quotes\" prevent splitting)"
+        )
         get
         set
         (reqArg' "OPTS" (\args -> [(prog, splitArgs args)]) (const []))

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -275,7 +275,7 @@ programDbOption progDb showOrParseArgs get set =
         [prog ++ "-option"]
         ( "give an extra option to "
             ++ prog
-            ++ " (no need to quote options containing spaces)"
+            ++ " (passed directly to " ++ prog ++ " as a single argument)"
         )
         get
         set
@@ -312,7 +312,9 @@ programDbOptions progDb showOrParseArgs get set =
       option
         ""
         [prog ++ "-options"]
-        ("give extra options to " ++ prog)
+        ( "give extra options to "
+            ++ prog
+            ++ " (split on spaces, \"quotes\" prevent splitting)")
         get
         set
         (reqArg' "OPTS" (\args -> [(prog, splitArgs args)]) (const []))

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -316,7 +316,7 @@ programDbOptions progDb showOrParseArgs get set =
         [prog ++ "-options"]
         ( "give extra options to "
             ++ prog
-            ++ " (split on spaces, \"quotes\" prevent splitting)"
+            ++ " (split on spaces, use \"\" to prevent splitting)"
         )
         get
         set

--- a/Cabal/src/Distribution/Simple/Setup/Test.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Test.hs
@@ -245,7 +245,8 @@ testOptions' showOrParseArgs =
         []
         ["test-options"]
         ( "give extra options to test executables "
-            ++ "(name templates can use $pkgid, $compiler, "
+            ++ "(split on spaces, \"quotes\" prevent splitting; "
+            ++ "name templates can use $pkgid, $compiler, "
             ++ "$os, $arch, $test-suite)"
         )
         testOptions
@@ -259,7 +260,7 @@ testOptions' showOrParseArgs =
         []
         ["test-option"]
         ( "give extra option to test executables "
-            ++ "(no need to quote options containing spaces, "
+            ++ "(passed directly as a single argument; "
             ++ "name template can use $pkgid, $compiler, "
             ++ "$os, $arch, $test-suite)"
         )

--- a/Cabal/src/Distribution/Simple/Setup/Test.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Test.hs
@@ -245,7 +245,7 @@ testOptions' showOrParseArgs =
         []
         ["test-options"]
         ( "give extra options to test executables "
-            ++ "(split on spaces, \"quotes\" prevent splitting; "
+            ++ "(split on spaces, use \"\" to prevent splitting; "
             ++ "name templates can use $pkgid, $compiler, "
             ++ "$os, $arch, $test-suite)"
         )

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -1063,10 +1063,11 @@ configuration from the 'cabal.project', 'cabal.project.local' and other files.
 .. option:: --repl-options=FLAG
 
     To avoid ``ghci``-specific flags from triggering unneeded global rebuilds, these
-    flags are stripped from the internal configuration. As a result,
-    ``--ghc-options`` will no longer (reliably) work to pass flags to ``ghci`` (or
-    other REPLs). Instead, you should use the ``--repl-options`` flag to
-    specify these options to the invoked REPL.
+    flags are stripped from the internal configuration when using
+    ``--ghc-option`` or ``--ghc-options``. As a result, ``--ghc-options`` will
+    not (reliably) work to pass flags to ``ghci`` (or other REPLs).
+    ``--repl-options`` bypasses this and allows you to specify options to the
+    invoked REPL without influencing the build configuration for other packages.
 
 .. option:: --repl-no-load
 

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -1069,6 +1069,9 @@ configuration from the 'cabal.project', 'cabal.project.local' and other files.
     ``--repl-options`` bypasses this and allows you to specify options to the
     invoked REPL without influencing the build configuration for other packages.
 
+    Note: ``--repl-options`` does not accept ``"quotes"`` to pass options
+    containing spaces to the REPL.
+
 .. option:: --repl-no-load
 
     Disables the loading of target modules at startup.

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -1060,7 +1060,7 @@ Examples:
 Configuration flags can be specified on the command line and these extend the project
 configuration from the 'cabal.project', 'cabal.project.local' and other files.
 
-.. option:: --repl-options=FLAG
+.. option:: --repl-options=OPTS
 
     To avoid ``ghci``-specific flags from triggering unneeded global rebuilds, these
     flags are stripped from the internal configuration when using

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -1069,7 +1069,7 @@ configuration from the 'cabal.project', 'cabal.project.local' and other files.
     ``--repl-options`` bypasses this and allows you to specify options to the
     invoked REPL without influencing the build configuration for other packages.
 
-    Note: ``--repl-options`` does not accept ``"quotes"`` to pass options
+    Note: ``--repl-options`` does not accept double quotes (``""``) to pass options
     containing spaces to the REPL.
 
 .. option:: --repl-no-load

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -211,18 +211,29 @@ files of a package:
     ``--alex-options="--template=mytemplatedir/"``. The *options* is
     split into program options based on spaces. Any options containing
     embedded spaced need to be quoted, for example
-    ``--foo-options='--bar="C:\Program File\Bar"'``. As an alternative
+    ``--foo-options='--bar="C:\Program Files\Bar"'``. As an alternative
     that takes only one option at a time but avoids the need to quote,
     use :option:`--PROG-option` instead.
 
+    Note: if *prog* is ``ghc``, then options that do not affect build
+    artifacts, such as warning flags, are dropped. This is because
+    ``--ghc-options`` applies to GHC for the entire build plan, not just the
+    current package, and recompiling the entire dependency tree is probably
+    unintended. If you want to apply some options to ``cabal repl`` only, pass
+    ``--repl-options`` to ``cabal repl``.
+
 .. option:: --PROG-option=OPT
 
-    Specify a single additional option to the program *prog*. For
+    Specify a single additional option to the program *prog*. The option is
+    passed to *prog* as a single argument, without any splitting. For
     passing an option that contains embedded spaces, such as a file name
     with embedded spaces, using this rather than :option:`--PROG-options`
     means you do not need an additional level of quoting. Of course if you
     are using a command shell you may still need to quote, for example
-    ``--foo-options="--bar=C:\Program File\Bar"``.
+    ``--foo-options="--bar=C:\Program Files\Bar"``.
+
+    The same note ragarding dropping flags as for :option:`--PROG-options`
+    applies to ``--PROG-option`` as well.
 
 All of the options passed with either :option:`--PROG-options`
 or :option:`--PROG-option` are passed in the order they were
@@ -1443,11 +1454,11 @@ Flags for repl:
 
 .. option:: --PROG-option=OPT
 
-    Give an extra option to PROG (no need to quote options containing spaces).
+    Give an extra option to PROG (passed directly to PROG as a single argument).
 
 .. option:: --PROG-options=OPTS
 
-    Give extra options to PROG.
+    Give extra options to PROG (split on spaces, "quotes" prevent splitting).
 
 .. option:: --repl-no-load
 

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -210,10 +210,11 @@ files of a package:
     to Cabal can be used in place of *prog*. For example:
     ``--alex-options="--template=mytemplatedir/"``. The *options* is
     split into program options based on spaces. Any options containing
-    embedded spaced need to be quoted, for example
-    ``--foo-options='--bar="C:\Program Files\Bar"'``. As an alternative
-    that takes only one option at a time but avoids the need to quote,
-    use :option:`--PROG-option` instead.
+    embedded spaces need to be quoted with "double quotes", for example
+    ``--foo-options='--bar="C:\Program Files\Bar"'``. (The ``'single'`` quotes
+    are for your shell, the ``"double"`` quotes are passed to Cabal.) As an
+    alternative that takes only one option at a time but avoids the need to
+    quote, use :option:`--PROG-option` instead.
 
     Note: if *prog* is ``ghc``, then options that do not affect build
     artifacts, such as warning flags, are dropped. This is because

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -233,7 +233,7 @@ files of a package:
     are using a command shell you may still need to quote, for example
     ``--foo-options="--bar=C:\Program Files\Bar"``.
 
-    The same note ragarding dropping flags as for :option:`--PROG-options`
+    The same note regarding dropping flags as for :option:`--PROG-options`
     applies to ``--PROG-option`` as well.
 
 All of the options passed with either :option:`--PROG-options`

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -213,7 +213,7 @@ files of a package:
     embedded spaces need to be quoted with double quotes (``""``), for example
     ``--foo-options='--bar="C:\Program Files\Bar"'``. (The single quotes
     (``''``) are for your shell, the ``"double"`` quotes are passed to Cabal.)
-    As an alternative that takes only one option at a time but avoids the need
+    For an alternative that takes only one option at a time but avoids the need
     to quote, use :option:`--PROG-option` instead.
 
     Note: if *prog* is ``ghc``, then options that do not affect build

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -210,11 +210,11 @@ files of a package:
     to Cabal can be used in place of *prog*. For example:
     ``--alex-options="--template=mytemplatedir/"``. The *options* is
     split into program options based on spaces. Any options containing
-    embedded spaces need to be quoted with "double quotes", for example
-    ``--foo-options='--bar="C:\Program Files\Bar"'``. (The ``'single'`` quotes
-    are for your shell, the ``"double"`` quotes are passed to Cabal.) As an
-    alternative that takes only one option at a time but avoids the need to
-    quote, use :option:`--PROG-option` instead.
+    embedded spaces need to be quoted with double quotes (``""``), for example
+    ``--foo-options='--bar="C:\Program Files\Bar"'``. (The single quotes
+    (``''``) are for your shell, the ``"double"`` quotes are passed to Cabal.)
+    As an alternative that takes only one option at a time but avoids the need
+    to quote, use :option:`--PROG-option` instead.
 
     Note: if *prog* is ``ghc``, then options that do not affect build
     artifacts, such as warning flags, are dropped. This is because
@@ -1459,7 +1459,7 @@ Flags for repl:
 
 .. option:: --PROG-options=OPTS
 
-    Give extra options to PROG (split on spaces, "quotes" prevent splitting).
+    Give extra options to PROG (split on spaces, use "" to prevent splitting).
 
 .. option:: --repl-no-load
 


### PR DESCRIPTION
Spawned by a question [on IRC](https://ircbrowse.tomsmeding.com/day/lchaskell/2025/02/12?id=1480039#trid1480039) of what exactly `--ghc-option`, `--ghc-options` and `--repl-options` take as their input format, I reformulated and expanded on the relevant documentation. Correctness of this information was checked in two ways:

- Limited experimentation with the `cabal` CLI;
- Asking questions to @merijn on IRC (later in the same log linked above).

This list conspicuously _excludes_ "looking at the code". My apologies.

Checklist for template B (does not modify behaviour or interface):

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).