### PR TITLE
Add PR size guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,6 +360,23 @@ If your PR is trivial you can omit this process (but explain in the PR why you
 think it does not warrant an issue). Feel free to open a new issue (or new
 issues) when appropriate.
 
+### Pull request size
+
+Keep your pull requests small, write one pull request per feature, let
+the content of the pull request match the title of the pull request.
+
+To get merged, your pull request needs to be reviewed by two other
+contributors. Large pull requests are daunting to inspect, and the
+back-and-forth between the author and reviewer can get frustrating and
+difficult to follow.
+
+Split your pull requests in multiple ones if possible (e.g. a refactor
+and a feature implementation should go in two different pull requests).
+This is *especially* important when we decide to backport a pull request
+(be it fix or a feature).
+
+Thorough reviews mean less regressions, keeping your pull requests small
+will improve Cabal codebase quality.
 
 ## Changelog
 


### PR DESCRIPTION
As per today dev call, comments/modifications welcome

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ N/A
