### PR TITLE
testsuite: Set TMPDIR to a specific folder rather than the test root

### DIFF
--- a/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.test.hs
@@ -15,7 +15,7 @@ main = cabalTest $ recordMode DoNotRecord $ withProjectFile "cabal.project" $ do
           else "haddock-response*.txt"
 
   -- Check that there is a response file.
-  responseFiles <- assertGlobMatchesTestDir testTmpDir glob
+  responseFiles <- assertGlobMatchesTestDir testSystemTmpDir glob
 
   -- Check that the matched response file is not empty, and is indeed a Haddock
   -- response file.

--- a/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.test.hs
@@ -22,7 +22,7 @@ main =
             else "haddock-response*.txt"
 
     -- Check that there is a response file.
-    responseFiles <- assertGlobMatchesTestDir testTmpDir glob
+    responseFiles <- assertGlobMatchesTestDir testSystemTmpDir glob
 
     -- Check that the matched response file is not empty, and is indeed a Haddock
     -- response file.

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -34,6 +34,7 @@ module Test.Cabal.Monad (
     testPrefixDir,
     testLibInstallDir,
     testDistDir,
+    testSystemTmpDir,
     testPackageDbDir,
     testRepoDir,
     testKeysDir,
@@ -407,9 +408,9 @@ runTestM mode m =
                         , ("CABAL_DIR", Just (testCabalDir env))
                         , ("CABAL_CONFIG", Just (testUserCabalConfigFile env))
                         -- Set `TMPDIR` so that temporary files aren't created in the global `TMPDIR`.
-                        , ("TMPDIR", Just tmp_dir)
+                        , ("TMPDIR", Just (testSystemTmpDir env))
                         -- Windows uses `TMP` for the `TMPDIR`.
-                        , ("TMP", Just tmp_dir)
+                        , ("TMP", Just (testSystemTmpDir env))
                         ],
                     testShouldFail = False,
                     testRelativeCurrentDir = ".",
@@ -548,6 +549,7 @@ initWorkDir :: TestM ()
 initWorkDir = do
     env <- getTestEnv
     liftIO $ createDirectoryIfMissing True (testWorkDir env)
+    liftIO $ createDirectoryIfMissing True (testSystemTmpDir env)
 
 
 
@@ -823,6 +825,11 @@ testName env = testSubName env <.> testMode env
 -- subtests.)  To clean, you ONLY need to delete this directory.
 testWorkDir :: TestEnv -> FilePath
 testWorkDir env = testTmpDir env </> (testName env <.> "dist")
+
+-- The folder which TMPDIR is set to.
+-- This is different to testTmpDir, which is the folder which is the test is run from.
+testSystemTmpDir :: TestEnv -> FilePath
+testSystemTmpDir env = testWorkDir env </> "tmp"
 
 -- | The absolute prefix where installs go.
 testPrefixDir :: TestEnv -> FilePath


### PR DESCRIPTION
If things start getting created in the TMPDIR, then it is better to not place them directly in the project root next to the source and test files. This also makes it easier to write tests which are sensitive to what is created in the CWD.



**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
