### PR TITLE
Fix typo in shouldDirectoryNotExist

### DIFF
--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -785,7 +785,7 @@ shouldDirectoryExist path =
 shouldDirectoryNotExist :: MonadIO m => WithCallStack (FilePath -> m ())
 shouldDirectoryNotExist path =
     withFrozenCallStack $
-    liftIO $ doesDirectoryExist path >>= assertBool (path ++ " should exist") . not
+    liftIO $ doesDirectoryExist path >>= assertBool (path ++ " should not exist") . not
 
 assertRegex :: MonadIO m => String -> String -> Result -> m ()
 assertRegex msg regex r =


### PR DESCRIPTION

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
