### PR TITLE
Allow containers-0.8

### DIFF
--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -30,7 +30,7 @@ library
     , Cabal-syntax    >= 3.15      && < 3.17
     , Cabal           >= 3.15      && < 3.17
     , base            >= 4.13      && < 5
-    , containers      >= 0.5.0.0   && < 0.8
+    , containers      >= 0.5.0.0   && < 0.9
     , transformers    >= 0.5.6.0   && < 0.7
 
   ghc-options: -Wall -fno-ignore-asserts -Wtabs -Wincomplete-uni-patterns -Wincomplete-record-updates

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -32,7 +32,7 @@ library
     , base       >= 4.13     && < 5
     , binary     >= 0.7      && < 0.9
     , bytestring >= 0.10.0.0 && < 0.13
-    , containers >= 0.5.0.0  && < 0.8
+    , containers >= 0.5.0.0  && < 0.9
     , deepseq    >= 1.3.0.1  && < 1.7
     , directory  >= 1.2      && < 1.4
     , filepath   >= 1.3.0.1  && < 1.6

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -43,7 +43,7 @@ library
     , array      >= 0.4.0.1  && < 0.6
     , base       >= 4.13     && < 5
     , bytestring >= 0.10.0.0 && < 0.13
-    , containers >= 0.5.0.0  && < 0.8
+    , containers >= 0.5.0.0  && < 0.9
     , deepseq    >= 1.3.0.1  && < 1.7
     , directory  >= 1.2      && < 1.4
     , filepath   >= 1.3.0.1  && < 1.6

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -103,7 +103,7 @@ library
     , bytestring    >=0.10.6.0 && <0.13
     , Cabal         ^>=3.15
     , Cabal-syntax  ^>=3.15
-    , containers    >=0.5.6.2  && <0.8
+    , containers    >=0.5.6.2  && <0.9
     , edit-distance ^>= 0.2.2
     , directory     >= 1.3.7.0  && < 1.4
     , filepath      ^>=1.4.0.0 || ^>=1.5.0.0

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -235,7 +235,7 @@ library
       , base16-bytestring >= 0.1.1 && < 1.1.0.0
       , binary     >= 0.7.3    && < 0.9
       , bytestring >= 0.10.6.0 && < 0.13
-      , containers >= 0.5.6.2  && < 0.8
+      , containers >= 0.5.6.2  && < 0.9
       , cryptohash-sha256 >= 0.11 && < 0.12
       , directory  >= 1.3.7.0  && < 1.4
       , echo       >= 0.1.3    && < 0.2


### PR DESCRIPTION
Relaxed the upper bound for the containers dependency from <0.8 to <0.9
 - Cabal-hooks
 - Cabal-syntax
 - Cabal
 - cabal-install-solver
 - cabal-install

I tested this locally by running the command.

```
cabal build --constraint="containers==0.8.*" --allow-newer=resolv:containers --allow-newer=hackage-security:containers --allow-newer=hashable:containers exe:cabal
```

This uses containers version 0.8.x
while relaxing version constraints for the resolv, hackage-security, and hashable packages to allow them to work with this newer containers version.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
