### PR TITLE
Fix PATH changes not triggering REPL reconfiguration (#2015)

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2334,6 +2334,7 @@ elaborateInstallPlan
                 )
                 (perPkgOptionMapMappend pkgid packageConfigProgramArgs)
             elabProgramPathExtra = perPkgOptionNubList pkgid packageConfigProgramPathExtra
+            elabConfiguredPrograms = configuredPrograms compilerprogdb
             elabConfigureScriptArgs = perPkgOptionList pkgid packageConfigConfigureArgs
             elabExtraLibDirs = perPkgOptionList pkgid packageConfigExtraLibDirs
             elabExtraLibDirsStatic = perPkgOptionList pkgid packageConfigExtraLibDirsStatic

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -274,6 +274,7 @@ data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
   , elabProgramPaths :: Map String FilePath
   , elabProgramArgs :: Map String [String]
   , elabProgramPathExtra :: [FilePath]
+  , elabConfiguredPrograms :: [ConfiguredProgram]
   , elabConfigureScriptArgs :: [String]
   , elabExtraLibDirs :: [FilePath]
   , elabExtraLibDirsStatic :: [FilePath]

--- a/cabal-testsuite/PackageTests/PathRecomp/PathRecomp.cabal
+++ b/cabal-testsuite/PackageTests/PathRecomp/PathRecomp.cabal
@@ -1,0 +1,13 @@
+name:                PathRecomp
+version:             0.1.0.0
+license:             BSD3
+author:              Test Author
+maintainer:          test@example.com
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:     Lib
+  hs-source-dirs:      src
+  build-depends:       base
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/PathRecomp/Setup.hs
+++ b/cabal-testsuite/PackageTests/PathRecomp/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+main = defaultMain
+

--- a/cabal-testsuite/PackageTests/PathRecomp/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/PathRecomp/cabal.test.hs
@@ -1,0 +1,21 @@
+import Test.Cabal.Prelude
+import qualified Data.Map as Map
+import qualified Control.Monad.IO.Class as IO
+import System.Environment (getEnvironment)
+
+main = cabalTest $ recordMode DoNotRecord $ do
+    -- First run cabal repl with the normal PATH
+    env <- IO.liftIO getEnvironment
+    let originalPath = maybe "" id (lookup "PATH" env)
+
+    -- Run repl with original PATH
+    cabalWithStdin "repl" ["lib:PathRecomp"] "" >>= assertOutputContains "module loaded"
+
+    -- Now modify the PATH by prefixing with a dummy directory
+    -- This simulates a user modifying their PATH between cabal commands
+    let modifiedPath = "/dummy/path:" ++ originalPath
+    withEnv [("PATH", Just modifiedPath)] $ do
+        -- Run repl with modified PATH - this should still work
+        r <- cabalWithStdin "repl" ["lib:PathRecomp"] "(Prelude.fmap . Prelude.fmap) (\"/dummy/path\" `Data.List.isInfixOf`) (System.Environment.lookupEnv \"PATH\")"
+        assertOutputContains "module loaded" r
+        assertOutputContains "Just True" r

--- a/cabal-testsuite/PackageTests/PathRecomp/src/Lib.hs
+++ b/cabal-testsuite/PackageTests/PathRecomp/src/Lib.hs
@@ -1,0 +1,7 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+

--- a/changelog.d/pr-10817
+++ b/changelog.d/pr-10817
@@ -1,0 +1,12 @@
+synopsis: Fix PATH changes not triggering REPL reconfiguration
+packages: cabal-install
+prs: #10817
+issues: #2015
+
+Previously, if you changed your PATH after initial configuration, Cabal would
+continue using the old PATH settings in REPL sessions without warning.
+With this fix, Cabal properly detects PATH changes and reconfigures the REPL
+accordingly, ensuring tools and libraries in your current PATH are available.
+While this may cause additional rebuilds when PATH changes, it prevents the
+confusing errors that could occur when your REPL environment didn't match your
+system configuration.


### PR DESCRIPTION
When a user's PATH environment variable changes between Cabal commands, the environment in the REPL becomes incorrect. This occurs because during initial package configuration, the current PATH is captured via `programSearchPathAsPATHVar` and then stored in the `programOverrideEnv` field of a ConfiguredProgram. These `ConfiguredProgram`s are subsequently serialized into the setup-config file, effectively baking in the PATH environment from the time of configuration.

The issue manifests when `PATH` is updated after initial configuration. Although the solver re-runs when detecting `PATH` changes, the `dryRunLocalPkg` function examines `ElaboratedConfiguredPackage` and incorrectly determines that nothing has changed that would require reconfiguration. This decision is incorrect because `setup-config` now contains a stale reference to the original `PATH` value, which no longer matches the current environment.

To fix this problem, we need to store the `ConfiguredProgram`s directly in `ElaboratedConfiguredPackage`. This approach will ensure that when `PATH` changes, the `ConfiguredProgram`s will also change, properly triggering reconfiguration. While this solution will cause more recompilations when `PATH` changes, it guarantees that the correct environment is always used during builds and REPL sessions.

An alternative approach would be to stop baking the `PATH` variable into the environment of programs, but this would require more substantial changes to how Cabal manages environment variables.

Fixes #2015

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)


