### PR TITLE
Re #10819 Take format specification history back to version 1.8

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1578,7 +1578,7 @@ system-dependent values for these fields.
       compiled twice, once as part of the library and again for the executable.
 
 .. pkg-field:: default-extensions: identifier list
-   :since: 1.12
+   :since: 1.10
 
     A list of Haskell extensions used by every module. These determine
     corresponding compiler options enabled for all files. Extension
@@ -1588,7 +1588,7 @@ system-dependent values for these fields.
     to be preprocessed with a C preprocessor.
 
 .. pkg-field:: other-extensions: identifier list
-   :since: 1.12
+   :since: 1.10
 
     A list of Haskell extensions used by some (but not necessarily all)
     modules. From GHC version 6.6 onward, these may be specified by
@@ -1617,7 +1617,7 @@ system-dependent values for these fields.
     :pkg-field:`other-extensions` declarations.
 
 .. pkg-field:: default-language: identifier
-   :since: 1.12
+   :since: 1.10
 
     Specifies a language standard or a group of language extensions to be activated for the project. In the case of GHC, `see here for details <https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/control.html#controlling-extensions>`__.
 
@@ -1629,9 +1629,9 @@ system-dependent values for these fields.
     -  ``Haskell98``
 
 .. pkg-field:: other-languages: identifier
-   :since: 1.12
+   :since: 1.10
 
-   TBW
+    Specifies a language standard used by some (but not necessarily all) modules.
 
 .. pkg-field:: extensions: identifier list
    :deprecated: 1.12

--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -305,9 +305,42 @@ relative to the respective preceding *published* version.
 ``cabal-version: 1.12``
 -----------------------
 
-* Change syntax of :pkg-field:`cabal-version` to support the new recommended
+* Change the syntax of :pkg-field:`cabal-version` to support the new recommended
   ``cabal-version: x.y`` style
 
+``cabal-version: ==1.10``
+-------------------------
 
+* Change the syntax of :pkg-field:`cabal-version` to require a version range of
+  the form ``cabal-version: >= x.y``. (Consequently, ``cabal-version: ==1.10``
+  is, itself, not valid syntax.)
+
+* New :pkg-field:`default-language` (to specify a default language standard when
+  one is not explicitly specified) and :pkg-field:`other-languages`
+  (for language standards used by some modules) added.
+
+* New :pkg-field:`default-extensions` (for Haskell language extensions used by
+  every module) and :pkg-field:`other-extensions` (for extensions used by some
+  modules) added. :pkg-field:`extensions` deprecated.
+
+* New :pkg-section:`test-suite` stanza for describing a package test suite
+  added.
+
+* ``exitcode-stdio-1.0`` is a valid value of the `type` field in a
+  :pkg-section:`test-suite` stanza.
+
+``cabal-version: ==1.8``
+------------------------
+
+* Added support for the :pkg-field:`build-depends` of a
+  :pkg-section:`executable` stanza being able to specify the library in the same
+  package (if the package provides one) by the name of the package (without a
+  version constraint). Cabal then treats the executable as if it were in another
+  package that depended on the package providing the executable and the library.
+
+* The syntax for specifying package version ranges is expanded.
+
+* New :pkg-field:`license` types ``MIT`` and versioned ``GPL`` and ``LGPL``
+  added.
 
 .. include:: references.inc


### PR DESCRIPTION
See:
* #10819 

Also corrects when `default-extensions`, `other-extensions`, `default-language` and `other-languages` were, in fact, first introduced.

Also supplies missing ('TBW') documentation for `other-languages`.

The introduction of the `exitcode-stdio-1.0` value is documented because this is needed to make sense of the changes that occurred in `cabal-version: 1.14` (see:

* https://github.com/haskell/cabal/pull/10822).

Sources for changes:
* Change logs;
* Other documentation provided with released Cabal versions; and
* source code for published Cabal versions, including Haddock documentation and other code documentation.

**This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
  Not applicable, but added documentation follows the style of similar existing language.
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
  Not applicable.
