### PR TITLE
Fix #10821 Clear 'to do' in format specification history

### DIFF
--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -287,13 +287,16 @@ relative to the respective preceding *published* version.
 
 * Add ``getSysconfDir`` operation to ``Paths_`` API.
 
-``cabal-version: 1.16``
+``cabal-version: 1.14``
 -----------------------
 
-.. todo::
+* New :pkg-section:`benchmark` stanza for describing a package benchmark added.
 
-   this needs to be researched; there were only few changes between
-   1.12 and 1.18;
+* ``exitcode-stdio-1.0`` is a valid value of the `type` field in a
+  :pkg-section:`benchmark` stanza.
+
+* ``detailed-0.9`` added as a valid value of the `type` field in a
+  :pkg-section:`test-suite` stanza.
 
 ``cabal-version: 1.12``
 -----------------------


### PR DESCRIPTION
Documents changes in `cabal-version: 1.14`.

(There were no changes in `cabal-version: 1.16`.)

**This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
  Not applicable, but follows the language of similar parts of the page.
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
  Not applicable.
