### PR TITLE
Fix #10773 Document new `build-type: Hooks` in format specification history

### DIFF
--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -22,11 +22,15 @@ relative to the respective preceding *published* version.
 ``cabal-version: 3.14``
 -----------------------
 
-* Added field ``extra-files`` for specifying extra files to be included in
-  ``sdist`` without adding any other semantics (cf. ``extra-source-files``
-  is tracked by ``cabal build``).
+* Added field :pkg-field:`extra-files` for specifying extra files to be included
+  in ``sdist`` without adding any other semantics (compare,
+  :pkg-field:`extra-source-files` is tracked by ``cabal build``).
+
 * License fields use identifiers from SPDX License List version
   ``3.25 2024-08-19``.
+
+* The :pkg-field:`build-type` field allows the new build type ``Hooks`` to be
+  specified.
 
 ``cabal-version: 3.12``
 -----------------------


### PR DESCRIPTION
Also corrects formatting of other existing documentation under `cabal-version: 3.14`.

**This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
  Not applicable.
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
  Not applicable.
