### PR TITLE
Fix environment variable handling when running executables 

### DIFF
--- a/Cabal/src/Distribution/Simple/Bench.hs
+++ b/Cabal/src/Distribution/Simple/Bench.hs
@@ -22,7 +22,6 @@ module Distribution.Simple.Bench
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Distribution.Compat.Environment
 import qualified Distribution.PackageDescription as PD
 import Distribution.Pretty
 import Distribution.Simple.Build (addInternalBuildTools)
@@ -89,15 +88,12 @@ bench args pkg_descr lbi flags = do
               dieWithException verbosity $
                 NoBenchMarkProgram cmd
 
-            existingEnv <- getEnvironment
-
             -- Compute the appropriate environment for running the benchmark
             let progDb = LBI.withPrograms lbiForBench
                 pathVar = progSearchPath progDb
                 envOverrides = progOverrideEnv progDb
             newPath <- programSearchPathAsPATHVar pathVar
-            overrideEnv <- fromMaybe [] <$> getEffectiveEnvironment ([("PATH", Just newPath)] ++ envOverrides)
-            let shellEnv = overrideEnv ++ existingEnv
+            shellEnv <- getFullEnvironment ([("PATH", Just newPath)] ++ envOverrides)
 
             -- Add (DY)LD_LIBRARY_PATH if needed
             shellEnv' <-

--- a/cabal-install/src/Distribution/Client/Run.hs
+++ b/cabal-install/src/Distribution/Client/Run.hs
@@ -59,7 +59,6 @@ import Distribution.Types.UnqualComponentName
 import qualified Distribution.Simple.GHCJS as GHCJS
 
 import Distribution.Client.Errors
-import Distribution.Compat.Environment (getEnvironment)
 import Distribution.Utils.Path
 
 -- | Return the executable to run and any extra arguments that should be
@@ -178,13 +177,11 @@ run verbosity lbi exe exeArgs = do
             return (p, [])
 
   -- Compute the appropriate environment for running the executable
-  existingEnv <- getEnvironment
   let progDb = withPrograms lbiForExe
       pathVar = progSearchPath progDb
       envOverrides = progOverrideEnv progDb
   newPath <- programSearchPathAsPATHVar pathVar
-  overrideEnv <- fromMaybe [] <$> getEffectiveEnvironment ([("PATH", Just newPath)] ++ envOverrides)
-  let env = overrideEnv ++ existingEnv
+  env <- getFullEnvironment ([("PATH", Just newPath)] ++ envOverrides)
 
   -- Add (DY)LD_LIBRARY_PATH if needed
   env' <-

--- a/cabal-testsuite/PackageTests/DuplicateEnvVars/cabal.project
+++ b/cabal-testsuite/PackageTests/DuplicateEnvVars/cabal.project
@@ -1,0 +1,1 @@
+packages: p

--- a/cabal-testsuite/PackageTests/DuplicateEnvVars/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/DuplicateEnvVars/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ recordMode DoNotRecord $ do
+    res <- cabal' "test" ["all"]
+    assertOutputContains "No duplicate environment variables found" res

--- a/cabal-testsuite/PackageTests/DuplicateEnvVars/p/Main.hs
+++ b/cabal-testsuite/PackageTests/DuplicateEnvVars/p/Main.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Data.List (group, sort)
+import System.Environment (getEnvironment)
+
+main = do
+    env <- getEnvironment
+    let sortedEnv = sort env
+        duplicates = filter (\g -> length g > 1) $ group $ map fst sortedEnv
+
+    if null duplicates
+        then putStrLn "No duplicate environment variables found."
+        else do
+            putStrLn "Found duplicate environment variables:"
+            mapM_ (\d -> putStrLn $ "  - " ++ head d) duplicates
+            fail "Test failed due to duplicate environment variables"

--- a/cabal-testsuite/PackageTests/DuplicateEnvVars/p/p.cabal
+++ b/cabal-testsuite/PackageTests/DuplicateEnvVars/p/p.cabal
@@ -1,0 +1,10 @@
+cabal-version:      3.0
+name:               p
+version:            0.1.0.0
+build-type:         Simple
+
+test-suite env-test
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    build-depends:    base

--- a/changelog.d/pr-10827.md
+++ b/changelog.d/pr-10827.md
@@ -1,0 +1,11 @@
+---
+synopsis: "Fix duplicate environment variables in test and benchmark runs"
+packages: [Cabal, cabal-install]
+prs: 10827
+issues: 10718
+---
+
+Cabal no longer creates duplicate environment variables when running test
+suites, benchmarks, or internal executables. Previously, when setting up the
+environment for these processes, Cabal would append the overridden environment
+to the existing environment, creating duplicates of the same variable.


### PR DESCRIPTION
This fixes a bug where environment variables were duplicated when running executables.

```
overrideEnv <- fromMaybe [] <$> getEffectiveEnvironment ([("PATH", Just newPath)] ++ envOverrides)
let shellEnv = overrideEnv ++ existingEnv
```

Since getEffectiveEnvironment already calls getEnvironment internally, if any overrides
are passed then the result is a complete environment. Appending it to
the already existing environment results in duplicated environment variables.

The fix:
* Added getFullEnvironment function to handle the common pattern correctly
* Updated code in Bench, Test/ExeV10, Test/LibV09, and Client/Run to use this function

In the future it would be good to generalise `getFullEnvironment`
further so it can also handle the `addLibraryPath` case, which modifies
an environment variable, rather than merely setting or unsetting it.

Fixes #10718.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
