### PR TITLE
Cabal: Always pass -package-env=- to supported GHC versions 

### DIFF
--- a/cabal-testsuite/PackageTests/EnvironmentFile/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/EnvironmentFile/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for EnvironmentFile
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/EnvironmentFile/EnvironmentFile.cabal
+++ b/cabal-testsuite/PackageTests/EnvironmentFile/EnvironmentFile.cabal
@@ -1,0 +1,18 @@
+cabal-version:   3.14
+name:            EnvironmentFile
+version:         0.1.0.0
+license:         NONE
+author:          Matthew Pickering
+maintainer:      matthewtpickering@gmail.com
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+executable EnvironmentFile
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    base < 5,
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/EnvironmentFile/app/Main.hs
+++ b/cabal-testsuite/PackageTests/EnvironmentFile/app/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/cabal-testsuite/PackageTests/EnvironmentFile/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/EnvironmentFile/cabal.test.hs
@@ -1,0 +1,8 @@
+import Test.Cabal.Prelude
+import System.FilePath
+main = cabalTest $ recordMode DoNotRecord $ do
+    env <- getTestEnv
+    let cur_dir = testCurrentDir env
+    -- Set GHC_ENVIRONMENT to a file which contains garbage
+    withEnv [("GHC_ENVIRONMENT", Just (cur_dir </> "ghc.environment"))] $ do
+        cabal "build" ["all"]

--- a/cabal-testsuite/PackageTests/EnvironmentFile/ghc.environment
+++ b/cabal-testsuite/PackageTests/EnvironmentFile/ghc.environment
@@ -1,0 +1,1 @@
+this-file-(ghc.environment)-contains-garbage-it-should-not-be-read

--- a/changelog.d/pr-10828.md
+++ b/changelog.d/pr-10828.md
@@ -1,0 +1,15 @@
+---
+synopsis: "Isolate Cabal from the GHC_ENVIRONMENT variable"
+packages: [Cabal]
+prs: 10828
+
+issues: 10759
+---
+
+For GHC 8.4.4 and later, Cabal now passes the `-package-env=-` flag to GHC.
+This prevents the `GHC_ENVIRONMENT` variable or any package environment files
+from affecting Cabal builds.
+
+This change eliminates unexpected build behavior that could occur when users
+had GHC environment files configured in their system that Cabal wasn't aware
+of.


### PR DESCRIPTION
Issue https://github.com/haskell/cabal/issues/10759 highlighted the issue that we were not isolating the calls
to ghc from the existence of environment files.

This manifested in a terminal bug where extra arguments form the
environment file were causing a link failure which was due to a
combination of https://github.com/haskell/cabal/issues/10692.

However, even before this bug the test executable was relinked to due to
the extra flags from the environment file.

```
Building test suite 'aeson-schemas-test' for aeson-schemas-1.4.2.1...
Loaded package environment from /home/runner/work/aeson-schemas/aeson-schemas/dist-newstyle/tmp/environment.-69233/.ghc.environment.x86_64-linux-9.6.6
Loaded package environment from /home/runner/work/aeson-schemas/aeson-schemas/dist-newstyle/tmp/environment.-69233/.ghc.environment.x86_64-linux-9.6.6
[23 of 23] Linking /home/runner/work/aeson-schemas/aeson-schemas/dist-newstyle/build/x86_64-linux/ghc-9.6.6/aeson-schemas-1.4.2.1/t/aeson-schemas-test/build/aeson-schemas-test/aeson-schemas-test [Flags changed]
```

The correct solution is that calls to `ghc` made by `Cabal` should never
implicitly use an environment file. This is similar to how
`GHC_PACKAGE_PATH` is treated.

Fixes https://github.com/haskell/cabal/issues/10759

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

