### PR TITLE
Use a newer ci-images for centos7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,6 @@ linux:
       - ARCH: x86_64
         TAG: x86_64-linux
         OS:
-          - centos7
           - deb9
           - deb10
           - deb11
@@ -50,6 +49,14 @@ linux:
           - ubuntu18_04
           - ubuntu20_04
           - ubuntu22_04
+      # Pull this one from the future, since it's missing.
+      # We can't move the entire file to this DOCKER_REV, because
+      # i386-linux-deb9 is missing from it.
+      - ARCH: x86_64
+        TAG: x86_64-linux
+        OS: centos7
+        DOCKER_REV: f2d12519f45a13a61fcca03a949f927ceead6492
+
       - ARCH: aarch64
         TAG: aarch64-linux
         OS:

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -4,7 +4,14 @@ set -Eeuo pipefail
 
 source "$CI_PROJECT_DIR/.gitlab/common.sh"
 
-if [[ "$(uname)" == "Linux" ]]; then
+## Figure out how to get the Haskell toolchain.
+
+# For backport, the centos image no longer has the right GHC version, so use
+# ghcup.
+if [[ -f /etc/os-release && "$(grep ^ID /etc/os-release)" =~ "centos" ]]; then
+    . "$CI_PROJECT_DIR/.gitlab/ghcup.sh"
+# All the other ones are fine.
+elif [[ "$(uname)" == "Linux" ]]; then
     export PATH="/opt/ghc/${GHC_VERSION}/bin:${PATH}"
 # Not all runners use ci-images, so ghcup is used.
 else


### PR DESCRIPTION
Fix for #10804 designed for backport.

For the next major version of Cabal, I suggest a larger update of supported platforms. But *not* in this PR. This one is just about maintaining support of platforms that were already supported.

 [![pipeline status](https://gitlab.haskell.org/haskell/cabal/badges/b/backportable-centos7/pipeline.svg)](https://gitlab.haskell.org/haskell/cabal/-/commits/b/backportable-centos7) 