### PR TITLE
plan.json: Include compiler-abi field

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -109,6 +109,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
     , "compiler-id"
         J..= (J.String . showCompilerId . pkgConfigCompiler)
           elaboratedSharedConfig
+    , "compiler-abi" J..= jdisplay (compilerAbiTag (pkgConfigCompiler elaboratedSharedConfig))
     , "os" J..= jdisplay os
     , "arch" J..= jdisplay arch
     , "install-plan" J..= installPlanToJ elaboratedInstallPlan


### PR DESCRIPTION
    The plan.json file was missing crucial information needed to locate
    packages in the store directory structure. When cabal-install stores
    packages, it uses a full compiler identifier including an ABI tag (e.g.,
    "ghc-9.10.1-69c3") but plan.json only included the basic compiler ID
    ("ghc-9.10.1"). This made it impossible for external tools like
    cabal-plan to correctly locate packages and their files in the store.
    
    This commit adds a new "compiler-abi" field with the ABI tag string
    
    The issue reported in the original ticket seems to be about the location
    of LICENSE files, but the plan.json may still lack sufficient
    information to locate all license files since the packages may not be
    located in the store, but in different package databases given by
    the --package-db flag.  This will do for now.
    
    Fixes #10726


Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
