### PR TITLE
Take format specification history back to Cabal-1.0

### DIFF
--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -347,4 +347,108 @@ relative to the respective preceding *published* version.
 * New :pkg-field:`license` types ``MIT`` and versioned ``GPL`` and ``LGPL``
   added.
 
+``cabal-version: ==1.6``
+------------------------
+
+* New :pkg-section:`source-repository` stanza for information about the
+  location of the package's source code within a source code repository.
+
+* Add support for new :pkg-field:`bug-reports` field, to specify the URL where
+  users should direct bug reports.
+
+* Add support for wildcards in :pkg-field:`data-files` and
+  :pkg-field:`extra-source-files` fields.
+
+* Add support for ``foo ==1.2.*`` syntax to :pkg-field:`build-depends` field.
+
+* Add support for new :pkg-field:`library:exposed` field (default: ``True``), to
+  be able to specify that the package should not be exposed.
+
+* :pkg-field:`cpp-options`, :pkg-field:`cc-options` and :pkg-field:`ld-options`
+  fields no longer use ``,`` as a separator.
+
+``cabal-version: ==1.2.1``
+--------------------------
+
+* New format for the :pkg-section:`flag`, :pkg-section:`library` and
+  :pkg-section:`executable` stanzas.
+
+* Add support for new :pkg-field:`cpp-options` field, to specify options used
+  when pre-processing Haskell modules.
+
+* Replace ``nhc-options`` field with ``nhc98-options`` field.
+
+``cabal-version: ==1.2.0``
+--------------------------
+
+* The :pkg-field:`cabal-version` field is now required.
+
+* New :pkg-section:`flag` stanza for specifying configuration flags and add
+  support for conditional blocks in :pkg-section:`library` and
+  :pkg-section:`executable` stanzas.
+
+* Add distinct :pkg-section:`library` stanza.
+
+* New format for :pkg-section:`executable` stanzas.
+
+* Add support for new :pkg-field:`build-type` field (default: ``Custom``), to
+  specify the type of build used by this package.
+
+* Add support for new :pkg-field:`build-tools` field, to specify tools needed to
+  build the package.
+
+* Add support for new :pkg-field:`pkgconfig-depends` field, to specify
+  ``pkg-config`` packages needed to build the package.
+
+* Add support for new :pkg-field:`ghc-shared-options` field, to specify
+  additional options for GHC when the package is built as a shared library.
+
+``cabal-version: ==1.1.6``
+--------------------------
+
+* Add support for new :pkg-field:`install-includes` field, distinct from the
+  :pkg-field:`includes` field, to specify header files from the package.
+
+* Add support for new ``jhc-options`` field, to specify additional options for
+  John Meacham's Haskell compiler (JHC).
+
+``cabal-version: ==1.1.4``
+--------------------------
+
+* Add support for new optional :pkg-field:`cabal-version` field, to specify the
+  version of ``Cabal`` required for the package.
+
+* Add support for new :pkg-field:`author`, :pkg-field:`homepage`,
+  :pkg-field:`package-url`, :pkg-field:`synopsis`, :pkg-field:`description` and
+  :pkg-field:`category` fields.
+
+* Add support for new :pkg-field:`tested-with` field to specify compilers and
+  versions against which the package has been tested.
+
+* Add support for new :pkg-field:`data-files` field to specify files for use by
+  the package at run-time.
+
+* Add support for new :pkg-field:`extra-source-files` field to specify files to
+  be included in source distributions.
+
+* Add support for new :pkg-field:`extra-tmp-files` field to specify files to
+  be removed when cleaning up.
+
+* Replace :pkg-field:`hs-source-dir` field with :pkg-field:`hs-source-dirs`
+  field.
+
+* Add support for new :pkg-field:`ghc-prof-options` field, to specify
+  additional options for GHC when the package is built with profiling.
+
+* Add support for extension fields beginning with ``x-``.
+
+``Cabal-1.0``
+-------------
+
+``Cabal-1.0``, released March 2005, came with a
+`specification <https://downloads.haskell.org/~cabal/Cabal-1.0/doc/pkg-spec-html/>`__
+for 'The Haskell Cabal: A Common Architecture for Building Applications and
+Tools', including `Section 5.2 <https://downloads.haskell.org/~cabal/Cabal-1.0/doc/pkg-spec-html/x611.html#SBI-PKG-DESC>`__
+'Package description in the simple build infrastructure'.
+
 .. include:: references.inc


### PR DESCRIPTION
The motivation is that the documentation of the history of the format specification is almost complete (it currently stops at Cabal 1.8). This will complete it.

Some background to early Cabal version numbering is available [here](https://pilgrem.com/2025/03/26/early-cabal/).

The format specification appears to have been stable between Cabal 1.2.1 and Cabal 1.6.

**This PR does not modify behaviour or interface**

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
  Not applicable, but aims to be consistent with existing text.
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
  Not applicable.