### PR TITLE
Document deprecation of hugs- nhc98- jhc-options fields in format history

### DIFF
--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -194,6 +194,8 @@ relative to the respective preceding *published* version.
 * License fields use identifiers from SPDX License List version
   ``3.2 2018-07-10``
 
+* Deprecate ``jhc-options`` field.
+
 
 ``cabal-version: 2.2``
 ----------------------
@@ -266,6 +268,8 @@ relative to the respective preceding *published* version.
   :pkg-field:`build-depends`.
 
 * New :pkg-field:`license` type ``ISC`` added.
+
+* Deprecate ``hugs-options`` and ``nhc98-options`` fields.
 
 ``cabal-version: 1.20``
 -----------------------


### PR DESCRIPTION
**This PR does not modify behaviour or interface**
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
  Not applicable. 
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
  Not applicable.
