### PR TITLE
multi-repl: Support module renaming for ghc-9.12 onwards

### DIFF
--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -84,6 +84,7 @@ module Distribution.Simple.Compiler
   , libraryDynDirSupported
   , libraryVisibilitySupported
   , jsemSupported
+  , reexportedAsSupported
 
     -- * Support for profiling detail levels
   , ProfDetailLevel (..)
@@ -428,6 +429,14 @@ backpackSupported = ghcSupported "Support Backpack"
 jsemSupported :: Compiler -> Bool
 jsemSupported comp = case compilerFlavor comp of
   GHC -> v >= mkVersion [9, 7]
+  _ -> False
+  where
+    v = compilerVersion comp
+
+-- | Does the compiler support the -reexported-modules "A as B" syntax
+reexportedAsSupported :: Compiler -> Bool
+reexportedAsSupported comp = case compilerFlavor comp of
+  GHC -> v >= mkVersion [9, 12]
   _ -> False
   where
     v = compilerVersion comp

--- a/Cabal/src/Distribution/Simple/Errors.hs
+++ b/Cabal/src/Distribution/Simple/Errors.hs
@@ -169,6 +169,7 @@ data CabalException
   | UnknownVersionDb String VersionRange FilePath
   | MissingCoveredInstalledLibrary UnitId
   | SetupHooksException SetupHooksException
+  | MultiReplDoesNotSupportComplexReexportedModules PackageName ComponentName
   deriving (Show)
 
 exceptionCode :: CabalException -> Int
@@ -302,6 +303,7 @@ exceptionCode e = case e of
   MissingCoveredInstalledLibrary{} -> 9341
   SetupHooksException err ->
     setupHooksExceptionCode err
+  MultiReplDoesNotSupportComplexReexportedModules{} -> 9355
 
 versionRequirement :: VersionRange -> String
 versionRequirement range
@@ -795,3 +797,10 @@ exceptionMessage e = case e of
       ++ "' in package database stack."
   SetupHooksException err ->
     setupHooksExceptionMessage err
+  MultiReplDoesNotSupportComplexReexportedModules pname cname ->
+    "When attempting start the repl for "
+      ++ showComponentName cname
+      ++ " from package "
+      ++ prettyShow pname
+      ++ " a module renaming was found.\n"
+      ++ "Multi-repl does not work with complicated reexported-modules until GHC-9.12."

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/cabal.project
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/cabal.project
@@ -1,0 +1,2 @@
+packages: package-a package-b
+multi-repl: true

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/cabal.test.hs
@@ -1,0 +1,15 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ recordMode DoNotRecord $ do
+    -- For the multi-repl command
+    good_ver <- isGhcVersion ">= 9.12"
+    skipUnlessGhcVersion ">= 9.4"
+    skipUnlessAnyCabalVersion ">= 3.15"
+    if good_ver
+      then do
+        res <- cabalWithStdin "v2-repl" ["all"] ""
+        assertOutputContains "Ok, two" res
+      else do
+        res <- fails $ cabalWithStdin "v2-repl" ["all"] ""
+        assertOutputContains "Multi-repl does not work with complicated" res
+

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-a/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-a/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for package-a
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-a/package-a.cabal
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-a/package-a.cabal
@@ -1,0 +1,19 @@
+cabal-version:   3.14
+name:            package-a
+version:         0.1.0.0
+license:         NONE
+author:          Matthew Pickering
+maintainer:      matthewtpickering@gmail.com
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  PackageA
+    reexported-modules: Prelude as PreludeA
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-a/src/PackageA.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-a/src/PackageA.hs
@@ -1,0 +1,2 @@
+module PackageA () where
+

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-b/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for package-b
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-b/package-b.cabal
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-b/package-b.cabal
@@ -1,0 +1,18 @@
+cabal-version:   3.14
+name:            package-b
+version:         0.1.0.0
+license:         NONE
+author:          Matthew Pickering
+maintainer:      matthewtpickering@gmail.com
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  PackageB
+    build-depends:    package-a
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-b/src/PackageB.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/ReexportedModule/package-b/src/PackageB.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module PackageB (someFunc) where
+
+-- reexport from package-a
+import PreludeA
+-- Normal import from package-a
+import PackageA ()
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/changelog.d/pr-10880.md
+++ b/changelog.d/pr-10880.md
@@ -1,0 +1,12 @@
+---
+synopsis: 'Fix multi-repl when using reexported-modules with renaming for GHC >= 9.12'
+packages: [cabal-install, Cabal]
+prs: 10880
+issues: 10181
+---
+
+Since GHC 9.12, the `-reexported-module` flag has supported module renaming. Therefore
+we now use that functionality when starting the multi-repl if it is needed. A new
+error message is added to catch the case where you attempt to load a project which
+uses this complicated export form but are using < 9.12.
+


### PR DESCRIPTION
In ghc-9.12 the -rexported-module flag was extended to add support for module renaming.

Therefore now if a module uses a module renaming, then the -reexported-module flag is passed the renaming.

Fixes #10181

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
