### PR TITLE
Cabal API change in 3.14 requires a lower bound bump in cabal-install

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          Cabal
-version:       3.14.1.1
+version:       3.14.2
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -55,7 +55,7 @@ common base-dep
     build-depends: base >=4.13 && <4.22
 
 common cabal-dep
-    build-depends: Cabal ^>=3.14
+    build-depends: Cabal >=3.14.2 && <3.15
 
 common cabal-syntax-dep
     build-depends: Cabal-syntax ^>=3.14


### PR DESCRIPTION
cabal-install on 3.14 depends on an unreleased Cabal fuction, so, needs a lower bound bump. The function in question is `addInternalBuildToolsFixed` (introduced in https://github.com/haskell/cabal/pull/10838).

This was found by the CI sdist-check job in https://github.com/haskell/cabal/pull/10865

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
