### PR TITLE
Fix docs: extensions field was deprecated in Cabal 1.10, not 1.12

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1634,7 +1634,7 @@ system-dependent values for these fields.
     Specifies a language standard used by some (but not necessarily all) modules.
 
 .. pkg-field:: extensions: identifier list
-   :deprecated: 1.12
+   :deprecated: 1.10
    :removed: 3.0
 
    Deprecated in favor of :pkg-field:`default-extensions`.


### PR DESCRIPTION
See change log entry for Cabal 1.10.0.0:
* https://downloads.haskell.org/~cabal/Cabal-1.10.2.0/changelog

**This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
  Not applicable.
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
  Not applicable.
