### PR TITLE
Bump `cabal-version`

### DIFF
--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.4
 name:          Cabal-hooks
 version:       3.16
 copyright:     2023, Cabal Development Team

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.4
 name:          Cabal-syntax
 version:       3.15.0.0
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.4
 name:          Cabal
 version:       3.15.0.0
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.4
 name:          cabal-install-solver
 version:       3.15.0.0
 synopsis:      The solver component of cabal-install

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:      3.0
+Cabal-Version:      3.4
 
 Name:               cabal-install
 Version:            3.15.0.0


### PR DESCRIPTION
3.0 uses SPDX License List version 3.6 2019-07-10
3.4 uses SPDX License List version 3.9 2020-05-15

`cabal-version` 3.0 is out of our support window.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~
