### PR TITLE
bump version fields of our packages to 3.14.2

### DIFF
--- a/Cabal-QuickCheck/Cabal-QuickCheck.cabal
+++ b/Cabal-QuickCheck/Cabal-QuickCheck.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-QuickCheck
-version:       3.14.0.0
+version:       3.14.2
 synopsis:      QuickCheck instances for types in Cabal
 category:      Testing
 build-type:    Simple

--- a/Cabal-described/Cabal-described.cabal
+++ b/Cabal-described/Cabal-described.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-described
-version:       3.14.0.0
+version:       3.14.2
 synopsis:      Described functionality for types in Cabal
 category:      Testing, Parsec
 description:   Provides rere bindings

--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-hooks
-version:       3.14
+version:       3.14.2
 copyright:     2023, Cabal Development Team
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-syntax
-version:       3.14.1.1
+version:       3.14.2
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/Cabal-tree-diff/Cabal-tree-diff.cabal
+++ b/Cabal-tree-diff/Cabal-tree-diff.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-tree-diff
-version:       3.14.0.0
+version:       3.14.2
 synopsis:      QuickCheck instances for types in Cabal
 category:      Testing
 description:   Provides tree-diff ToExpr instances for some types in Cabal

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          cabal-install-solver
-version:       3.14.1.1
+version:       3.14.2
 synopsis:      The solver component of cabal-install
 description:
   The solver component used in the cabal-install command-line program.

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -1,7 +1,7 @@
 Cabal-Version:      3.0
 
 Name:               cabal-install
-Version:            3.14.1.1
+Version:            3.14.2
 Synopsis:           The command-line interface for Cabal and Hackage.
 Description:
     The \'cabal\' command-line program simplifies the process of managing


### PR DESCRIPTION
This is to fullfill https://github.com/haskell/cabal/wiki/Making-a-release#c3-bumping-version-numbers as a part of the 3.14.2 release process, /cc @Mikolaj 


---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
