### PR TITLE
Cabal 3.14.2 depends on Cabal-syntax at least 3.14.2

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -34,7 +34,7 @@ library
   hs-source-dirs: src
 
   build-depends:
-    Cabal-syntax ^>= 3.14,
+    Cabal-syntax >= 3.14.2 && < 3.15,
     array      >= 0.4.0.1  && < 0.6,
     base       >= 4.13     && < 5,
     bytestring >= 0.10.0.0 && < 0.13,


### PR DESCRIPTION
fix #10916 

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
