### PR TITLE
Fix call convention warnings for AArch64

### DIFF
--- a/Cabal/src/Distribution/Compat/GetShortPathName.hs
+++ b/Cabal/src/Distribution/Compat/GetShortPathName.hs
@@ -23,7 +23,7 @@ import System.Win32          (LPCTSTR, LPTSTR, DWORD)
 import Foreign.Marshal.Array (allocaArray)
 
 {- FOURMOLU_DISABLE -}
-#ifdef x86_64_HOST_ARCH
+#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
 #define WINAPI ccall
 #else
 #define WINAPI stdcall

--- a/Cabal/src/Distribution/Compat/Time.hs
+++ b/Cabal/src/Distribution/Compat/Time.hs
@@ -94,7 +94,7 @@ getModTime path = allocaBytes size_WIN32_FILE_ATTRIBUTE_DATA $ \info -> do
       return $! ModTime (qwTime :: Word64)
 
 {- FOURMOLU_DISABLE -}
-#ifdef x86_64_HOST_ARCH
+#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
 #define CALLCONV ccall
 #else
 #define CALLCONV stdcall

--- a/Cabal/src/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/src/Distribution/Simple/InstallDirs.hs
@@ -537,7 +537,7 @@ csidl_PROGRAM_FILES = 0x0026
 -- csidl_PROGRAM_FILES_COMMON = 0x002b
 
 {- FOURMOLU_DISABLE -}
-#ifdef x86_64_HOST_ARCH
+#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
 #define CALLCONV ccall
 #else
 #define CALLCONV stdcall

--- a/cabal-install/src/Distribution/Client/Win32SelfUpgrade.hs
+++ b/cabal-install/src/Distribution/Client/Win32SelfUpgrade.hs
@@ -166,7 +166,7 @@ deleteOldExeFile verbosity oldPID tmpPath = do
 -- A bunch of functions sadly not provided by the Win32 package.
 
 {- FOURMOLU_DISABLE -}
-#ifdef x86_64_HOST_ARCH
+#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
 #define CALLCONV ccall
 #else
 #define CALLCONV stdcall


### PR DESCRIPTION
These warnings stop CI process at https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13856 due of `-Werror`:

```
libraries/Cabal/Cabal/src/Distribution/Compat/Time.hs:103:1: warning: [GHC-01245] [-Wunsupported-calling-conventions]
    • the 'stdcall' calling convention is unsupported on this platform,
      treating as ccall
    • When checking declaration:
        foreign import stdcall safe "windows.h GetFileAttributesExW" c_getFileAttributesEx
          :: LPCTSTR -> Int32 -> LPVOID -> Prelude.IO BOOL
    |
103 | foreign import CALLCONV "windows.h GetFileAttributesExW"
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

----

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
