### PR TITLE
GitLab CI image bump

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,6 @@ linux:
       - ARCH: x86_64
         TAG: x86_64-linux
         OS:
-          - deb9
           - deb10
           - deb11
           - deb12
@@ -49,13 +48,6 @@ linux:
           - ubuntu18_04
           - ubuntu20_04
           - ubuntu22_04
-      # Pull this one from the future, since it's missing.
-      # We can't move the entire file to this DOCKER_REV, because
-      # i386-linux-deb9 is missing from it.
-      - ARCH: x86_64
-        TAG: x86_64-linux
-        OS: centos7
-        DOCKER_REV: f2d12519f45a13a61fcca03a949f927ceead6492
 
       - ARCH: aarch64
         TAG: aarch64-linux

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 variables:
   # Commit of ghc/ci-images repository from which to pull Docker images
-  DOCKER_REV: "a9297a370025101b479cfd4977f8f910814e03ab"
+  DOCKER_REV: "e973f7fa82a181afcb90e3fcf071e1bc1a8b41da"
 
   GHC_VERSION: 9.6.4
   CABAL_INSTALL_VERSION: 3.10.2.0


### PR DESCRIPTION
 [![pipeline status](https://gitlab.haskell.org/haskell/cabal/badges/b/2025.04-ci-image-bump/pipeline.svg)](https://gitlab.haskell.org/haskell/cabal/-/pipelines?page=1&scope=all&ref=b%2F2025.04-ci-image-bump) 

**NB: This drops x86_64-linux-deb9**

The previously pinned batch of images may have taken a mortal blow from the GitLab migration. Let's see if we can just walk quickly past the scene of the crime.

Draft until the pipeline passes.