### PR TITLE
Mark dedup complex test as flaky

### DIFF
--- a/cabal-testsuite/PackageTests/ProjectImport/DedupUsingConfigFromComplex/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/DedupUsingConfigFromComplex/cabal.test.hs
@@ -1,7 +1,7 @@
 import Test.Cabal.Prelude
 import Data.Function ((&))
 
-main = cabalTest . recordMode RecordMarked $ do
+main = cabalTest . flakyIfCI 10927. recordMode RecordMarked $ do
   let log = recordHeader . pure
 
   log "check \"using config from message\" with URI imports"


### PR DESCRIPTION
Fixes #10927, mark a test that sometimes fails with HTTP code 525, SSL handshake failure, as flaky.


* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
