### PR TITLE
Print out the "Created semaphore" message only in verbose mode

### DIFF
--- a/cabal-install/src/Distribution/Client/JobControl.hs
+++ b/cabal-install/src/Distribution/Client/JobControl.hs
@@ -184,7 +184,7 @@ newSemaphoreJobControl _ n
       error $ "newParallelJobControl: not a sensible number of jobs: " ++ show n
 newSemaphoreJobControl verbosity maxJobLimit = do
   sem <- freshSemaphore "cabal_semaphore" maxJobLimit
-  notice verbosity $
+  info verbosity $
     "Created semaphore called "
       ++ getSemaphoreName (semaphoreName sem)
       ++ " with "

--- a/changelog.d/pr-10936.md
+++ b/changelog.d/pr-10936.md
@@ -1,8 +1,6 @@
 ---
 synopsis: Print out the "Created semaphore" message only in verbose mode (#10885)
-packages: cabal-install
+packages: [cabal-install]
 prs: 10936
 issues: 10885
 ---
-
-

--- a/changelog.d/pr-10936.md
+++ b/changelog.d/pr-10936.md
@@ -1,0 +1,8 @@
+---
+synopsis: Print out the "Created semaphore" message only in verbose mode (#10885)
+packages: cabal-install
+prs: 10936
+issues: 10885
+---
+
+


### PR DESCRIPTION
This addresses the smaller part of #10885, which seemed to get universal support.

I'll add a changelog when I see how CI is doing.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
