### PR TITLE
always run changelog.d

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - master
-    paths:
-    - 'changelog.d/*'
-    - '.github/workflows/changelogs.yml'
   pull_request:
-    paths:
-    - 'changelog.d/*'
-    - '.github/workflows/changelogs.yml'
   release:
     types:
       - created


### PR DESCRIPTION
We've made this a required job to ensure that changelogs are always valid. But this means we can't use "paths", or PRs that don't have changelogs will stall because the changelogs job doesn't get run so it's never considered "succeeded".

This job is cheap, so run it unconditionally. We already know things are currently valid, so this shouldn't produce any surprises.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ new rule is only on `master`
