### PR TITLE
Make `Flag a` a type synonym for `Last (Maybe a)`

### DIFF
--- a/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
+++ b/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
@@ -19,7 +19,6 @@ import Distribution.Compiler
 import Distribution.FieldGrammar.Newtypes
 import Distribution.ModuleName
 import Distribution.Simple.Compiler
-import Distribution.Simple.Flag                    (Flag (..))
 import Distribution.Simple.InstallDirs
 import Distribution.Simple.Setup                   (HaddockTarget (..), TestShowDetails (..), DumpBuildInfo)
 import Distribution.SPDX
@@ -241,23 +240,6 @@ instance Arbitrary LibraryName where
 
     shrink (LSubLibName _) = [LMainLibName]
     shrink _               = []
-
--------------------------------------------------------------------------------
--- option flags
--------------------------------------------------------------------------------
-
-instance Arbitrary a => Arbitrary (Flag a) where
-    arbitrary = arbitrary1
-
-    shrink NoFlag   = []
-    shrink (Flag x) = NoFlag : [ Flag x' | x' <- shrink x ]
-
-instance Arbitrary1 Flag where
-    liftArbitrary genA = sized $ \sz ->
-        if sz <= 0
-        then pure NoFlag
-        else frequency [ (1, pure NoFlag)
-                       , (3, Flag <$> genA) ]
 
 -------------------------------------------------------------------------------
 -- GPD flags

--- a/Cabal-syntax/src/Distribution/Utils/Structured.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Structured.hs
@@ -110,7 +110,7 @@ import Data.Typeable (TypeRep, Typeable, typeRep)
 
 import Distribution.Utils.MD5
 
-import Data.Monoid (mconcat)
+import Data.Monoid (Last, mconcat)
 
 import qualified Data.Foldable
 import qualified Data.Semigroup
@@ -413,6 +413,7 @@ instance Structured Float where structure = nominalStructure
 instance Structured Double where structure = nominalStructure
 
 instance Structured a => Structured (Maybe a)
+instance Structured a => Structured (Last a)
 instance (Structured a, Structured b) => Structured (Either a b)
 instance Structured a => Structured (Ratio a) where structure = containerStructure
 instance Structured a => Structured [a] where structure = containerStructure

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,4 +33,4 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x906e7b142a02710d412d471a5656769b
+    0x364f8e404df9ada84ea3b4e3b3084a10

--- a/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
+++ b/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
@@ -17,7 +17,6 @@ import Distribution.InstalledPackageInfo           (AbiDependency, ExposedModule
 import Distribution.ModuleName                     (ModuleName)
 import Distribution.PackageDescription
 import Distribution.Simple.Compiler                (DebugInfoLevel, OptimisationLevel, ProfDetailLevel)
-import Distribution.Simple.Flag                    (Flag)
 import Distribution.Simple.InstallDirs
 import Distribution.Simple.InstallDirs.Internal
 import Distribution.Simple.Setup                   (HaddockTarget, TestShowDetails)
@@ -43,7 +42,6 @@ instance (Eq a, Show a) => ToExpr (Condition a) where toExpr = defaultExprViaSho
 instance (Show a, ToExpr b, ToExpr c, Show b, Show c, Eq a, Eq c, Eq b) => ToExpr (CondTree a b c)
 instance (Show a, ToExpr b, ToExpr c, Show b, Show c, Eq a, Eq c, Eq b) => ToExpr (CondBranch a b c)
 instance (ToExpr a) => ToExpr (NubList a)
-instance (ToExpr a) => ToExpr (Flag a)
 instance ToExpr a => ToExpr (NES.NonEmptySet a) where
     toExpr xs = App "NonEmptySet.fromNonEmpty" [toExpr $ NES.toNonEmpty xs]
 

--- a/Cabal/src/Distribution/Backpack/Id.hs
+++ b/Cabal/src/Distribution/Backpack/Id.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 
 -- | See <https://github.com/ezyang/ghc-proposals/blob/backpack/proposals/0000-backpack.rst>
@@ -13,7 +14,7 @@ import Prelude ()
 
 import Distribution.PackageDescription
 import Distribution.Simple.Compiler
-import Distribution.Simple.Flag (Flag (..))
+import Distribution.Simple.Flag (Flag, pattern Flag, pattern NoFlag)
 import qualified Distribution.Simple.InstallDirs as InstallDirs
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Types.ComponentId

--- a/Cabal/src/Distribution/Simple/Flag.hs
+++ b/Cabal/src/Distribution/Simple/Flag.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -----------------------------------------------------------------------------
 
@@ -19,7 +18,9 @@
 --
 -- Split off from "Distribution.Simple.Setup" to break import cycles.
 module Distribution.Simple.Flag
-  ( Flag (..)
+  ( Flag
+  , pattern Flag
+  , pattern NoFlag
   , allFlags
   , toFlag
   , fromFlag
@@ -32,6 +33,7 @@ module Distribution.Simple.Flag
   , BooleanFlag (..)
   ) where
 
+import Data.Monoid (Last (..))
 import Distribution.Compat.Prelude hiding (get)
 import Distribution.Compat.Stack
 import Prelude ()
@@ -61,43 +63,15 @@ import Prelude ()
 -- 'NoFlag' and later flags override earlier ones.
 --
 -- Isomorphic to 'Maybe' a.
-data Flag a = Flag a | NoFlag deriving (Eq, Generic, Show, Read, Foldable, Traversable)
+type Flag = Last
 
-instance Binary a => Binary (Flag a)
-instance Structured a => Structured (Flag a)
+pattern Flag :: a -> Last a
+pattern Flag a = Last (Just a)
 
-instance Functor Flag where
-  fmap f (Flag x) = Flag (f x)
-  fmap _ NoFlag = NoFlag
+pattern NoFlag :: Last a
+pattern NoFlag = Last Nothing
 
-instance Applicative Flag where
-  (Flag x) <*> y = x <$> y
-  NoFlag <*> _ = NoFlag
-  pure = Flag
-
-instance Monoid (Flag a) where
-  mempty = NoFlag
-  mappend = (<>)
-
-instance Semigroup (Flag a) where
-  _ <> f@(Flag _) = f
-  f <> NoFlag = f
-
-instance Bounded a => Bounded (Flag a) where
-  minBound = toFlag minBound
-  maxBound = toFlag maxBound
-
-instance Enum a => Enum (Flag a) where
-  fromEnum = fromEnum . fromFlag
-  toEnum = toFlag . toEnum
-  enumFrom (Flag a) = map toFlag . enumFrom $ a
-  enumFrom _ = []
-  enumFromThen (Flag a) (Flag b) = toFlag `map` enumFromThen a b
-  enumFromThen _ _ = []
-  enumFromTo (Flag a) (Flag b) = toFlag `map` enumFromTo a b
-  enumFromTo _ _ = []
-  enumFromThenTo (Flag a) (Flag b) (Flag c) = toFlag `map` enumFromThenTo a b c
-  enumFromThenTo _ _ _ = []
+{-# COMPLETE Flag, NoFlag #-}
 
 -- | Wraps a value in 'Flag'.
 toFlag :: a -> Flag a
@@ -110,26 +84,22 @@ fromFlag NoFlag = error "fromFlag NoFlag. Use fromFlagOrDefault"
 
 -- | Extracts a value from a 'Flag', and returns the default value on 'NoFlag'.
 fromFlagOrDefault :: a -> Flag a -> a
-fromFlagOrDefault _ (Flag x) = x
-fromFlagOrDefault def NoFlag = def
+fromFlagOrDefault def = fromMaybe def . getLast
 
 -- | Converts a 'Flag' value to a 'Maybe' value.
 flagToMaybe :: Flag a -> Maybe a
-flagToMaybe (Flag x) = Just x
-flagToMaybe NoFlag = Nothing
+flagToMaybe = getLast
 
 -- | Pushes a function through a 'Flag' value, and returns a default
 -- if the 'Flag' value is 'NoFlag'.
 --
 -- @since 3.4.0.0
 flagElim :: b -> (a -> b) -> Flag a -> b
-flagElim n _ NoFlag = n
-flagElim _ f (Flag x) = f x
+flagElim n f = maybe n f . getLast
 
 -- | Converts a 'Flag' value to a list.
 flagToList :: Flag a -> [a]
-flagToList (Flag x) = [x]
-flagToList NoFlag = []
+flagToList = maybeToList . getLast
 
 -- | Returns 'True' only if every 'Flag' 'Bool' value is Flag True, else 'False'.
 allFlags :: [Flag Bool] -> Flag Bool
@@ -140,8 +110,7 @@ allFlags flags =
 
 -- | Converts a 'Maybe' value to a 'Flag' value.
 maybeToFlag :: Maybe a -> Flag a
-maybeToFlag Nothing = NoFlag
-maybeToFlag (Just x) = Flag x
+maybeToFlag = Last
 
 -- | Merge the elements of a list 'Flag' with another list 'Flag'.
 mergeListFlag :: Flag [a] -> Flag [a] -> Flag [a]

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 
 -----------------------------------------------------------------------------
@@ -67,7 +68,7 @@ import Distribution.Pretty (prettyShow)
 import Distribution.Simple.BuildPaths
 import Distribution.Simple.Compiler
 import Distribution.Simple.Errors
-import Distribution.Simple.Flag (Flag (NoFlag), maybeToFlag, toFlag)
+import Distribution.Simple.Flag (Flag, maybeToFlag, toFlag, pattern NoFlag)
 import Distribution.Simple.GHC.ImplInfo
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Program

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 
 -- |
@@ -118,7 +119,9 @@ module Distribution.Simple.Setup
   , splitArgs
   , defaultDistPref
   , optionDistPref
-  , Flag (..)
+  , Flag
+  , pattern Flag
+  , pattern NoFlag
   , toFlag
   , fromFlag
   , fromFlagOrDefault

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 
 -- |
@@ -32,7 +33,9 @@ module Distribution.Simple.Setup.Common
   , defaultDistPref
   , extraCompilationArtifacts
   , optionDistPref
-  , Flag (..)
+  , Flag
+  , pattern Flag
+  , pattern NoFlag
   , toFlag
   , fromFlag
   , fromFlagOrDefault

--- a/cabal-install/src/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/src/Distribution/Client/CmdBuild.hs
@@ -50,7 +50,7 @@ import Distribution.Simple.Command
   , option
   , usageAlternatives
   )
-import Distribution.Simple.Flag (Flag (..), fromFlag, fromFlagOrDefault, toFlag)
+import Distribution.Simple.Flag (Flag, fromFlag, fromFlagOrDefault, toFlag)
 import Distribution.Simple.Utils
   ( dieWithException
   , wrapText

--- a/cabal-install/src/Distribution/Client/CmdClean.hs
+++ b/cabal-install/src/Distribution/Client/CmdClean.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Distribution.Client.CmdClean (cleanCommand, cleanAction) where
@@ -38,13 +39,14 @@ import Distribution.Simple.Command
   , option
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( Flag
   , falseArg
   , flagToMaybe
   , fromFlagOrDefault
   , optionDistPref
   , optionVerbosity
   , toFlag
+  , pattern NoFlag
   )
 import Distribution.Simple.Utils
   ( dieWithException

--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | cabal-install CLI command: freeze
@@ -53,7 +54,7 @@ import Distribution.PackageDescription
   ( FlagAssignment
   , nullFlagAssignment
   )
-import Distribution.Simple.Flag (Flag (..), fromFlagOrDefault)
+import Distribution.Simple.Flag (fromFlagOrDefault, pattern Flag)
 import Distribution.Simple.Utils
   ( dieWithException
   , notice

--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | cabal-install CLI command: haddock
@@ -47,7 +48,7 @@ import Distribution.Simple.Command
   , option
   , usageAlternatives
   )
-import Distribution.Simple.Flag (Flag (..))
+import Distribution.Simple.Flag (Flag, pattern Flag)
 import Distribution.Simple.Program.Builtin
   ( haddockProgram
   )

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Distribution.Client.CmdHaddockProject
   ( haddockProjectCommand
   , haddockProjectAction
@@ -64,9 +66,10 @@ import Distribution.Simple.Command
   ( CommandUI (..)
   )
 import Distribution.Simple.Flag
-  ( Flag (..)
-  , fromFlag
+  ( fromFlag
   , fromFlagOrDefault
+  , pattern Flag
+  , pattern NoFlag
   )
 import Distribution.Simple.Haddock (createHaddockIndex)
 import Distribution.Simple.InstallDirs

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -162,8 +163,10 @@ import Distribution.Simple.Program.Db
   , userSpecifyPaths
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( Flag
   , installDirsOptions
+  , pattern Flag
+  , pattern NoFlag
   )
 import Distribution.Simple.Utils
   ( createDirectoryIfMissingVerbose

--- a/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Distribution.Client.CmdInstall.ClientInstallFlags
   ( InstallMethod (..)
@@ -21,10 +22,11 @@ import Distribution.Simple.Command
   , reqArg
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( Flag
   , flagToList
   , toFlag
   , trueArg
+  , pattern Flag
   )
 
 import Distribution.Client.Types.InstallMethod

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -97,7 +97,7 @@ import Distribution.Simple.Compiler
   , compilerInfo
   )
 import Distribution.Simple.Flag
-  ( Flag (..)
+  ( Flag
   , flagToMaybe
   , fromFlagOrDefault
   , toFlag

--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- |
@@ -66,9 +67,11 @@ import Distribution.Simple.Command
   )
 import Distribution.Simple.Compiler
 import Distribution.Simple.Flag
-  ( Flag (..)
+  ( Flag
   , flagToList
   , fromFlagOrDefault
+  , pattern Flag
+  , pattern NoFlag
   )
 import Distribution.Simple.Program
 import Distribution.Simple.Utils

--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -177,7 +178,7 @@ import Distribution.Client.ReplFlags
   , topReplOptions
   )
 import Distribution.Compat.Binary (decode)
-import Distribution.Simple.Flag (Flag (Flag), fromFlagOrDefault)
+import Distribution.Simple.Flag (fromFlagOrDefault, pattern Flag)
 import Distribution.Simple.Program.Builtin (ghcProgram)
 import Distribution.Simple.Program.Db (requireProgram)
 import Distribution.Simple.Program.Run

--- a/cabal-install/src/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/src/Distribution/Client/CmdSdist.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Distribution.Client.CmdSdist
@@ -97,7 +98,7 @@ import Distribution.Simple.PreProcess
   ( knownSuffixHandlers
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( Flag
   , flagToList
   , flagToMaybe
   , fromFlagOrDefault
@@ -105,6 +106,7 @@ import Distribution.Simple.Setup
   , optionVerbosity
   , toFlag
   , trueArg
+  , pattern Flag
   )
 import Distribution.Simple.SrcDist
   ( listPackageSourcesWithDie

--- a/cabal-install/src/Distribution/Client/CmdTest.hs
+++ b/cabal-install/src/Distribution/Client/CmdTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | cabal-install CLI command: test
@@ -48,7 +49,8 @@ import Distribution.Simple.Command
   , usageAlternatives
   )
 import Distribution.Simple.Flag
-  ( Flag (..)
+  ( Flag
+  , pattern Flag
   )
 import Distribution.Simple.Setup
   ( TestFlags (..)

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -----------------------------------------------------------------------------
 
@@ -181,7 +182,7 @@ import Distribution.Simple.Setup
   ( BenchmarkFlags (..)
   , CommonSetupFlags (..)
   , ConfigFlags (..)
-  , Flag (..)
+  , Flag
   , HaddockFlags (..)
   , TestFlags (..)
   , configureOptions
@@ -197,6 +198,8 @@ import Distribution.Simple.Setup
   , programDbOptions
   , programDbPaths'
   , toFlag
+  , pattern Flag
+  , pattern NoFlag
   )
 import Distribution.Simple.Utils
   ( cabalVersion

--- a/cabal-install/src/Distribution/Client/Get.hs
+++ b/cabal-install/src/Distribution/Client/Get.hs
@@ -1,6 +1,4 @@
------------------------------------------------------------------------------
-
------------------------------------------------------------------------------
+{-# LANGUAGE PatternSynonyms #-}
 
 -- |
 -- Module      :  Distribution.Client.Get
@@ -39,10 +37,10 @@ import Distribution.Simple.Program
   ( programName
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
-  , flagToMaybe
+  ( flagToMaybe
   , fromFlag
   , fromFlagOrDefault
+  , pattern NoFlag
   )
 import Distribution.Simple.Utils
   ( dieWithException

--- a/cabal-install/src/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/src/Distribution/Client/GlobalFlags.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -28,9 +29,10 @@ import Distribution.Client.Types
   , unRepoName
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( Flag
   , flagToMaybe
   , fromFlag
+  , pattern Flag
   )
 import Distribution.Simple.Utils
   ( info

--- a/cabal-install/src/Distribution/Client/Init/FlagExtractors.hs
+++ b/cabal-install/src/Distribution/Client/Init/FlagExtractors.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Distribution.Client.Init.FlagExtractors
   ( -- * Flag extractors
@@ -51,7 +52,7 @@ import Distribution.Client.Init.Types
 import Distribution.FieldGrammar.Newtypes (SpecLicense)
 import Distribution.ModuleName (ModuleName)
 import Distribution.Simple.Flag (flagElim)
-import Distribution.Simple.Setup (Flag (..), flagToMaybe, fromFlagOrDefault)
+import Distribution.Simple.Setup (Flag, flagToMaybe, fromFlagOrDefault, pattern Flag, pattern NoFlag)
 import Distribution.Types.Dependency (Dependency (..))
 import Distribution.Types.PackageName (PackageName)
 import Distribution.Version (Version)

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -----------------------------------------------------------------------------
 
@@ -58,7 +59,7 @@ import Distribution.Client.Types (SourcePackageDb (..))
 import Distribution.FieldGrammar.Newtypes (SpecLicense (..))
 import qualified Distribution.SPDX as SPDX
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
-import Distribution.Simple.Setup (Flag (..), fromFlagOrDefault)
+import Distribution.Simple.Setup (fromFlagOrDefault, pattern Flag, pattern NoFlag)
 import Distribution.Solver.Types.PackageIndex (elemByPackageName)
 import Distribution.Types.PackageName (PackageName, unPackageName)
 import Distribution.Version (Version)

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Distribution.Client.Init.NonInteractive.Command
   ( genPkgDescription
   , genLibTarget
@@ -49,7 +51,7 @@ import Distribution.Client.Init.Utils
 import Distribution.Client.Types (SourcePackageDb (..))
 import Distribution.ModuleName (ModuleName, components)
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
-import Distribution.Simple.Setup (Flag (..), fromFlagOrDefault)
+import Distribution.Simple.Setup (fromFlagOrDefault, pattern Flag, pattern NoFlag)
 import Distribution.Solver.Types.PackageIndex (elemByPackageName)
 import Distribution.Types.Dependency (Dependency (..))
 import Distribution.Types.PackageName (PackageName, unPackageName)

--- a/cabal-install/src/Distribution/Client/Init/Simple.hs
+++ b/cabal-install/src/Distribution/Client/Init/Simple.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Distribution.Client.Init.Simple
   ( -- * Project creation
     createProject
@@ -16,7 +18,7 @@ import Distribution.Client.Init.FlagExtractors
 import Distribution.Client.Init.Types
 import Distribution.Client.Init.Utils (currentDirPkgName, fixupDocFiles, mkPackageNameDep)
 import Distribution.Client.Types.SourcePackageDb (SourcePackageDb (..))
-import Distribution.Simple.Flag (Flag (..), flagElim, fromFlagOrDefault)
+import Distribution.Simple.Flag (flagElim, fromFlagOrDefault, pattern Flag, pattern NoFlag)
 import Distribution.Simple.PackageIndex
 import Distribution.Types.Dependency
 import Distribution.Types.PackageName (unPackageName)

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -80,7 +80,7 @@ import Distribution.Client.Utils as P
 import Distribution.Fields.Pretty
 import Distribution.ModuleName
 import qualified Distribution.Package as P
-import Distribution.Simple.Setup (Flag (..))
+import Distribution.Simple.Setup (Flag)
 import Distribution.Verbosity (silent)
 import Distribution.Version
 import Language.Haskell.Extension (Extension, Language (..))

--- a/cabal-install/src/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Init/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Distribution.Client.Init.Utils
@@ -42,7 +43,7 @@ import Distribution.InstalledPackageInfo (InstalledPackageInfo, exposed)
 import Distribution.ModuleName (ModuleName)
 import qualified Distribution.Package as P
 import Distribution.Simple.PackageIndex (InstalledPackageIndex, moduleNameIndex)
-import Distribution.Simple.Setup (Flag (..))
+import Distribution.Simple.Setup (pattern Flag, pattern NoFlag)
 import Distribution.Types.Dependency (Dependency, mkDependency)
 import Distribution.Types.LibraryName
 import Distribution.Types.PackageName

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
@@ -74,7 +75,7 @@ import Distribution.Simple.Setup
   ( BenchmarkFlags (..)
   , CleanFlags (..)
   , CopyFlags (..)
-  , Flag (..)
+  , Flag
   , HaddockFlags (..)
   , HaddockTarget (..)
   , HscolourFlags (..)
@@ -87,6 +88,8 @@ import Distribution.Simple.Setup
   , fromFlagOrDefault
   , hscolourCommand
   , toFlag
+  , pattern Flag
+  , pattern NoFlag
   )
 
 import Distribution.Client.Compat.Prelude hiding (get)

--- a/cabal-install/src/Distribution/Client/ManpageFlags.hs
+++ b/cabal-install/src/Distribution/Client/ManpageFlags.hs
@@ -9,7 +9,7 @@ module Distribution.Client.ManpageFlags
 import Distribution.Client.Compat.Prelude
 
 import Distribution.Simple.Command (OptionField (..), ShowOrParseArgs (..), option)
-import Distribution.Simple.Setup (Flag (..), optionVerbosity, toFlag, trueArg)
+import Distribution.Simple.Setup (Flag, optionVerbosity, toFlag, trueArg)
 import Distribution.Verbosity (normal)
 
 data ManpageFlags = ManpageFlags

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -177,12 +178,13 @@ import Distribution.Simple.Program
   ( ConfiguredProgram (..)
   )
 import Distribution.Simple.Setup
-  ( Flag (Flag)
+  ( Flag
   , flagToList
   , flagToMaybe
   , fromFlag
   , fromFlagOrDefault
   , toFlag
+  , pattern Flag
   )
 import Distribution.System
   ( Platform

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -109,7 +110,7 @@ import Distribution.Simple.Setup
   , CommonSetupFlags (..)
   , ConfigFlags (..)
   , DumpBuildInfo (DumpBuildInfo, NoDumpBuildInfo)
-  , Flag (..)
+  , Flag
   , HaddockFlags (..)
   , TestFlags (..)
   , benchmarkOptions'
@@ -126,6 +127,8 @@ import Distribution.Simple.Setup
   , splitArgs
   , testOptions'
   , toFlag
+  , pattern Flag
+  , pattern NoFlag
   )
 import Distribution.Simple.Utils
   ( debug

--- a/cabal-install/src/Distribution/Client/ProjectFlags.hs
+++ b/cabal-install/src/Distribution/Client/ProjectFlags.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Distribution.Client.ProjectFlags
   ( ProjectFlags (..)
@@ -20,7 +21,15 @@ import Distribution.Simple.Command
   , option
   , reqArg
   )
-import Distribution.Simple.Setup (Flag (..), flagToList, flagToMaybe, toFlag, trueArg)
+import Distribution.Simple.Setup
+  ( Flag
+  , flagToList
+  , flagToMaybe
+  , toFlag
+  , trueArg
+  , pattern Flag
+  , pattern NoFlag
+  )
 
 data ProjectFlags = ProjectFlags
   { flagProjectDir :: Flag FilePath

--- a/cabal-install/src/Distribution/Client/ReplFlags.hs
+++ b/cabal-install/src/Distribution/Client/ReplFlags.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Distribution.Client.ReplFlags (EnvFlags (..), ReplFlags (..), topReplOptions, multiReplOption, defaultReplFlags) where
 
 import Distribution.Client.Compat.Prelude
@@ -21,12 +23,13 @@ import Distribution.Simple.Command
   , reqArg
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( Flag
   , ReplOptions (..)
   , boolOpt
   , falseArg
   , replOptions
   , toFlag
+  , pattern NoFlag
   )
 import Distribution.Types.Dependency
   ( Dependency (..)

--- a/cabal-install/src/Distribution/Client/Sandbox.hs
+++ b/cabal-install/src/Distribution/Client/Sandbox.hs
@@ -48,7 +48,7 @@ import Distribution.Simple.Configure
 import qualified Distribution.Simple.LocalBuildInfo as LocalBuildInfo
 import Distribution.Simple.Program (ProgramDb)
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( Flag
   , flagToMaybe
   , fromFlagOrDefault
   )

--- a/cabal-install/src/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/src/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -55,7 +55,7 @@ import Distribution.Deprecated.ParseUtils
 import Distribution.Simple.InstallDirs (InstallDirs (..), PathTemplate)
 import Distribution.Simple.Setup
   ( ConfigFlags (..)
-  , Flag (..)
+  , Flag
   , HaddockFlags (..)
   )
 import Distribution.Simple.Utils (debug, warn)

--- a/cabal-install/src/Distribution/Client/ScriptUtils.hs
+++ b/cabal-install/src/Distribution/Client/ScriptUtils.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Utilities to help commands with scripts
@@ -126,7 +127,7 @@ import Distribution.Simple.PackageDescription
   ( parseString
   )
 import Distribution.Simple.Setup
-  ( Flag (..)
+  ( pattern Flag
   )
 import Distribution.Simple.Utils
   ( createDirectoryIfMissingVerbose

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -169,7 +170,7 @@ import Distribution.Simple.Configure
   , interpretPackageDbFlags
   )
 import Distribution.Simple.Flag
-  ( Flag (..)
+  ( Flag
   , flagElim
   , flagToList
   , flagToMaybe
@@ -177,6 +178,8 @@ import Distribution.Simple.Flag
   , maybeToFlag
   , mergeListFlag
   , toFlag
+  , pattern Flag
+  , pattern NoFlag
   )
 import Distribution.Simple.InstallDirs
   ( InstallDirs (..)

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {- FOURMOLU_DISABLE -}
 
 -----------------------------------------------------------------------------
@@ -144,7 +145,7 @@ import Distribution.Simple.Program.GHC
   )
 import Distribution.Simple.Setup
   ( CommonSetupFlags (..)
-  , Flag (..)
+  , pattern Flag
   , GlobalFlags (..)
   , globalCommand
   )

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Distribution.Client.Utils
@@ -69,7 +70,7 @@ import Data.List
 import Distribution.Client.Errors
 import Distribution.Compat.Environment
 import Distribution.Compat.Time (getModTime)
-import Distribution.Simple.Setup (Flag (..))
+import Distribution.Simple.Setup (Flag, pattern Flag, pattern NoFlag)
 import Distribution.Simple.Utils (dieWithException, findPackageDesc, noticeNoWrap)
 import Distribution.Utils.Path
   ( CWD

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- For the handy instance IsString PackageIdentifier
@@ -99,7 +100,7 @@ import System.IO.Silently
 
 import qualified Data.ByteString as BS
 import Data.Maybe (fromJust)
-import Distribution.Simple.Flag (Flag (Flag, NoFlag))
+import Distribution.Simple.Flag (Flag, pattern Flag, pattern NoFlag)
 import Distribution.Types.ParStrat
 
 main :: IO ()

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -25,6 +25,7 @@ import Prelude ()
 
 import Data.Char (isLetter)
 import Data.List ((\\))
+import Data.Monoid (Last (..))
 
 import Distribution.Simple.Setup
 import Distribution.Types.Flag (mkFlagAssignment)
@@ -199,7 +200,7 @@ instance Arbitrary WriteGhcEnvironmentFilesPolicy where
   arbitrary = arbitraryBoundedEnum
 
 arbitraryFlag :: Gen a -> Gen (Flag a)
-arbitraryFlag = liftArbitrary
+arbitraryFlag = fmap (fmap Last) liftArbitrary
 
 instance Arbitrary RepoName where
   -- TODO: rename refinement?

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module UnitTests.Distribution.Client.UserConfig
   ( tests
   ) where
@@ -18,7 +20,7 @@ import Test.Tasty.HUnit
 import Distribution.Client.Config
 import Distribution.Client.Setup (GlobalFlags (..), InstallFlags (..))
 import Distribution.Client.Utils (removeExistingFile)
-import Distribution.Simple.Setup (ConfigFlags (..), Flag (..), fromFlag)
+import Distribution.Simple.Setup (ConfigFlags (..), fromFlag, pattern Flag)
 import Distribution.Simple.Utils (withTempDirectory)
 import Distribution.Utils.NubList (fromNubList)
 import Distribution.Verbosity (silent)

--- a/cabal-testsuite/src/Test/Cabal/Script.hs
+++ b/cabal-testsuite/src/Test/Cabal/Script.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 
 -- | Functionality for invoking Haskell scripts with the correct
@@ -25,7 +26,7 @@ import Distribution.Simple.Program
 import Distribution.Simple.Compiler
 import Distribution.Verbosity
 import Distribution.System
-import Distribution.Simple.Setup (Flag(..))
+import Distribution.Simple.Setup (pattern Flag)
 
 import qualified Data.Monoid as M
 

--- a/changelog.d/pr-10948.md
+++ b/changelog.d/pr-10948.md
@@ -1,0 +1,18 @@
+synopsis: Make `Flag a` a type synonym for `Last (Maybe a)`
+packages: Cabal cabal-install
+prs: #10948
+
+description: {
+
+- Replace `data Flag a = Flag a | NoFlag` with `type Flag = Data.Monoid.Last`
+  and provide `pattern Flag a = Last (Just a)` and `pattern NoFlag = Last Nothing`
+  for backward compatibility.
+- The change aims to be non-breaking for the majority of clients, although
+  imports of form `import Distribution.Simple.Flag (Flag (..))` should be replaced
+  with `import Distribution.Simple.Flag (Flag, pattern Flag, pattern NoFlag)`
+  (the latter form is backwards compatible with older versions of Cabal).
+  Enable language extension `PatternSynonyms` if required. In the unlikely case
+  of defining instances for `Flag`, `TypeSynonymInstances` extension
+  is needed.
+
+}

--- a/release-notes/WIP-Cabal-3.16.x.0.md
+++ b/release-notes/WIP-Cabal-3.16.x.0.md
@@ -1,0 +1,18 @@
+Cabal 3.16.x.0 changelog and release notes.
+
+This file will be edited and the changes incorporated into the official
+3.16.x.0 Cabal and Cabal-syntax release notes.
+
+---
+
+### Migration guide
+
+- `data Flag a = Flag a | NoFlag` has been replaced with `type Flag = Data.Monoid.Last`,
+  while `pattern Flag a = Last (Just a)` and `pattern NoFlag = Last Nothing` are provided
+  for backward compatibility.
+  Imports of form `import Distribution.Simple.Flag (Flag (..))` should be replaced
+  with `import Distribution.Simple.Flag (Flag, pattern Flag, pattern NoFlag)`
+  (the latter form is backwards compatible with older versions of Cabal).
+  Enable `{-# LANGUAGE PatternSynonyms #-}` if required. In the unlikely case
+  of defining instances for `Flag`, `{-# LANGUAGE TypeSynonymInstances #-}`
+  is needed.


### PR DESCRIPTION
As http://www.haskell.org/pipermail/cabal-devel/2007-December/001509.html explains, `Data.Monoid.Last` was introduced only in base-3.0 and was too new in 2007 to rely on. Thus a compatibility shim `data Flag a` was vendored in.

We are long past 2007 and `Data.Monoid.Last` can now be used instead. The commit keeps providing `Flag` and `NoFlag` as pattern synonyms for backward compatibility, but makes `type Flag = Last.`

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)