### PR TITLE
Mark untrimmed import test as flaky

### DIFF
--- a/cabal-testsuite/PackageTests/ProjectImport/UntrimmedImport/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/UntrimmedImport/cabal.test.hs
@@ -1,6 +1,6 @@
 import Test.Cabal.Prelude
 
-main = cabalTest . recordMode RecordMarked $ do
+main = cabalTest . flakyIfCI 10950. recordMode RecordMarked $ do
   let log = recordHeader . pure
 
   log "checking project import with trailing space"


### PR DESCRIPTION
Fixes #10950, mark a test that sometimes fails with a parsing error, as flaky.


* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
