### PR TITLE
test suite: mark DedupUsingConfigFromSimple as flaky

### DIFF
--- a/cabal-testsuite/PackageTests/ProjectImport/DedupUsingConfigFromSimple/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/DedupUsingConfigFromSimple/cabal.test.hs
@@ -1,6 +1,6 @@
 import Test.Cabal.Prelude
 
-main = cabalTest . recordMode RecordMarked $ do
+main = cabalTest . flakyIfCI 10975 . recordMode RecordMarked $ do
   let log = recordHeader . pure
 
   out <- fails $ cabal' "v2-build" [ "all", "--dry-run" ]


### PR DESCRIPTION
see https://github.com/haskell/cabal/issues/10975

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
