### PR TITLE
Fix parsing AbiTag for development compilers

### DIFF
--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -195,6 +195,7 @@ module Distribution.Simple.Utils
   , unintersperse
   , wrapText
   , wrapLine
+  , stripCommonPrefix
 
     -- * FilePath stuff
   , isAbsoluteOnAnyPlatform
@@ -2062,3 +2063,10 @@ findHookedPackageDesc verbosity mbWorkDir dir = do
 
 buildInfoExt :: String
 buildInfoExt = ".buildinfo"
+
+-- | @stripCommonPrefix xs ys@ gives you @ys@ without the common prefix with @xs@.
+stripCommonPrefix :: String -> String -> String
+stripCommonPrefix (x : xs) (y : ys)
+  | x == y = stripCommonPrefix xs ys
+  | otherwise = y : ys
+stripCommonPrefix _ ys = ys

--- a/changelog.d/pr-10979
+++ b/changelog.d/pr-10979
@@ -1,0 +1,8 @@
+synopsis: Fix parsing the AbiTag with development versions of GHC
+packages: Cabal
+prs: #10979
+issues: #10170
+
+description: {
+- Allow parsing the AbiTag for developmement versions of GHC.
+}


### PR DESCRIPTION
When using a development compiler the compilerId isn't a prefix of the Project Unit Id. This led to a failure to parse the AbiTag.

We extend the parsing logic to handle these cases by only removing the common prefix and then any leading '-'s.

Resolves #10170

### Manual QA notes

To test this try using cabal-install with a development version of the compiler, and check that the AbiTag is actually parsed. (I did this with traces locally)

---

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [X] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)