### PR TITLE
Support reinstalling more packages (including base and template-haskell) with GHC >=9.14

### DIFF
--- a/Cabal-syntax/src/Distribution/Compiler.hs
+++ b/Cabal-syntax/src/Distribution/Compiler.hs
@@ -56,8 +56,10 @@ import Language.Haskell.Extension
 import Distribution.Version (Version, mkVersion', nullVersion)
 
 import qualified Distribution.Compat.CharParsing as P
+import Distribution.Package (PackageName)
 import Distribution.Parsec (Parsec (..))
 import Distribution.Pretty (Pretty (..), prettyShow)
+import Distribution.Types.UnitId (UnitId)
 import qualified System.Info (compilerName, compilerVersion)
 import qualified Text.PrettyPrint as Disp
 
@@ -213,6 +215,12 @@ data CompilerInfo = CompilerInfo
   -- ^ Supported language standards, if known.
   , compilerInfoExtensions :: Maybe [Extension]
   -- ^ Supported extensions, if known.
+  , compilerInfoWiredInUnitIds :: Maybe [(PackageName, UnitId)]
+  -- ^ 'UnitId's that the compiler doesn't support reinstalling.
+  -- 'Nothing' indicates that the compiler hasn't supplied this
+  -- information and that we should act pessimistically.
+  -- For instance, when using GHC plugins, one wants to use the exact same
+  -- version of the `ghc` package as the one the compiler was linked against.
   }
   deriving (Generic, Show, Read)
 
@@ -245,4 +253,4 @@ abiTagString (AbiTag tag) = tag
 --   compiler id's.
 unknownCompilerInfo :: CompilerId -> AbiTag -> CompilerInfo
 unknownCompilerInfo compilerId abiTag =
-  CompilerInfo compilerId abiTag (Just []) Nothing Nothing
+  CompilerInfo compilerId abiTag (Just []) Nothing Nothing Nothing

--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
@@ -54,6 +54,7 @@ tests = testGroup "Distribution.Simple.Program.GHC"
                       , compilerLanguages = []
                       , compilerExtensions = []
                       , compilerProperties = Map.singleton "Support parallel --make" "YES"
+                      , compilerWiredInUnitIds = Nothing
                       })
                   (Platform X86_64 Linux)
                   (mempty { ghcOptNumJobs = Flag (NumJobs (Just 4)) })

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,4 +33,4 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0xea86b170fa32ac289cbd1fb6174b5cbf
+    0xed69bb9372239b67b14b3e4dd3597c56

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -101,7 +101,9 @@ import Distribution.Pretty
 import Prelude ()
 
 import Distribution.Compiler
+import Distribution.Package (PackageName)
 import Distribution.Simple.Utils
+import Distribution.Types.UnitId (UnitId)
 import Distribution.Utils.Path
 import Distribution.Version
 
@@ -124,6 +126,12 @@ data Compiler = Compiler
   -- ^ Supported language standards.
   , compilerExtensions :: [(Extension, Maybe CompilerFlag)]
   -- ^ Supported extensions.
+  , compilerWiredInUnitIds :: Maybe [(PackageName, UnitId)]
+  -- ^ 'UnitId's that the compiler doesn't support reinstalling.
+  -- For instance, when using GHC plugins, one wants to use the exact same
+  -- version of the `ghc` package as the one the compiler was linked against.
+  -- 'Nothing' indicates that the compiler hasn't supplied this
+  -- information and that we should act pessimistically.
   , compilerProperties :: Map String String
   -- ^ A key-value map for properties not covered by the above fields.
   }
@@ -183,6 +191,7 @@ compilerInfo c =
     (Just . compilerCompat $ c)
     (Just . map fst . compilerLanguages $ c)
     (Just . map fst . compilerExtensions $ c)
+    (compilerWiredInUnitIds c)
 
 -- ------------------------------------------------------------
 

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -170,6 +170,7 @@ configureCompiler verbosity hcPath conf0 = do
           , compilerLanguages = languages
           , compilerExtensions = extensions
           , compilerProperties = ghcInfoMap
+          , compilerWiredInUnitIds = Nothing
           }
       compPlatform = Internal.targetPlatform ghcjsInfo
   return (comp, compPlatform, progdb1)

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -77,6 +77,7 @@ configure verbosity hcPath progdb = do
           , compilerLanguages = uhcLanguages
           , compilerExtensions = uhcLanguageExtensions
           , compilerProperties = Map.empty
+          , compilerWiredInUnitIds = Nothing
           }
       compPlatform = Nothing
   return (comp, compPlatform, progdb')

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -318,6 +318,7 @@ showFR _ UnknownPackage                   = " (unknown package)"
 showFR _ (GlobalConstraintVersion vr (ConstraintSourceProjectConfig pc)) = '\n' : (render . nest 6 $ docProjectConfigPathFailReason vr pc)
 showFR _ (GlobalConstraintVersion vr src) = " (" ++ constraintSource src ++ " requires " ++ prettyShow vr ++ ")"
 showFR _ (GlobalConstraintInstalled src)  = " (" ++ constraintSource src ++ " requires installed instance)"
+showFR _ (GlobalConstraintInstalledSpecificUnitId unitId src)  = " (" ++ constraintSource src ++ " requires installed instance with unit id " ++ prettyShow unitId ++ ")"
 showFR _ (GlobalConstraintSource src)     = " (" ++ constraintSource src ++ " requires source instance)"
 showFR _ (GlobalConstraintFlag src)       = " (" ++ constraintSource src ++ " requires opposite flag selection)"
 showFR _ ManualFlag                       = " (manual flag can only be changed explicitly)"

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
@@ -10,6 +10,7 @@ module Distribution.Solver.Modular.Package
   , PN
   , QPV
   , instI
+  , instUid
   , makeIndependent
   , primaryPP
   , setupPP
@@ -76,6 +77,10 @@ showPI (PI qpn i) = showQPN qpn ++ "-" ++ showI i
 instI :: I -> Bool
 instI (I _ (Inst _)) = True
 instI _              = False
+
+instUid :: UnitId -> I -> Bool
+instUid uid (I _ (Inst uid')) = uid == uid'
+instUid _ _ = False
 
 -- | Is the package in the primary group of packages.  This is used to
 -- determine (1) if we should try to establish stanza preferences

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
@@ -190,6 +190,9 @@ processPackageConstraintP qpn c i (LabeledPackageConstraint (PackageConstraint s
     go _       PackagePropertyInstalled
         | instI i       = r
         | otherwise     = Fail c (GlobalConstraintInstalled src)
+    go _       (PackagePropertyInstalledSpecificUnitId unitId)
+        | instUid unitId i       = r
+        | otherwise     = Fail c (GlobalConstraintInstalledSpecificUnitId unitId src)
     go _       PackagePropertySource
         | not (instI i) = r
         | otherwise     = Fail c (GlobalConstraintSource src)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
@@ -118,6 +118,7 @@ data FailReason = UnsupportedExtension Extension
                 | UnknownPackage
                 | GlobalConstraintVersion VR ConstraintSource
                 | GlobalConstraintInstalled ConstraintSource
+                | GlobalConstraintInstalledSpecificUnitId UnitId ConstraintSource
                 | GlobalConstraintSource ConstraintSource
                 | GlobalConstraintFlag ConstraintSource
                 | ManualFlag

--- a/cabal-install-solver/src/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PackageConstraint.hs
@@ -19,7 +19,7 @@ module Distribution.Solver.Types.PackageConstraint (
 import Distribution.Solver.Compat.Prelude
 import Prelude ()
 
-import Distribution.Package                        (PackageName)
+import Distribution.Package                        (PackageName, UnitId)
 import Distribution.PackageDescription             (FlagAssignment, dispFlagAssignment)
 import Distribution.Pretty                         (flatStyle, Pretty(pretty))
 import Distribution.Types.PackageVersionConstraint (PackageVersionConstraint (..))
@@ -90,6 +90,7 @@ instance Pretty ConstraintScope where
 data PackageProperty
    = PackagePropertyVersion   VersionRange
    | PackagePropertyInstalled
+   | PackagePropertyInstalledSpecificUnitId UnitId
    | PackagePropertySource
    | PackagePropertyFlags     FlagAssignment
    | PackagePropertyStanzas   [OptionalStanza]
@@ -102,6 +103,7 @@ instance Structured PackageProperty
 instance Pretty PackageProperty where
   pretty (PackagePropertyVersion verrange) = pretty verrange
   pretty PackagePropertyInstalled          = Disp.text "installed"
+  pretty (PackagePropertyInstalledSpecificUnitId unitId) = Disp.text "installed(" <> pretty unitId <> Disp.text ")"
   pretty PackagePropertySource             = Disp.text "source"
   pretty (PackagePropertyFlags flags)      = dispFlagAssignment flags
   pretty (PackagePropertyStanzas stanzas)  =
@@ -139,6 +141,7 @@ packageConstraintToDependency (PackageConstraint scope prop) = toDep prop
   where
     toDep (PackagePropertyVersion vr) = Just $ PackageVersionConstraint (scopeToPackageName scope) vr
     toDep (PackagePropertyInstalled)  = Nothing
+    toDep (PackagePropertyInstalledSpecificUnitId {}) = Nothing
     toDep (PackagePropertySource)     = Nothing
     toDep (PackagePropertyFlags _)    = Nothing
     toDep (PackagePropertyStanzas _)  = Nothing

--- a/cabal-install/tests/UnitTests/Distribution/Client/Store.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Store.hs
@@ -46,6 +46,7 @@ testListEmpty =
         , compilerLanguages = []
         , compilerExtensions = []
         , compilerProperties = mempty
+        , compilerWiredInUnitIds = Nothing
         }
 
     unitid = mkUnitId "foo-1.0-xyz"
@@ -102,6 +103,7 @@ testInstallSerial =
         , compilerLanguages = []
         , compilerExtensions = []
         , compilerProperties = mempty
+        , compilerWiredInUnitIds = Nothing
         }
 
     unitid1 = mkUnitId "foo-1.0-xyz"

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -96,6 +96,7 @@ import Distribution.Solver.Types.Settings
 import Distribution.Solver.Types.SolverPackage
 import Distribution.Solver.Types.SourcePackage
 import Distribution.Solver.Types.Variable
+import Distribution.Types.UnitId (UnitId)
 
 {-------------------------------------------------------------------------------
   Example package database DSL
@@ -783,6 +784,8 @@ exResolve
   -> Maybe [Extension]
   -- List of languages supported by the compiler, or Nothing if unknown.
   -> Maybe [Language]
+  -> Maybe [(C.PackageName, UnitId)]
+  -- ^ List of units that are wired in to the compiler
   -> Maybe PC.PkgConfigDb
   -> [ExamplePkgName]
   -> Maybe Int
@@ -806,6 +809,7 @@ exResolve
   db
   exts
   langs
+  wiredInUnitIds
   pkgConfigDb
   targets
   mbj
@@ -831,6 +835,7 @@ exResolve
         defaultCompiler
           { C.compilerInfoExtensions = exts
           , C.compilerInfoLanguages = langs
+          , C.compilerInfoWiredInUnitIds = wiredInUnitIds
           }
       (inst, avai) = partitionEithers db
       instIdx = exInstIdx inst

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -18,6 +18,7 @@ module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
   , preferences
   , setVerbose
   , enableAllTests
+  , wiredInUnitIds
   , solverSuccess
   , solverFailure
   , anySolverFailure
@@ -50,6 +51,7 @@ import qualified Distribution.Solver.Types.PackagePath as P
 import Distribution.Solver.Types.PkgConfigDb (PkgConfigDb (..), pkgConfigDbFromList)
 import Distribution.Solver.Types.Settings
 import Distribution.Solver.Types.Variable
+import Distribution.Types.UnitId (UnitId, mkUnitId)
 import UnitTests.Distribution.Solver.Modular.DSL
 import UnitTests.Options
 
@@ -106,6 +108,16 @@ setVerbose test = test{testVerbosity = verbose}
 enableAllTests :: SolverTest -> SolverTest
 enableAllTests test = test{testEnableAllTests = EnableAllTests True}
 
+wiredInUnitIds :: SolverTest -> SolverTest
+wiredInUnitIds test =
+  test
+    { testWiredInUnitIds =
+        Just
+          [ (C.mkPackageName "ghc-internal", mkUnitId "ghc-internal-1")
+          , (C.mkPackageName "ghc", mkUnitId "ghc-1")
+          ]
+    }
+
 {-------------------------------------------------------------------------------
   Solver tests
 -------------------------------------------------------------------------------}
@@ -130,6 +142,7 @@ data SolverTest = SolverTest
   , testDb :: ExampleDb
   , testSupportedExts :: Maybe [Extension]
   , testSupportedLangs :: Maybe [Language]
+  , testWiredInUnitIds :: Maybe [(C.PackageName, UnitId)]
   , testPkgConfigDb :: Maybe PkgConfigDb
   , testEnableAllTests :: EnableAllTests
   }
@@ -233,6 +246,7 @@ mkTestExtLangPC exts langs mPkgConfigDb db label targets result =
     , testDb = db
     , testSupportedExts = exts
     , testSupportedLangs = langs
+    , testWiredInUnitIds = Nothing
     , testPkgConfigDb = pkgConfigDbFromList <$> mPkgConfigDb
     , testEnableAllTests = EnableAllTests False
     }
@@ -245,6 +259,7 @@ runTest SolverTest{..} = askOption $ \(OptionShowSolverLog showSolverLog) ->
             testDb
             testSupportedExts
             testSupportedLangs
+            testWiredInUnitIds
             testPkgConfigDb
             testTargets
             testMaxBackjumps

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -242,6 +242,7 @@ solve enableBj fineGrainedConflicts reorder countConflicts indep prefOldest goal
             (unTestDb (testDb test))
             Nothing
             Nothing
+            Nothing
             (Just $ pkgConfigDbFromList [])
             (map unPN (testTargets test))
             -- The backjump limit prevents individual tests from using

--- a/cabal-testsuite/Setup.hs
+++ b/cabal-testsuite/Setup.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE CPP #-}
 module Main (main) where
 
 import Distribution.Backpack
@@ -51,7 +52,14 @@ generateScriptEnvModule lbi verbosity = do
       , "lbiPlatform = " ++ show (hostPlatform lbi)
       , ""
       , "lbiCompiler :: Compiler"
+      -- We added a new field to compiler so we need to be careful
+      -- to make sure that it is always defined,
+      -- even if the test suite is being built with an older Cabal
+#if MIN_VERSION_Cabal(3,15,0)
       , "lbiCompiler = " ++ show (compiler lbi)
+#else
+      , "lbiCompiler = " ++ init (show (compiler lbi)) ++ ", compilerWiredInUnitIds = Nothing}"
+#endif
       , ""
       , "lbiPackages :: [(OpenUnitId, ModuleRenaming)]"
       , "lbiPackages = read " ++ show (show (cabalTestsPackages lbi))

--- a/changelog.d/pr-10982
+++ b/changelog.d/pr-10982
@@ -1,0 +1,14 @@
+synopsis: Allow reinstalling packages like base and template-haskell for GHC>=9.14
+packages: cabal-install cabal-install-solver
+prs: #10982
+issues: #10087
+significance: significant
+
+description: {
+
+Historically cabal-install disallowed reinstalling packages like `base` and `template-haskell`.
+As of GHC-9.12, the reasons for this have been lifted.
+We update cabal-install to become aware of this and allow reinstalling more packages.
+Certain packages like `ghc` and `ghc-internal` still cannot be reinstalled.
+
+}


### PR DESCRIPTION
### Summary

This change allows reinstalling packages like `base` and
`template-haskell` with GHC >=9.14, and it doesn't modify the behaviour
of cabal-install with older versions of GHC for backwards-compatibility.


### Context


cabal-install includes a hardcoded list of non-reinstallable packages.
cabal-install will refuse to use a different version of these packages
in a build plan unless the --allow-boot-library-installs flag is set.

This list of packages is too pessimistic, and needlessly coupled to GHC.
For instance, as of GHC-9.12, `base` and `template-haskell` can be
"re-installed" without issue.

### Change

This patch allows compilers to specify exactly which packages are wired-in
and so should not be reinstalled.

In the case of GHC-9.14+, this amounts to ghc-internal and ghc itself.

If a compiler chooses to specify this information then it overrides the
hardcoded non-reinstallable package list. Otherwise, it is still used
for the sake of backwards compatibility.

Note that this information comes in the form of unit-ids rather than
package names. This patch extends the solver with constraints that force
the use of a precise unit-id.

The behaviour here is still somewhat pessimistic. In the future, we
could further relax this restriction and only ban reinstalling these
packafes when absolutely necessary, eg, only ban re-installing `ghc` if
we are using plugins, etc.

For the GHC change that added the interface to expose the unit-id of
ghc-internal, see: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13297

Resolves https://github.com/haskell/cabal/issues/10087


## Manual QA Notes

Build a compiler from this branch: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13297

and then confirm that when used with cabal from this branch it allows you to reinstall `template-haskell` for instance.

For instance this is what happens if I try to build template-haskell with a released version of cabal-install:

<details><summary>cabal output</summary>
<p>

```
❯ cabal build --with-ghc=$GHC template-haskell
Warning: Both /home/teo/.cabal and /home/teo/.config/cabal/config exist -
ignoring the former.
It is advisable to remove one of them. In that case, we will use the remaining
one by default (unless '$CABAL_DIR' is explicitly set).
Resolving dependencies...
Error: [Cabal-7107]
Could not resolve dependencies:
[__0] next goal: template-haskell (user goal)
[__0] rejecting: template-haskell-2.23.0.0 (constraint from non-reinstallable package requires installed instance)
[__0] rejecting: template-haskell; 2.22.0.0, 2.21.0.0, 2.20.0.0, 2.19.0.0, 2.18.0.0, 2.17.0.0, 2.16.0.0, 2.15.0.0, 2.14.0.0, 2.13.0.0, 2.12.0.0, 2.11.1.0, 2.11.0.0, 2.10.0.0, 2.9.0.0, 2.8.0.0, 2.7.0.0, 2.6.0.0, 2.5.0.0, 2.4.0.1, 2.4.0.0, 2.3.0.1, 2.3.0.0, 2.2.0.0 (constraint from user target requires ==2.23.0.0)
[__0] fail (backjumping, conflict set: template-haskell)
After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: template-haskell
``` 

</p>
</details> 

versus from this branch

<details><summary>cabal output</summary>
<p>

```
Warning: this is a debug build of cabal-install with assertions enabled.
Warning: Both /home/teo/.cabal and /home/teo/.config/cabal/config exist -
ignoring the former.
It is advisable to remove one of them. In that case, we will use the remaining
one by default (unless '$CABAL_DIR' is explicitly set).
Warning: Parsing the index cache failed (Data.Binary.Get.runGet at position
16: Non-matching structured hashes: f46da61e7afa58a5e8fd1d2b6fb79899;
expected: d81bdd513f41b5d7ee4cd28455adadbe). Trying to regenerate the index
cache...
Resolving dependencies...
Build profile: -w ghc-9.13.20250617 -O1
In order, the following will be built (use -v for more details):
 - template-haskell-2.23.0.0 (lib) (first run)
Warning: this is a debug build of cabal-install with assertions enabled.
Configuring library for template-haskell-2.23.0.0...
Warning: this is a debug build of cabal-install with assertions enabled.
Preprocessing library for template-haskell-2.23.0.0...
Building library for template-haskell-2.23.0.0...
[ 1 of 11] Compiling Language.Haskell.TH.LanguageExtensions ( Language/Haskell/TH/LanguageExtensions.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/LanguageExtensions.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/LanguageExtensions.dyn_o )
[ 2 of 11] Compiling Language.Haskell.TH.Ppr ( Language/Haskell/TH/Ppr.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Ppr.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Ppr.dyn_o )
[ 3 of 11] Compiling Language.Haskell.TH.PprLib ( Language/Haskell/TH/PprLib.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/PprLib.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/PprLib.dyn_o )
[ 4 of 11] Compiling Language.Haskell.TH.Quote ( Language/Haskell/TH/Quote.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Quote.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Quote.dyn_o )
[ 5 of 11] Compiling System.FilePath.Posix ( vendored-filepath/System/FilePath/Posix.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/System/FilePath/Posix.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/System/FilePath/Posix.dyn_o )
[ 6 of 11] Compiling System.FilePath  ( vendored-filepath/System/FilePath.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/System/FilePath.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/System/FilePath.dyn_o )
[ 7 of 11] Compiling Language.Haskell.TH.Syntax ( Language/Haskell/TH/Syntax.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Syntax.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Syntax.dyn_o )
[ 8 of 11] Compiling Language.Haskell.TH.Lib ( Language/Haskell/TH/Lib.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Lib.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/Lib.dyn_o )
[ 9 of 11] Compiling Language.Haskell.TH.CodeDo ( Language/Haskell/TH/CodeDo.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/CodeDo.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH/CodeDo.dyn_o )
[10 of 11] Compiling Language.Haskell.TH ( Language/Haskell/TH.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/Language/Haskell/TH.dyn_o )
[11 of 11] Compiling System.FilePath.Windows ( vendored-filepath/System/FilePath/Windows.hs, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/System/FilePath/Windows.o, dist-newstyle/build/x86_64-linux/ghc-9.13.20250617/template-haskell-2.23.0.0/build/System/FilePath/Windows.dyn_o )
Warning: this is a debug build of cabal-install with assertions enabled.

``` 

</p>
</details> 

---


Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
