### PR TITLE
docs: Explain how to build only .dyn_o.

### DIFF
--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -1188,6 +1188,13 @@ Dynamic linking options
     Build shared library. This implies a separate compiler run to
     generate position independent code as required on most platforms.
 
+    ``--enable-shared`` is enabled automatically if GHC is dynamically linked
+    (see ``ghc --info``'s ``GHC Dynamic`` field)
+    or you request to build dynamic executables.
+
+    If you want to build *only* dynamic object files,
+    you also have to pass ``--disable-library-vanilla``.
+
     The command line variant of this flag is ``--enable-shared`` and
     ``--disable-shared``.
 

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -807,8 +807,12 @@ Miscellaneous options
     Build shared library. This implies a separate compiler run to
     generate position independent code as required on most platforms.
 
-    ``--enable-shared`` is enabled automatically if GHC is dynamically linked or
-    you request to build dynamic executables.
+    ``--enable-shared`` is enabled automatically if GHC is dynamically linked
+    (see ``ghc --info``'s ``GHC Dynamic`` field)
+    or you request to build dynamic executables.
+
+    If you want to build *only* dynamic object files,
+    you also have to pass ``--disable-library-vanilla``.
 
 .. option:: --disable-shared
 


### PR DESCRIPTION
We struggled for a while at ZuriHac 2025 to figure out why Cabal kept adding `-static -dynamic-too` to GHC flags, even when the GHC is built dynamic-by-default
(`ghc --info` outputs `("GHC Dynamic","YES")`).

The docs so far,

    ``--enable-shared`` is enabled automatically if GHC is dynamically linked or
    you request to build dynamic executables.

did not explain it sufficiently.

It is beacause of this code:

    wantedLibWays is_indef =
        <> [StaticWay | withVanillaLib lbi || withStaticLib lbi]

This commit clarifies the docs.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
