### PR TITLE
Take working directory into account in preprocessor hs-boot hack

### DIFF
--- a/cabal-testsuite/PackageTests/HsBootHack/dep/dep.cabal
+++ b/cabal-testsuite/PackageTests/HsBootHack/dep/dep.cabal
@@ -1,0 +1,15 @@
+cabal-version: 3.0
+name:          dep
+version:       0.1.0.0
+license:       BSD-3-Clause
+author:        sheaf
+maintainer:    sheaf
+category:      Testing
+build-type:    Simple
+description:   Testing the preprocessor hs-boot hack
+
+library
+  hs-source-dirs:   src
+  exposed-modules:  DepA, DepB, DepC
+  build-depends:    base
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepA.hs
+++ b/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepA.hs
@@ -1,0 +1,5 @@
+module DepA where
+
+import {-# SOURCE #-} DepB
+
+data A = A B

--- a/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepB.hs-boot
+++ b/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepB.hs-boot
@@ -1,0 +1,3 @@
+module DepB where
+
+data B

--- a/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepB.hsc
+++ b/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepB.hsc
@@ -1,0 +1,5 @@
+module DepB where
+
+import DepA
+
+data B = B A

--- a/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepC.hs
+++ b/cabal-testsuite/PackageTests/HsBootHack/dep/src/DepC.hs
@@ -1,0 +1,5 @@
+module DepC where
+
+import DepB
+
+data C = C B

--- a/cabal-testsuite/PackageTests/HsBootHack/setup.test.hs
+++ b/cabal-testsuite/PackageTests/HsBootHack/setup.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+-- Test the hs-boot hack respects working directory
+main = setupTest . recordMode DoNotRecord $ withDirectory "dep" $ do
+ void $ setup' "configure" []
+ void $ setup' "build" []

--- a/changelog.d/pr-10991.md
+++ b/changelog.d/pr-10991.md
@@ -1,0 +1,15 @@
+---
+synopsis: "Take --working-dir into account in runPreProcessorWithHsBootHack"
+packages: [Cabal]
+prs: 10991
+issues: [11000]
+---
+
+The preprocessor hs-boot hack handles the situation in which a file to be
+preprocessed is supplied alongside an hs-boot file, e.g. Foo.x and Foo.hs-boot
+are given together.
+
+This code now respects the --working-dir Cabal global argument. This fixes
+build failures of the form:
+
+  attempting to use module `Foo` (Foo.hs-boot) which is not loaded


### PR DESCRIPTION
This commit fixes an oversight in `runPreProcessorWithHsBootHack`, which did not correctly take into account the working directory. This could lead to situations in which we failed to apply the hack.

Recall that this hack is for situations when one has both an `hs-boot` file and a file in need of preprocessing, such as:

```
  Foo.y
  Foo.hs-boot
```

or

```
  Bar.hsc
  Bar.hs-boot
```

Failing to apply the hack essentially meant that GHC would not be able to see the `hs-boot` file, which caused build failures.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.
