### PR TITLE
Hi Haddock: don't try to copy artifacts that don't exist

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -1071,7 +1071,13 @@ reusingGHCCompilationArtifacts verbosity tmpFileOpts mbWorkDir lbi bi clbi versi
           let
             vanillaOpts = componentGhcOptions normal lbi bi clbi (buildDir lbi)
             i = interpretSymbolicPath mbWorkDir
-            copyDir ghcDir tmpDir = copyDirectoryRecursive verbosity (i $ fromFlag $ ghcDir vanillaOpts) (i tmpDir)
+            copyDir getGhcDir tmpDir = do
+              let ghcDir = i $ fromFlag $ getGhcDir vanillaOpts
+              ghcDirExists <- doesDirectoryExist ghcDir
+              -- Don't try to copy artifacts if they don't exist, e.g. if
+              -- we have not yet run the 'build' command.
+              when ghcDirExists $
+                copyDirectoryRecursive verbosity ghcDir (i tmpDir)
           copyDir ghcOptObjDir tmpObjDir
           copyDir ghcOptHiDir tmpHiDir
           -- copyDir ghcOptStubDir tmpStubDir -- (see W.1 in Note [Hi Haddock Recompilation Avoidance])

--- a/cabal-testsuite/PackageTests/HaddockArtifacts/a.cabal
+++ b/cabal-testsuite/PackageTests/HaddockArtifacts/a.cabal
@@ -1,0 +1,10 @@
+name: a
+version: 0.1.0.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/HaddockArtifacts/setup.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockArtifacts/setup.test.hs
@@ -1,0 +1,11 @@
+import Test.Cabal.Prelude
+
+import System.Directory
+import System.FilePath
+
+main = setupTest . recordMode DoNotRecord $ do
+    workDir <- fmap testWorkDir getTestEnv
+    setup "configure" []
+    setup "build" []
+    liftIO $ removeDirectoryRecursive $ workDir </> "work" </> "dist" </> "build"
+    setup "haddock" []

--- a/cabal-testsuite/PackageTests/HaddockArtifacts/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/HaddockArtifacts/src/MyLib.hs
@@ -1,0 +1,8 @@
+module MyLib where
+
+-- | Some docs
+foo :: Int
+foo = 3
+
+-- | More docs
+data A = A Int -- ^ field

--- a/changelog.d/pr-10992.md
+++ b/changelog.d/pr-10992.md
@@ -1,0 +1,11 @@
+---
+synopsis: "Haddock: don't try to copy build dir if it doesn't exist"
+packages: [Cabal]
+prs: 10992
+issues: [11001]
+---
+
+This small patch fixes a little oversight in 'reusingGHCCompilationArtifacts',
+which would unconditionally attempt to copy over the GHC build artifacts to be
+re-used by Haddock, even when those artifacts did not exist (which caused
+an error).


### PR DESCRIPTION
This fixes a bug in which, if we run `cabal haddock` without having run `cabal build` first, then we could try to copy over artifacts that don't exist, which would cause a build failure. Simply not attempting to copy non-existing artifacts fixes the issue.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.
