### PR TITLE
try out merge queues

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -55,6 +55,8 @@ pull_request_rules:
       - base=master
       - -draft
       - -closed
+      - '-label=merge delay passed'
+      - '-label=priority: high :fire:'
       - or:
           - label=merge me
           - label=squash+merge me
@@ -189,14 +191,21 @@ pull_request_rules:
     conditions:
       - body~=automatic backport
 
+merge_queue:
+  max_parallel_checks: 2
+
 queue_rules:
   # Mergify now requires different queues for different strategies
   - name: default
+    batch_size: 3
+    batch_max_wait_time: 10 min
     update_bot_account: Mikolaj
     merge_method: merge
     update_method: rebase
 
   - name: squash-merge
+    batch_size: 3
+    batch_max_wait_time: 10 min
     update_bot_account: Mikolaj
     merge_method: squash
     update_method: merge


### PR DESCRIPTION
Also enabling parallel checks, which should speed things up even more especially since Mergify forced us to separate the normal and squash-merge queues.

Also adjust the labels set for the bot to try to avoid making noise when it's being shoved straight in.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ Mergify configuration is only read on `master`
