### PR TITLE
bump index state to get new `hackage-security`

### DIFF
--- a/cabal.bootstrap.project
+++ b/cabal.bootstrap.project
@@ -9,4 +9,4 @@ packages:
 tests: False
 benchmarks: False
 
-index-state: hackage.haskell.org 2025-04-08T00:00:00Z
+index-state: hackage.haskell.org 2025-06-25T18:35:38Z

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -2,7 +2,7 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
-index-state: hackage.haskell.org 2024-11-20T00:00:00Z
+index-state: hackage.haskell.org 2025-06-25T18:35:38Z
 
 -- never include this or its TH dependency in a release!
 package cabal-install

--- a/cabal.validate.project
+++ b/cabal.validate.project
@@ -12,3 +12,7 @@ program-options
 -- to disable this
 package cabal-install
   flags: +git-rev
+
+-- splitmix-0.1.3 is demanding a symbol GitHub's Mac runners don't admit to having
+constraints:
+  splitmix < 0.1.3


### PR DESCRIPTION
**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
