### PR TITLE
swap `updated-at` condition

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -38,7 +38,7 @@ pull_request_rules:
     conditions:
       - or:
           - 'label=priority: high :fire:'
-          - updated-at<2 days ago
+          - updated-at>=2 days ago
       - or:
           - label=merge me
           - label=squash+merge me
@@ -86,7 +86,7 @@ pull_request_rules:
       - -merged
       - '#approved-reviews-by>=2'
       - '#changes-requested-reviews-by=0'
-      - updated-at<4 days ago
+      - updated-at>=4 days ago
       - label=merge delay passed
       # oy
       # lifted these from branch protection imports


### PR DESCRIPTION
Mergify has apparently fixed the bug that caused it to invert the `updated-at` condition, which caused a PR to be dropped on the floor yesterday and is now skipping the cooldown. Invert it.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ Mergify only reads the rules on `master`
