### PR TITLE
adjust versions for 3.16.0.0 release

### DIFF
--- a/Cabal-QuickCheck/Cabal-QuickCheck.cabal
+++ b/Cabal-QuickCheck/Cabal-QuickCheck.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-QuickCheck
-version:       3.17.0.0
+version:       3.16.0.0
 synopsis:      QuickCheck instances for types in Cabal
 category:      Testing
 build-type:    Simple
@@ -14,8 +14,8 @@ library
   build-depends:
     , base
     , bytestring
-    , Cabal         ^>=3.17.0.0
-    , Cabal-syntax  ^>=3.17.0.0
+    , Cabal         ^>=3.16.0.0
+    , Cabal-syntax  ^>=3.16.0.0
     , QuickCheck    >= 2.13.2 && < 2.17
 
   exposed-modules:

--- a/Cabal-described/Cabal-described.cabal
+++ b/Cabal-described/Cabal-described.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-described
-version:       3.17.0.0
+version:       3.16.0.0
 synopsis:      Described functionality for types in Cabal
 category:      Testing, Parsec
 description:   Provides rere bindings
@@ -12,8 +12,8 @@ library
   ghc-options:      -Wall
   build-depends:
     , base
-    , Cabal             ^>=3.17.0.0
-    , Cabal-syntax      ^>=3.17.0.0
+    , Cabal             ^>=3.16.0.0
+    , Cabal-syntax      ^>=3.16.0.0
     , containers
     , pretty
     , QuickCheck

--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          Cabal-hooks
-version:       3.17
+version:       3.16
 copyright:     2023, Cabal Development Team
 license:       BSD-3-Clause
 license-file:  LICENSE
@@ -27,8 +27,8 @@ library
   hs-source-dirs: src
 
   build-depends:
-    , Cabal-syntax    >= 3.17      && < 3.18
-    , Cabal           >= 3.17      && < 3.18
+    , Cabal-syntax    >= 3.16      && < 3.17
+    , Cabal           >= 3.16      && < 3.17
     , base            >= 4.13      && < 5
     , containers      >= 0.5.0.0   && < 0.9
     , transformers    >= 0.5.6.0   && < 0.7

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          Cabal-syntax
-version:       3.17.0.0
+version:       3.16.0.0
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/Cabal-tree-diff/Cabal-tree-diff.cabal
+++ b/Cabal-tree-diff/Cabal-tree-diff.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-tree-diff
-version:       3.17.0.0
+version:       3.16.0.0
 synopsis:      QuickCheck instances for types in Cabal
 category:      Testing
 description:   Provides tree-diff ToExpr instances for some types in Cabal
@@ -11,8 +11,8 @@ library
   ghc-options:      -Wall
   build-depends:
     , base
-    , Cabal-syntax  ^>=3.17.0.0
-    , Cabal         ^>=3.17.0.0
+    , Cabal-syntax  ^>=3.16.0.0
+    , Cabal         ^>=3.16.0.0
     , tree-diff     ^>=0.1 || ^>=0.2 || ^>=0.3
 
   exposed-modules:  Data.TreeDiff.Instances.Cabal

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          Cabal
-version:       3.17.0.0
+version:       3.16.0.0
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)
 license:       BSD-3-Clause
 license-file:  LICENSE
@@ -39,7 +39,7 @@ library
   hs-source-dirs: src
 
   build-depends:
-    , Cabal-syntax ^>= 3.17
+    , Cabal-syntax ^>= 3.16
     , array      >= 0.4.0.1  && < 0.6
     , base       >= 4.13     && < 5
     , bytestring >= 0.10.0.0 && < 0.13

--- a/Cabal/Makefile
+++ b/Cabal/Makefile
@@ -1,4 +1,4 @@
-VERSION=3.15.0.0
+VERSION=3.16.0.0
 
 #KIND=devel
 KIND=rc

--- a/bootstrap/linux-9.10.2.json
+++ b/bootstrap/linux-9.10.2.json
@@ -124,7 +124,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -136,7 +136,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -146,7 +146,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17"
+            "version": "3.16"
         },
         {
             "cabal_sha256": "725ef6da03d3d6e332db4de0a35bee45d72e4d31decc5ec7f153e6837af5f03e",
@@ -308,7 +308,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -487,7 +487,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -501,7 +501,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.12.2.json
+++ b/bootstrap/linux-9.12.2.json
@@ -128,7 +128,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -140,7 +140,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -150,7 +150,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17"
+            "version": "3.16"
         },
         {
             "cabal_sha256": "725ef6da03d3d6e332db4de0a35bee45d72e4d31decc5ec7f153e6837af5f03e",
@@ -312,7 +312,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -479,7 +479,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -493,7 +493,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.2.8.json
+++ b/bootstrap/linux-9.2.8.json
@@ -154,7 +154,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "6def2e07c317f52f4d30c43e92f97b7bc5f7c27cb1270d386b15dce429e1180f",
@@ -178,7 +178,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -188,7 +188,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17"
+            "version": "3.16"
         },
         {
             "cabal_sha256": "725ef6da03d3d6e332db4de0a35bee45d72e4d31decc5ec7f153e6837af5f03e",
@@ -361,7 +361,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -538,7 +538,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -552,7 +552,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.4.8.json
+++ b/bootstrap/linux-9.4.8.json
@@ -154,7 +154,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "6def2e07c317f52f4d30c43e92f97b7bc5f7c27cb1270d386b15dce429e1180f",
@@ -178,7 +178,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -188,7 +188,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17"
+            "version": "3.16"
         },
         {
             "cabal_sha256": "725ef6da03d3d6e332db4de0a35bee45d72e4d31decc5ec7f153e6837af5f03e",
@@ -351,7 +351,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -528,7 +528,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -542,7 +542,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.6.7.json
+++ b/bootstrap/linux-9.6.7.json
@@ -112,7 +112,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -124,7 +124,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -134,7 +134,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17"
+            "version": "3.16"
         },
         {
             "cabal_sha256": "725ef6da03d3d6e332db4de0a35bee45d72e4d31decc5ec7f153e6837af5f03e",
@@ -306,7 +306,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -495,7 +495,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -509,7 +509,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.8.4.json
+++ b/bootstrap/linux-9.8.4.json
@@ -116,7 +116,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -128,7 +128,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -138,7 +138,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17"
+            "version": "3.16"
         },
         {
             "cabal_sha256": "725ef6da03d3d6e332db4de0a35bee45d72e4d31decc5ec7f153e6837af5f03e",
@@ -310,7 +310,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -489,7 +489,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         },
         {
             "cabal_sha256": null,
@@ -503,7 +503,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.17.0.0"
+            "version": "3.16.0.0"
         }
     ]
 }

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          cabal-install-solver
-version:       3.17.0.0
+version:       3.16.0.0
 synopsis:      The solver component of cabal-install
 description:
   The solver component used in the cabal-install command-line program.
@@ -101,8 +101,8 @@ library
     , array         >=0.4      && <0.6
     , base          >=4.13     && <4.22
     , bytestring    >=0.10.6.0 && <0.13
-    , Cabal         ^>=3.17
-    , Cabal-syntax  ^>=3.17
+    , Cabal         ^>=3.16
+    , Cabal-syntax  ^>=3.16
     , containers    >=0.5.6.2  && <0.9
     , edit-distance ^>= 0.2.2
     , directory     >= 1.3.7.0  && < 1.4

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -1,7 +1,7 @@
 Cabal-Version:      3.6
 
 Name:               cabal-install
-Version:            3.17.0.0
+Version:            3.16.0.0
 Synopsis:           The command-line interface for Cabal and Hackage.
 Description:
     The \'cabal\' command-line program simplifies the process of managing
@@ -62,15 +62,15 @@ common base-dep
 
 common cabal-dep
     build-depends:
-      , Cabal ^>=3.17
+      , Cabal ^>=3.16
 
 common cabal-syntax-dep
     build-depends:
-      , Cabal-syntax ^>=3.17
+      , Cabal-syntax ^>=3.16
 
 common cabal-install-solver-dep
     build-depends:
-      , cabal-install-solver ^>=3.17
+      , cabal-install-solver ^>=3.16
 
 library
     import: warnings, base-dep, cabal-dep, cabal-syntax-dep, cabal-install-solver-dep

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -28,7 +28,7 @@ common shared
   build-depends:
     , base >= 4.11 && < 4.22
     -- this needs to match the in-tree lib:Cabal version
-    , Cabal ^>= 3.17.0.0
+    , Cabal ^>= 3.16.0.0
 
   ghc-options:
     -Wall

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,7 +13,7 @@ import sphinx_rtd_theme
 sys.path.insert(0, os.path.abspath('.'))
 import cabaldomain
 
-version = "3.15.0.0"
+version = "3.16.0.0"
 
 extensions = [
     'sphinx.ext.extlinks',

--- a/solver-benchmarks/solver-benchmarks.cabal
+++ b/solver-benchmarks/solver-benchmarks.cabal
@@ -31,7 +31,7 @@ library
     , base
     , bytestring
     , containers
-    , Cabal-syntax ^>= 3.17
+    , Cabal-syntax ^>= 3.16
     , directory
     , filepath
     , optparse-applicative


### PR DESCRIPTION
This commit is directly to 3.16 branch.

Note that I discovered two missed version bumps on `master` which must be addressed in a separate PR.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~
