### PR TITLE
adjust Mergify queue rules for release branches

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,12 +11,12 @@ priority_rules:
   - name: priority for queue `default`
     conditions:
       - queue-name=default
-    priority: 2750
+    priority: 2500
 
   - name: priority for queue `squash-merge`
     conditions:
       - queue-name=squash-merge
-    priority: 2750
+    priority: 2500
 
   # The idea is we slightly prioritize those PRs because we're in
   # a release cycle if a PR matches.
@@ -24,7 +24,7 @@ priority_rules:
     conditions:
       - 'base~=^3\.'
       - 'label!=backport'
-    priority: 2800
+    priority: 2750
 
 pull_request_rules:
 
@@ -142,7 +142,7 @@ pull_request_rules:
     conditions:
       - label=merge me
       - base!=master
-      - -body~=backport
+      - -label=backport
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
 
@@ -154,7 +154,7 @@ pull_request_rules:
     conditions:
       - base!=master
       - label=squash+merge me
-      - -body~=backport
+      - -label=backport
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
 
@@ -166,7 +166,7 @@ pull_request_rules:
     conditions:
       - label=merge me
       - base!=master
-      - body~=backport
+      - label=backport
       - '#approved-reviews-by>=1'
       - '-label~=^blocked:'
 
@@ -178,7 +178,7 @@ pull_request_rules:
     conditions:
       - label=squash+merge me
       - base!=master
-      - body~=backport
+      - label=backport
       - '#approved-reviews-by>=1'
       - '-label~=^blocked:'
 


### PR DESCRIPTION
It just inappropriately used a backport queue (luckily with no ill effects) for a release branch non-backport PR. Use the label we set on backports (which has a better pattern for matching them) instead of a body check.

Also undid the attempted hack to stop the Mergify upgrade bot from breaking our priorities.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ Mergify configuration is only read on `master`
