### PR TITLE
Capitalise “AArch” properly

### DIFF
--- a/Cabal/src/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule.hs
@@ -51,7 +51,7 @@ generatePathsModule pkg_descr lbi clbi =
       , Z.zIsWindows = isWindows
       , Z.zIsI386 = buildArch == I386
       , Z.zIsX8664 = buildArch == X86_64
-      , Z.zIsAarch64 = buildArch == AArch64
+      , Z.zIsAArch64 = buildArch == AArch64
       , Z.zNot = not
       , Z.zManglePkgName = showPkgName
       , Z.zPrefix = show flat_prefix

--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -12,7 +12,7 @@ data Z
          zIsWindows :: Bool,
          zIsI386 :: Bool,
          zIsX8664 :: Bool,
-         zIsAarch64 :: Bool,
+         zIsAArch64 :: Bool,
          zPrefix :: FilePath,
          zBindir :: FilePath,
          zLibdir :: FilePath,
@@ -350,13 +350,13 @@ render z_root = execWriter $ do
             tell "  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
             return ()
           else do
-            if (zIsAarch64 z_root)
+            if (zIsAArch64 z_root)
             then do
               tell "foreign import ccall unsafe \"windows.h GetModuleFileNameW\"\n"
               tell "  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
               return ()
             else do
-              tell "-- win32 supported only with I386, X86_64, Aarch64\n"
+              tell "-- win32 supported only with I386, X86_64, AArch64\n"
               tell "c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
               tell "c_GetModuleFileName  = _\n"
               return ()

--- a/cabal-dev-scripts/src/GenPathsModule.hs
+++ b/cabal-dev-scripts/src/GenPathsModule.hs
@@ -32,7 +32,7 @@ $(capture "decls" [d|
         , zIsWindows                  :: Bool
         , zIsI386                     :: Bool
         , zIsX8664                    :: Bool
-        , zIsAarch64                  :: Bool
+        , zIsAArch64                  :: Bool
 
         , zPrefix     :: FilePath
         , zBindir     :: FilePath

--- a/changelog.d/pr-10705
+++ b/changelog.d/pr-10705
@@ -1,8 +1,8 @@
 ---
-synopsis: 'Add support for Windows Aarch64'
+synopsis: 'Add support for Windows AArch64'
 packages: [Cabal, cabal-install]
 prs: 10705
 ---
 
-Adds to preprocessor branches the option to support `aarch64_HOST_ARCH` platform on Windows Aarch64 target.
-`ccall` convention is used at Aarch64, same as for `x86_64_HOST_ARCH`. Introduce `zIsAarch64` to make paths generation support Windows Aarch64 target.
+Adds to preprocessor branches the option to support `aarch64_HOST_ARCH` platform on Windows AArch64 target.
+`ccall` convention is used at AArch64, same as for `x86_64_HOST_ARCH`. Introduce `zIsAArch64` to make paths generation support Windows AArch64 target.

--- a/templates/Paths_pkg.template.hs
+++ b/templates/Paths_pkg.template.hs
@@ -205,11 +205,11 @@ foreign import stdcall unsafe "windows.h GetModuleFileNameW"
 {% elif isX8664 %}
 foreign import ccall unsafe "windows.h GetModuleFileNameW"
   c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
-{% elif isAarch64 %}
+{% elif isAArch64 %}
 foreign import ccall unsafe "windows.h GetModuleFileNameW"
   c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
 {% else %}
--- win32 supported only with I386, X86_64, Aarch64
+-- win32 supported only with I386, X86_64, AArch64
 c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
 c_GetModuleFileName  = _
 {% endif %}


### PR DESCRIPTION
The official capitalisation is “AArch”,
see https://developer.arm.com/documentation/102374/latest/.


---

As noted by @ulysses4ever in #11033. Addition in #10705 by @GulinSS (who might want to tell us if he is OK with the change)

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog). ← note, forward-porting changelogs to master will have some conflicts because of this.
* [x] The documentation has been updated, if necessary.
* [x] ~~[Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.~~ N/A
* [x] ~~Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~ N/A