### PR TITLE
Backport #11047: Capitalise “AArch” properly

### DIFF
--- a/Cabal/src/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule.hs
@@ -51,7 +51,7 @@ generatePathsModule pkg_descr lbi clbi =
       , Z.zIsWindows = isWindows
       , Z.zIsI386 = buildArch == I386
       , Z.zIsX8664 = buildArch == X86_64
-      , Z.zIsAarch64 = buildArch == AArch64
+      , Z.zIsAArch64 = buildArch == AArch64
       , Z.zNot = not
       , Z.zManglePkgName = showPkgName
       , Z.zPrefix = show flat_prefix

--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -12,7 +12,7 @@ data Z
          zIsWindows :: Bool,
          zIsI386 :: Bool,
          zIsX8664 :: Bool,
-         zIsAarch64 :: Bool,
+         zIsAArch64 :: Bool,
          zPrefix :: FilePath,
          zBindir :: FilePath,
          zLibdir :: FilePath,
@@ -350,13 +350,13 @@ render z_root = execWriter $ do
             tell "  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
             return ()
           else do
-            if (zIsAarch64 z_root)
+            if (zIsAArch64 z_root)
             then do
               tell "foreign import ccall unsafe \"windows.h GetModuleFileNameW\"\n"
               tell "  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
               return ()
             else do
-              tell "-- win32 supported only with I386, X86_64, Aarch64\n"
+              tell "-- win32 supported only with I386, X86_64, AArch64\n"
               tell "c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
               tell "c_GetModuleFileName  = _\n"
               return ()

--- a/cabal-dev-scripts/src/GenPathsModule.hs
+++ b/cabal-dev-scripts/src/GenPathsModule.hs
@@ -32,7 +32,7 @@ $(capture "decls" [d|
         , zIsWindows                  :: Bool
         , zIsI386                     :: Bool
         , zIsX8664                    :: Bool
-        , zIsAarch64                  :: Bool
+        , zIsAArch64                  :: Bool
 
         , zPrefix     :: FilePath
         , zBindir     :: FilePath

--- a/templates/Paths_pkg.template.hs
+++ b/templates/Paths_pkg.template.hs
@@ -205,11 +205,11 @@ foreign import stdcall unsafe "windows.h GetModuleFileNameW"
 {% elif isX8664 %}
 foreign import ccall unsafe "windows.h GetModuleFileNameW"
   c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
-{% elif isAarch64 %}
+{% elif isAArch64 %}
 foreign import ccall unsafe "windows.h GetModuleFileNameW"
   c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
 {% else %}
--- win32 supported only with I386, X86_64, Aarch64
+-- win32 supported only with I386, X86_64, AArch64
 c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32
 c_GetModuleFileName  = _
 {% endif %}


### PR DESCRIPTION
*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~

This is a backport, the relevant documentation (release notes) was already taken care of in #11033.
