### PR TITLE
Solver: shorten the skipping message if needed

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular.hs
@@ -200,7 +200,7 @@ solve' sc cinfo idx pkgConfigDB pprefs gcs pns =
           -- original goal order.
           goalOrder' = preferGoalsFromConflictSet cs <> fromMaybe mempty (goalOrder sc)
 
-      in unlines ("Could not resolve dependencies:" : map renderSummarizedMessage (messages (toProgress (runSolver True sc'))))
+      in unlines ("Could not resolve dependencies:" : map (renderSummarizedMessage (solverVerbosity sc)) (messages (toProgress (runSolver True sc'))))
 
     printFullLog = solverVerbosity sc >= verbose
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -291,7 +291,7 @@ showOptions q xs = showQPN q ++ "; " ++ (L.intercalate ", "
     then showOption q x
     else showI i -- Don't show the package, just the version
   | x@(POption i linkedTo) <- take 3 xs
-  ] ++ if length xs >= 3 then " and earlier versions" else "")
+  ] ++ if length xs >= 3 then " and other versions" else "")
 
 showGR :: QGoalReason -> String
 showGR UserGoal            = " (user goal)"

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -268,22 +268,22 @@ showOption qpn@(Q _pp pn) (POption i linkedTo) =
 
 -- | Shows a mixed list of instances and versions in a human-friendly way,
 -- abbreviated.
--- >>> showOptions foobarQPN [v0, v1]
+-- >>> showOptions verbose foobarQPN [v0, v1]
 -- "foo-bar; 0, 1"
--- >>> showOptions foobarQPN [v0]
+-- >>> showOptions verbose foobarQPN [v0]
 -- "foo-bar-0"
--- >>> showOptions foobarQPN [i0, i1]
+-- >>> showOptions verbose foobarQPN [i0, i1]
 -- "foo-bar; 0/installed-inplace, 1/installed-inplace"
--- >>> showOptions foobarQPN [i0, v1]
+-- >>> showOptions verbose foobarQPN [i0, v1]
 -- "foo-bar; 0/installed-inplace, 1"
--- >>> showOptions foobarQPN [v0, i1]
+-- >>> showOptions verbose foobarQPN [v0, i1]
 -- "foo-bar; 0, 1/installed-inplace"
--- >>> showOptions foobarQPN []
+-- >>> showOptions verbose foobarQPN []
 -- "unexpected empty list of versions"
--- >>> showOptions foobarQPN [k1, k2]
+-- >>> showOptions verbose foobarQPN [k1, k2]
 -- "foo-bar; foo-bar~>bazqux.foo-bar-1, foo-bar~>bazqux.foo-bar-2"
--- >>> showOptions foobarQPN [v0, i1, k2]
--- "foo-bar; 0, 1/installed-inplace, foo-bar~>bazqux.foo-bar-2 and earlier versions"
+-- >>> showOptions verbose foobarQPN [v0, i1, k2]
+-- "foo-bar; 0, 1/installed-inplace, foo-bar~>bazqux.foo-bar-2"
 showOptions :: Verbosity -> QPN -> [POption] -> String
 showOptions _ _ [] = "unexpected empty list of versions"
 showOptions _ q [x] = showOption q x

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -291,8 +291,8 @@ showOptions verb q xs = showQPN q ++ "; " ++ (L.intercalate ", "
   [if isJust linkedTo
     then showOption q x
     else showI i -- Don't show the package, just the version
-  | x@(POption i linkedTo) <- if verb >= verbose then xs else take 3 xs
-  ] ++ if verb < verbose && length xs >= 3 then " and other versions" else "")
+  | x@(POption i linkedTo) <- if verb >= verbose then xs else take 1 xs
+  ] ++ if verb < verbose && length xs >= 1 then " and other versions" else "")
 
 showGR :: QGoalReason -> String
 showGR UserGoal            = " (user goal)"

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -54,6 +54,7 @@ import Distribution.Types.LibraryName
     ( LibraryName(LSubLibName, LMainLibName) )
 import Distribution.Types.UnqualComponentName
     ( unUnqualComponentName )
+import Distribution.Verbosity (Verbosity, verbose)
 
 import Text.PrettyPrint ( nest, render )
 
@@ -69,32 +70,32 @@ data Message =
   | Success
   | Failure ConflictSet FailReason
 
-renderSummarizedMessage :: SummarizedMessage -> String
-renderSummarizedMessage (SummarizedMsg i) = displayMessageAtLevel i
-renderSummarizedMessage (StringMsg s) = s
+renderSummarizedMessage :: Verbosity -> SummarizedMessage -> String
+renderSummarizedMessage verb (SummarizedMsg i) = displayMessageAtLevel verb i
+renderSummarizedMessage _ (StringMsg s) = s
 
-displayMessageAtLevel :: EntryAtLevel -> String
-displayMessageAtLevel (AtLevel l msg) =
+displayMessageAtLevel :: Verbosity -> EntryAtLevel -> String
+displayMessageAtLevel verb (AtLevel l msg) =
   let s = show l
-  in  "[" ++ replicate (3 - length s) '_' ++ s ++ "] " ++ displayMessage msg
+  in  "[" ++ replicate (3 - length s) '_' ++ s ++ "] " ++ displayMessage verb msg
 
-displayMessage :: Entry -> String
-displayMessage (EntryPackageGoal qpn gr) = "next goal: " ++ showQPN qpn ++ showGR gr
-displayMessage (EntryRejectF qfn b c fr) = "rejecting: " ++ showQFNBool qfn b ++ showFR c fr
-displayMessage (EntryRejectS qsn b c fr) = "rejecting: " ++ showQSNBool qsn b ++ showFR c fr
-displayMessage (EntrySkipping cs) = "skipping: " ++ showConflicts cs
-displayMessage (EntryTryingF qfn b) = "trying: " ++ showQFNBool qfn b
-displayMessage (EntryTryingP qpn i) = "trying: " ++ showOption qpn i
-displayMessage (EntryTryingNewP qpn i gr) = "trying: " ++ showOption qpn i ++ showGR gr
-displayMessage (EntryTryingS qsn b) = "trying: " ++ showQSNBool qsn b
-displayMessage (EntryUnknownPackage qpn gr) = "unknown package: " ++ showQPN qpn ++ showGR gr
-displayMessage EntrySuccess = "done"
-displayMessage (EntryFailure c fr) = "fail" ++ showFR c fr
-displayMessage (EntrySkipMany qsn b cs) = "skipping: " ++ showOptions qsn b ++ " " ++ showConflicts cs
+displayMessage :: Verbosity -> Entry -> String
+displayMessage _ (EntryPackageGoal qpn gr) = "next goal: " ++ showQPN qpn ++ showGR gr
+displayMessage _ (EntryRejectF qfn b c fr) = "rejecting: " ++ showQFNBool qfn b ++ showFR c fr
+displayMessage _ (EntryRejectS qsn b c fr) = "rejecting: " ++ showQSNBool qsn b ++ showFR c fr
+displayMessage _ (EntrySkipping cs) = "skipping: " ++ showConflicts cs
+displayMessage _ (EntryTryingF qfn b) = "trying: " ++ showQFNBool qfn b
+displayMessage _ (EntryTryingP qpn i) = "trying: " ++ showOption qpn i
+displayMessage _ (EntryTryingNewP qpn i gr) = "trying: " ++ showOption qpn i ++ showGR gr
+displayMessage _ (EntryTryingS qsn b) = "trying: " ++ showQSNBool qsn b
+displayMessage _ (EntryUnknownPackage qpn gr) = "unknown package: " ++ showQPN qpn ++ showGR gr
+displayMessage _ EntrySuccess = "done"
+displayMessage _ (EntryFailure c fr) = "fail" ++ showFR c fr
+displayMessage verb (EntrySkipMany qsn b cs) = "skipping: " ++ showOptions verb qsn b ++ " " ++ showConflicts cs
 -- Instead of displaying `aeson-1.0.2.1, aeson-1.0.2.0, aeson-1.0.1.0, ...`,
 -- the following line aims to display `aeson: 1.0.2.1, 1.0.2.0, 1.0.1.0, ...`.
 --
-displayMessage (EntryRejectMany qpn is c fr) = "rejecting: " ++ showOptions qpn is ++ showFR c fr
+displayMessage verb (EntryRejectMany qpn is c fr) = "rejecting: " ++ showOptions verb qpn is ++ showFR c fr
 
 -- | Transforms the structured message type to actual messages (SummarizedMessage s).
 --
@@ -283,15 +284,15 @@ showOption qpn@(Q _pp pn) (POption i linkedTo) =
 -- "foo-bar; foo-bar~>bazqux.foo-bar-1, foo-bar~>bazqux.foo-bar-2"
 -- >>> showOptions foobarQPN [v0, i1, k2]
 -- "foo-bar; 0, 1/installed-inplace, foo-bar~>bazqux.foo-bar-2 and earlier versions"
-showOptions :: QPN -> [POption] -> String
-showOptions _ [] = "unexpected empty list of versions"
-showOptions q [x] = showOption q x
-showOptions q xs = showQPN q ++ "; " ++ (L.intercalate ", "
+showOptions :: Verbosity -> QPN -> [POption] -> String
+showOptions _ _ [] = "unexpected empty list of versions"
+showOptions _ q [x] = showOption q x
+showOptions verb q xs = showQPN q ++ "; " ++ (L.intercalate ", "
   [if isJust linkedTo
     then showOption q x
     else showI i -- Don't show the package, just the version
-  | x@(POption i linkedTo) <- take 3 xs
-  ] ++ if length xs >= 3 then " and other versions" else "")
+  | x@(POption i linkedTo) <- if verb >= verbose then xs else take 3 xs
+  ] ++ if verb < verbose && length xs >= 3 then " and other versions" else "")
 
 showGR :: QGoalReason -> String
 showGR UserGoal            = " (user goal)"

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -292,7 +292,7 @@ showOptions verb q xs = showQPN q ++ "; " ++ (L.intercalate ", "
     then showOption q x
     else showI i -- Don't show the package, just the version
   | x@(POption i linkedTo) <- if verb >= verbose then xs else take 1 xs
-  ] ++ if verb < verbose && length xs >= 1 then " and other versions" else "")
+  ] ++ if verb < verbose && length xs > 1 then " and " ++ show (length xs - 1) ++" other versions" else "")
 
 showGR :: QGoalReason -> String
 showGR UserGoal            = " (user goal)"

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -282,7 +282,7 @@ showOption qpn@(Q _pp pn) (POption i linkedTo) =
 -- >>> showOptions foobarQPN [k1, k2]
 -- "foo-bar; foo-bar~>bazqux.foo-bar-1, foo-bar~>bazqux.foo-bar-2"
 -- >>> showOptions foobarQPN [v0, i1, k2]
--- "foo-bar; 0, 1/installed-inplace, foo-bar~>bazqux.foo-bar-2"
+-- "foo-bar; 0, 1/installed-inplace, foo-bar~>bazqux.foo-bar-2 and earlier versions"
 showOptions :: QPN -> [POption] -> String
 showOptions _ [] = "unexpected empty list of versions"
 showOptions q [x] = showOption q x
@@ -290,8 +290,8 @@ showOptions q xs = showQPN q ++ "; " ++ (L.intercalate ", "
   [if isJust linkedTo
     then showOption q x
     else showI i -- Don't show the package, just the version
-  | x@(POption i linkedTo) <- xs
-  ])
+  | x@(POption i linkedTo) <- take 3 xs
+  ] ++ if length xs >= 3 then " and earlier versions" else "")
 
 showGR :: QGoalReason -> String
 showGR UserGoal            = " (user goal)"

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -864,7 +864,7 @@ resolveDependencies platform comp pkgConfigDB params =
           else dontInstallNonReinstallablePackages params
 
     formatProgress :: Progress SummarizedMessage String a -> Progress String String a
-    formatProgress p = foldProgress (\x xs -> Step (renderSummarizedMessage x) xs) Fail Done p
+    formatProgress p = foldProgress (\x xs -> Step (renderSummarizedMessage (depResolverVerbosity params) x) xs) Fail Done p
 
     preferences :: PackageName -> PackagePreferences
     preferences = interpretPackagesPreference targets defpref prefs

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -996,7 +996,7 @@ tests =
                     , Right $ exAv "B" 1 [ExFix "A" 6]
                     ]
                   rejecting = "rejecting: A-5.0.0 (conflict: B => A==6.0.0)"
-                  skipping = "skipping: A; 4.0.0, 3.0.0, 2.0.0 and earlier versions (has"
+                  skipping = "skipping: A; 4.0.0, 3.0.0, 2.0.0 and other versions (has"
                in mkTest db "show summarized skipping versions list" ["B"] $
                     solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
           ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -996,7 +996,7 @@ tests =
                     , Right $ exAv "B" 1 [ExFix "A" 4]
                     ]
                   rejecting = "rejecting: A-3.0.0 (conflict: B => A==4.0.0)"
-                  skipping = "skipping: A; 2.0.0 and other versions (has"
+                  skipping = "skipping: A; 2.0.0 and 1 other versions (has"
                in mkTest db "show summarized skipping versions list" ["B"] $
                     solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
           ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -986,6 +986,19 @@ tests =
                   skipping = "skipping: A; 2.0.0/installed-2.0.0, 1.0.0/installed-1.0.0"
                in mkTest db "show skipping versions list, installed" ["B"] $
                     solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
+          , runTest $
+              let db =
+                    [ Right $ exAv "A" 1 []
+                    , Right $ exAv "A" 2 []
+                    , Right $ exAv "A" 3 []
+                    , Right $ exAv "A" 4 []
+                    , Right $ exAv "A" 5 []
+                    , Right $ exAv "B" 1 [ExFix "A" 6]
+                    ]
+                  rejecting = "rejecting: A-5.0.0 (conflict: B => A==6.0.0)"
+                  skipping = "skipping: A; 4.0.0, 3.0.0, 2.0.0 and earlier versions (has"
+               in mkTest db "show summarized skipping versions list" ["B"] $
+                    solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
           ]
       ]
   ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -973,8 +973,9 @@ tests =
                     ]
                   rejecting = "rejecting: A-3.0.0"
                   skipping = "skipping: A; 2.0.0, 1.0.0"
-               in mkTest db "show skipping versions list" ["B"] $
-                    solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
+               in setVerbose $
+                    mkTest db "show skipping versions list" ["B"] $
+                      solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
           , runTest $
               let db =
                     [ Left $ exInst "A" 1 "A-1.0.0" []
@@ -984,8 +985,9 @@ tests =
                     ]
                   rejecting = "rejecting: A-3.0.0/installed-3.0.0"
                   skipping = "skipping: A; 2.0.0/installed-2.0.0, 1.0.0/installed-1.0.0"
-               in mkTest db "show skipping versions list, installed" ["B"] $
-                    solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
+               in setVerbose $
+                    mkTest db "show skipping versions list, installed" ["B"] $
+                      solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
           , runTest $
               let db =
                     [ Right $ exAv "A" 1 []

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -993,12 +993,10 @@ tests =
                     [ Right $ exAv "A" 1 []
                     , Right $ exAv "A" 2 []
                     , Right $ exAv "A" 3 []
-                    , Right $ exAv "A" 4 []
-                    , Right $ exAv "A" 5 []
-                    , Right $ exAv "B" 1 [ExFix "A" 6]
+                    , Right $ exAv "B" 1 [ExFix "A" 4]
                     ]
-                  rejecting = "rejecting: A-5.0.0 (conflict: B => A==6.0.0)"
-                  skipping = "skipping: A; 4.0.0, 3.0.0, 2.0.0 and other versions (has"
+                  rejecting = "rejecting: A-3.0.0 (conflict: B => A==4.0.0)"
+                  skipping = "skipping: A; 2.0.0 and other versions (has"
                in mkTest db "show summarized skipping versions list" ["B"] $
                     solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
           ]

--- a/changelog.d/pr-11062
+++ b/changelog.d/pr-11062
@@ -1,0 +1,8 @@
+synopsis: Solver: shorten the skipping message if needed
+packages: cabal-install-solver
+prs: #11062
+
+When the solver fails to find a solution, it can print out a long list
+of package versions which failed to meet the requirements. This PR
+shortens the message to at most 3 versions which failed to meet the
+requriements.

--- a/changelog.d/pr-11062
+++ b/changelog.d/pr-11062
@@ -4,5 +4,5 @@ prs: #11062
 
 When the solver fails to find a solution, it can print out a long list
 of package versions which failed to meet the requirements. This PR
-shortens the message to at most 3 versions which failed to meet the
-requriements.
+shortens the message price the one version that failed and the number
+of other versions which failed to meet the requriements.


### PR DESCRIPTION
Also add a test to prevent this regressing.

Closes: https://github.com/haskell/cabal/issues/4251

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
