### PR TITLE
Fix typo exsting

### DIFF
--- a/doc/cabaldomain.py
+++ b/doc/cabaldomain.py
@@ -384,7 +384,7 @@ class CabalObject(ObjectDescription):
             else:
                 return result
 
-            # find exsting field list and add to it
+            # find existing field list and add to it
             # or create new one
             for item in contents:
                 if isinstance(item, nodes.field_list):


### PR DESCRIPTION
Typo in comment.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
