### PR TITLE
Typo, seach, in comment

### DIFF
--- a/cabal-testsuite/src/Test/Cabal/NeedleHaystack.hs
+++ b/cabal-testsuite/src/Test/Cabal/NeedleHaystack.hs
@@ -145,7 +145,7 @@ data TxFwdBwd =
 txFwdBwdId :: TxFwdBwd
 txFwdBwdId = TxFwdBwd id id
 
--- | Conversions of the needle and haystack strings, the seach string and the
+-- | Conversions of the needle and haystack strings, the search string and the
 -- text to search in.
 data NeedleHaystack =
     NeedleHaystack


### PR DESCRIPTION
Typo in a haddock comment, seach.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
