### PR TITLE
Bump to hlint-3.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: haskell-actions/hlint-setup@v2
       with:
-        version: "3.8"
+        version: "3.10"
     - uses: haskell-actions/hlint-run@v2
       with:
         path: "."

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -24,10 +24,11 @@
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 19 hints
+- ignore: {name: "Redundant maybe"} # 2 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant return"} # 9 hints
-- ignore: {name: "Replace case with fromMaybe"} # 6 hints
-- ignore: {name: "Replace case with maybe"} # 11 hints
+- ignore: {name: "Replace case with fromMaybe"} # 4 hints
+- ignore: {name: "Replace case with maybe"} # 10 hints
 - ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 28 hints
@@ -40,7 +41,6 @@
 - ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use ?~"} # 1 hint
 - ignore: {name: "Use Down"} # 3 hints
-- ignore: {name: "Use Just"} # 2 hints
 - ignore: {name: "Use bimap"} # 7 hints
 - ignore: {name: "Use camelCase"} # 94 hints
 - ignore: {name: "Use catMaybes"} # 3 hints
@@ -55,7 +55,6 @@
 - ignore: {name: "Use fromMaybe"} # 5 hints
 - ignore: {name: "Use fromRight"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
-- ignore: {name: "Use if"} # 2 hints
 - ignore: {name: "Use infix"} # 20 hints
 - ignore: {name: "Use isAsciiLower"} # 2 hints
 - ignore: {name: "Use isAsciiUpper"} # 2 hints

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,13 +1,12 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
-- ignore: {name: "Avoid lambda"} # 47 hints
+- ignore: {name: "Avoid lambda"} # 50 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 23 hints
-- ignore: {name: "Eta reduce"} # 124 hints
+- ignore: {name: "Eta reduce"} # 132 hints
 - ignore: {name: "Evaluate"} # 10 hints
 - ignore: {name: "Functor law"} # 10 hints
 - ignore: {name: "Fuse concatMap/map"} # 3 hints
 - ignore: {name: "Fuse foldr/map"} # 3 hints
-- ignore: {name: "Fuse mapMaybe/map"} # 1 hint
 - ignore: {name: "Fuse traverse_/fmap"} # 1 hint
 - ignore: {name: "Fuse traverse_/map"} # 1 hint
 - ignore: {name: "Hoist not"} # 16 hints
@@ -16,11 +15,11 @@
 - ignore: {name: "Monoid law, right identity"} # 3 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Move guards forward"} # 4 hints
-- ignore: {name: "Redundant $"} # 178 hints
+- ignore: {name: "Redundant $"} # 192 hints
 - ignore: {name: "Redundant $!"} # 1 hint
-- ignore: {name: "Redundant <$>"} # 16 hints
+- ignore: {name: "Redundant <$>"} # 17 hints
 - ignore: {name: "Redundant =="} # 1 hint
-- ignore: {name: "Redundant bracket"} # 240 hints
+- ignore: {name: "Redundant bracket"} # 260 hints
 - ignore: {name: "Redundant fmap"} # 1 hint
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
@@ -28,13 +27,13 @@
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant return"} # 9 hints
 - ignore: {name: "Replace case with fromMaybe"} # 6 hints
-- ignore: {name: "Replace case with maybe"} # 10 hints
+- ignore: {name: "Replace case with maybe"} # 11 hints
 - ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
-- ignore: {name: "Use :"} # 30 hints
+- ignore: {name: "Use :"} # 28 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 87 hints
-- ignore: {name: "Use <&>"} # 14 hints
+- ignore: {name: "Use <$>"} # 86 hints
+- ignore: {name: "Use <&>"} # 15 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
 - ignore: {name: "Use =="} # 3 hints
@@ -43,19 +42,19 @@
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use Just"} # 2 hints
 - ignore: {name: "Use bimap"} # 7 hints
-- ignore: {name: "Use camelCase"} # 98 hints
+- ignore: {name: "Use camelCase"} # 94 hints
 - ignore: {name: "Use catMaybes"} # 3 hints
 - ignore: {name: "Use concatMap"} # 2 hints
-- ignore: {name: "Use const"} # 36 hints
+- ignore: {name: "Use const"} # 37 hints
 - ignore: {name: "Use elem"} # 2 hints
-- ignore: {name: "Use first"} # 4 hints
-- ignore: {name: "Use fmap"} # 25 hints
+- ignore: {name: "Use first"} # 5 hints
+- ignore: {name: "Use fmap"} # 24 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use for"} # 1 hint
 - ignore: {name: "Use forM_"} # 1 hint
-- ignore: {name: "Use fromMaybe"} # 4 hints
+- ignore: {name: "Use fromMaybe"} # 5 hints
 - ignore: {name: "Use fromRight"} # 1 hint
-- ignore: {name: "Use fst"} # 1 hint
+- ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use if"} # 2 hints
 - ignore: {name: "Use infix"} # 20 hints
 - ignore: {name: "Use isAsciiLower"} # 2 hints
@@ -63,7 +62,7 @@
 - ignore: {name: "Use isDigit"} # 2 hints
 - ignore: {name: "Use isJust"} # 1 hint
 - ignore: {name: "Use isNothing"} # 1 hint
-- ignore: {name: "Use lambda-case"} # 55 hints
+- ignore: {name: "Use lambda-case"} # 58 hints
 - ignore: {name: "Use lefts"} # 1 hint
 - ignore: {name: "Use list comprehension"} # 19 hints
 - ignore: {name: "Use list literal"} # 3 hints
@@ -74,7 +73,7 @@
 - ignore: {name: "Use max"} # 2 hints
 - ignore: {name: "Use maybe"} # 8 hints
 - ignore: {name: "Use minimumBy"} # 1 hint
-- ignore: {name: "Use newtype instead of data"} # 26 hints
+- ignore: {name: "Use newtype instead of data"} # 29 hints
 - ignore: {name: "Use notElem"} # 9 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints
@@ -82,12 +81,12 @@
 - ignore: {name: "Use replicateM_"} # 2 hints
 - ignore: {name: "Use rights"} # 2 hints
 - ignore: {name: "Use second"} # 7 hints
-- ignore: {name: "Use section"} # 17 hints
+- ignore: {name: "Use section"} # 18 hints
 - ignore: {name: "Use traverse"} # 1 hint
-- ignore: {name: "Use tuple-section"} # 28 hints
+- ignore: {name: "Use tuple-section"} # 27 hints
 - ignore: {name: "Use typeRep"} # 2 hints
 - ignore: {name: "Use uncurry"} # 1 hint
-- ignore: {name: "Use unless"} # 22 hints
+- ignore: {name: "Use unless"} # 23 hints
 - ignore: {name: "Use unwords"} # 8 hints
 - ignore: {name: "Use void"} # 23 hints
 - ignore: {name: "Use when"} # 1 hint


### PR DESCRIPTION
Bumps to `hlint-3.10` and updates the `.hlint.yaml` configuration.

---

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
