### PR TITLE
CI: validate.yml: remove the git workaround that started failing on Windows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -123,9 +123,6 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
 
-      - name: "Work around git problem https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586 (cabal PR #8546)"
-        run: git config --global protocol.file.allow always
-
       # The tool is not essential to the rest of the test suite. If
       # hackage-repo-tool is not present, any test that requires it will
       # be skipped.


### PR DESCRIPTION
I wanna see if this is still needed. 

The failure looks like this:

```shellsession
Run git config --global protocol.file.allow always
error: could not lock config file C:/msys64/home/runneradmin/.gitconfig: No such file or directory
Error: Process completed with exit code 255.
```

e.g. https://github.com/haskell/cabal/actions/runs/16415578333/job/46397611829

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
