### PR TITLE
Apply hlint suggestions with a single count

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,67 +2,55 @@
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
 - ignore: {name: "Avoid lambda"} # 50 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 23 hints
-- ignore: {name: "Eta reduce"} # 132 hints
+- ignore: {name: "Eta reduce"} # 136 hints
 - ignore: {name: "Evaluate"} # 10 hints
 - ignore: {name: "Functor law"} # 10 hints
 - ignore: {name: "Fuse concatMap/map"} # 3 hints
 - ignore: {name: "Fuse foldr/map"} # 3 hints
-- ignore: {name: "Fuse traverse_/fmap"} # 1 hint
-- ignore: {name: "Fuse traverse_/map"} # 1 hint
 - ignore: {name: "Hoist not"} # 16 hints
-- ignore: {name: "Missing NOINLINE pragma"} # 1 hint
 - ignore: {name: "Monoid law, left identity"} # 3 hints
 - ignore: {name: "Monoid law, right identity"} # 3 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Move guards forward"} # 4 hints
-- ignore: {name: "Redundant $"} # 192 hints
+- ignore: {name: "Redundant $"} # 202 hints
 - ignore: {name: "Redundant $!"} # 1 hint
-- ignore: {name: "Redundant <$>"} # 17 hints
-- ignore: {name: "Redundant =="} # 1 hint
-- ignore: {name: "Redundant bracket"} # 260 hints
-- ignore: {name: "Redundant fmap"} # 1 hint
+- ignore: {name: "Redundant <$>"} # 18 hints
+- ignore: {name: "Redundant bracket"} # 274 hints
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 19 hints
 - ignore: {name: "Redundant maybe"} # 2 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
-- ignore: {name: "Redundant return"} # 9 hints
+- ignore: {name: "Redundant return"} # 10 hints
 - ignore: {name: "Replace case with fromMaybe"} # 4 hints
 - ignore: {name: "Replace case with maybe"} # 10 hints
 - ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 28 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 86 hints
-- ignore: {name: "Use <&>"} # 15 hints
+- ignore: {name: "Use <$>"} # 88 hints
+- ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
 - ignore: {name: "Use =="} # 3 hints
 - ignore: {name: "Use >=>"} # 3 hints
-- ignore: {name: "Use ?~"} # 1 hint
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
-- ignore: {name: "Use camelCase"} # 94 hints
-- ignore: {name: "Use catMaybes"} # 3 hints
+- ignore: {name: "Use camelCase"} # 96 hints
+- ignore: {name: "Use catMaybes"} # 4 hints
 - ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 37 hints
 - ignore: {name: "Use elem"} # 2 hints
 - ignore: {name: "Use first"} # 5 hints
 - ignore: {name: "Use fmap"} # 24 hints
 - ignore: {name: "Use fold"} # 1 hint
-- ignore: {name: "Use for"} # 1 hint
-- ignore: {name: "Use forM_"} # 1 hint
 - ignore: {name: "Use fromMaybe"} # 5 hints
-- ignore: {name: "Use fromRight"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use infix"} # 20 hints
 - ignore: {name: "Use isAsciiLower"} # 2 hints
 - ignore: {name: "Use isAsciiUpper"} # 2 hints
 - ignore: {name: "Use isDigit"} # 2 hints
-- ignore: {name: "Use isJust"} # 1 hint
-- ignore: {name: "Use isNothing"} # 1 hint
 - ignore: {name: "Use lambda-case"} # 58 hints
-- ignore: {name: "Use lefts"} # 1 hint
 - ignore: {name: "Use list comprehension"} # 19 hints
 - ignore: {name: "Use list literal"} # 3 hints
 - ignore: {name: "Use list literal pattern"} # 11 hints
@@ -71,24 +59,19 @@
 - ignore: {name: "Use mapMaybe"} # 13 hints
 - ignore: {name: "Use max"} # 2 hints
 - ignore: {name: "Use maybe"} # 8 hints
-- ignore: {name: "Use minimumBy"} # 1 hint
-- ignore: {name: "Use newtype instead of data"} # 29 hints
+- ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use notElem"} # 9 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints
-- ignore: {name: "Use replicateM"} # 1 hint
 - ignore: {name: "Use replicateM_"} # 2 hints
 - ignore: {name: "Use rights"} # 2 hints
 - ignore: {name: "Use second"} # 7 hints
 - ignore: {name: "Use section"} # 18 hints
-- ignore: {name: "Use traverse"} # 1 hint
-- ignore: {name: "Use tuple-section"} # 27 hints
+- ignore: {name: "Use tuple-section"} # 28 hints
 - ignore: {name: "Use typeRep"} # 2 hints
-- ignore: {name: "Use uncurry"} # 1 hint
 - ignore: {name: "Use unless"} # 23 hints
 - ignore: {name: "Use unwords"} # 8 hints
 - ignore: {name: "Use void"} # 23 hints
-- ignore: {name: "Use when"} # 1 hint
 
 - arguments:
     - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs

--- a/Cabal-syntax/src/Distribution/Compat/Parsing.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Parsing.hs
@@ -58,6 +58,7 @@ import Control.Monad.Trans.Writer.Lazy as Lazy
 import Control.Monad.Trans.Writer.Strict as Strict
 import Data.Foldable (asum)
 
+import Control.Monad (replicateM)
 import qualified Data.List.NonEmpty as NE
 import qualified Text.Parsec as Parsec
 
@@ -141,7 +142,7 @@ endBy p sep = many (p <* sep)
 count :: Applicative m => Int -> m a -> m [a]
 count n p
   | n <= 0 = pure []
-  | otherwise = sequenceA (replicate n p)
+  | otherwise = replicateM n p
 {-# INLINE count #-}
 
 -- | @chainr p op x@ parses /zero/ or more occurrences of @p@,

--- a/Cabal-tests/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Version.hs
@@ -195,7 +195,7 @@ prop_anyVersion v' =
 
 prop_noVersion :: Version -> Bool
 prop_noVersion v' =
-  withinRange v' noVersion == False
+  not (withinRange v' noVersion)
 
 prop_thisVersion :: Version -> Version -> Bool
 prop_thisVersion v v' =

--- a/Cabal/src/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/src/Distribution/Simple/BuildPaths.hs
@@ -320,7 +320,7 @@ getSourceFiles
   -> [SymbolicPathX allowAbsolute Pkg (Dir Source)]
   -> [ModuleName.ModuleName]
   -> IO [(ModuleName.ModuleName, SymbolicPathX allowAbsolute Pkg File)]
-getSourceFiles verbosity mbWorkDir dirs modules = flip traverse modules $ \m ->
+getSourceFiles verbosity mbWorkDir dirs modules = for modules $ \m ->
   fmap ((,) m) $
     findFileCwdWithExtension
       mbWorkDir

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -883,7 +883,7 @@ configurePackage cfg lbc0 pkg_descr00 flags enabled comp platform programDb0 pac
             let unknownBuildTools =
                   [ buildTool
                   | buildTool <- buildTools bi
-                  , Nothing == desugarBuildTool pkg_descr0 buildTool
+                  , isNothing (desugarBuildTool pkg_descr0 buildTool)
                   ]
             externBuildToolDeps ++ unknownBuildTools
 
@@ -2766,7 +2766,7 @@ checkPackageProblems verbosity dir gpkg pkg = do
       (errors, warnings) =
         partitionEithers (M.mapMaybe classEW $ pureChecks ++ ioChecks)
   if null errors
-    then traverse_ (warn verbosity) (map ppPackageCheck warnings)
+    then traverse_ (warn verbosity . ppPackageCheck) warnings
     else dieWithException verbosity $ CheckPackageProblems (map ppPackageCheck errors)
   where
     -- Classify error/warnings. Left: error, Right: warning.
@@ -2836,22 +2836,19 @@ checkRelocatable verbosity pkg lbi =
         p = prefix installDirs
         relativeInstallDirs (InstallDirs{..}) =
           all
-            isJust
-            ( fmap
-                (stripPrefix p)
-                [ bindir
-                , libdir
-                , dynlibdir
-                , libexecdir
-                , includedir
-                , datadir
-                , docdir
-                , mandir
-                , htmldir
-                , haddockdir
-                , sysconfdir
-                ]
-            )
+            (isJust . stripPrefix p)
+            [ bindir
+            , libdir
+            , dynlibdir
+            , libexecdir
+            , includedir
+            , datadir
+            , docdir
+            , mandir
+            , htmldir
+            , haddockdir
+            , sysconfdir
+            ]
 
     -- Check if the library dirs of the dependencies that are in the package
     -- database to which the package is installed are relative to the

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -537,7 +537,7 @@ buildOrReplLib mReplFlags verbosity numJobs _pkg_descr lbi lib clbi = do
       whenStaticLib forceStatic =
         when (forceStatic || withStaticLib lbi)
       -- whenGHCiLib = when (withGHCiLib lbi)
-      forRepl = maybe False (const True) mReplFlags
+      forRepl = isJust mReplFlags
       -- ifReplLib = when forRepl
       comp = compiler lbi
       implInfo = getImplInfo comp

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -89,7 +89,7 @@ import Distribution.Version
 
 import Control.Monad
 import Data.Bool (bool)
-import Data.Either (rights)
+import Data.Either (lefts, rights)
 import System.Directory (doesDirectoryExist, doesFileExist)
 import System.FilePath (isAbsolute, normalise)
 import System.IO (hClose, hPutStrLn, hSetEncoding, utf8)
@@ -1386,7 +1386,7 @@ haddockPackagePaths ipkgs mkHtmlPath = do
       , pkgName pkgid `notElem` noHaddockWhitelist
       ]
 
-  let missing = [pkgid | Left pkgid <- interfaces]
+  let missing = lefts interfaces
       warning =
         "The following packages have no Haddock documentation "
           ++ "installed. No links will be generated to these packages: "

--- a/cabal-install/src/Distribution/Client/BuildReports/Upload.hs
+++ b/cabal-install/src/Distribution/Client/BuildReports/Upload.hs
@@ -21,6 +21,7 @@ import Network.TCP (HandleStream)
 -}
 import Network.URI (URI, uriPath) -- parseRelativeReference, relativeTo)
 
+import Data.Foldable (forM_)
 import Distribution.Client.BuildReports.Anonymous (BuildReport, showBuildReport)
 import qualified Distribution.Client.BuildReports.Anonymous as BuildReport
 import Distribution.Client.Errors
@@ -41,9 +42,7 @@ uploadReports :: Verbosity -> RepoContext -> Auth -> URI -> [(BuildReport, Maybe
 uploadReports verbosity repoCtxt auth uri reports = do
   for_ reports $ \(report, mbBuildLog) -> do
     buildId <- postBuildReport verbosity repoCtxt auth uri report
-    case mbBuildLog of
-      Just buildLog -> putBuildLog verbosity repoCtxt auth buildId buildLog
-      Nothing -> return ()
+    forM_ mbBuildLog (putBuildLog verbosity repoCtxt auth buildId)
 
 postBuildReport :: Verbosity -> RepoContext -> Auth -> URI -> BuildReport -> IO BuildReportId
 postBuildReport verbosity repoCtxt auth uri buildReport = do

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -266,9 +266,7 @@ outdatedAction flags targetStrings globalFlags =
               (ListOutdatedSettings ignorePred minorPred)
       when (not quiet) $
         showResult verbosity outdatedDeps simpleOutput
-      if exitCode && (not . null $ outdatedDeps)
-        then exitFailure
-        else return ()
+      when (exitCode && (not . null $ outdatedDeps)) exitFailure
   where
     OutdatedFlags{..} = extraFlags flags
     verbosity =

--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -297,8 +297,9 @@ replAction flags@NixStyleFlags{extraFlags = r@ReplFlags{..}, ..} targetStrings g
         let
           sourcePackage =
             fakeProjectSourcePackage projectRoot
-              & lSrcpkgDescription . L.condLibrary
-                .~ Just (CondNode library [baseDep] [])
+              & ( (lSrcpkgDescription . L.condLibrary)
+                    ?~ (CondNode library [baseDep] [])
+                )
           library = emptyLibrary{libBuildInfo = lBuildInfo}
           lBuildInfo =
             emptyBuildInfo

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -296,10 +296,7 @@ establishProjectBaseContextWithRoot verbosity cliConfig projectRoot currentComma
         } = projectConfigShared projectConfig
 
       mlogsDir = Setup.flagToMaybe projectConfigLogsDir
-  mstoreDir <-
-    sequenceA $
-      makeAbsolute
-        <$> Setup.flagToMaybe projectConfigStoreDir
+  mstoreDir <- traverse makeAbsolute (Setup.flagToMaybe projectConfigStoreDir)
 
   cabalDirLayout <- mkCabalDirLayout mstoreDir mlogsDir
 

--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -68,6 +68,7 @@ import Prelude ()
 
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BS
+import Data.Either (fromRight)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
@@ -768,7 +769,7 @@ readPackagesUpToDateCacheFile DistDirLayout{distProjectCacheFile} =
       withBinaryFile (distProjectCacheFile "up-to-date") ReadMode $ \hnd ->
         Binary.decodeOrFailIO =<< BS.hGetContents hnd
   where
-    handleDecodeFailure = fmap (either (const Set.empty) id)
+    handleDecodeFailure = fmap (fromRight Set.empty)
 
 -- | Helper for writing the package up-to-date cache file.
 --

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1191,9 +1191,9 @@ getPackageSourceHashes verbosity withRepoCtx solverPlan = do
 
   (repoTarballPkgsWithMetadata, repoTarballPkgsToDownloadWithMeta) <- fmap partitionEithers $
     liftIO $
-      withRepoCtx $ \repoctx -> flip concatMapM (Map.toList repoTarballPkgsWithMetadataUnvalidatedMap) $
-        \(repo, pkgids) ->
-          verifyFetchedTarballs verbosity repoctx repo pkgids
+      withRepoCtx $ \repoctx ->
+        flip concatMapM (Map.toList repoTarballPkgsWithMetadataUnvalidatedMap) $
+          uncurry (verifyFetchedTarballs verbosity repoctx)
 
   -- For tarballs from repos that do not have hashes available we now have
   -- to check if the packages were downloaded already.

--- a/cabal-install/src/Distribution/Client/Run.hs
+++ b/cabal-install/src/Distribution/Client/Run.hs
@@ -80,7 +80,7 @@ splitRunArgs verbosity lbi args =
             " Interpreting all parameters to `run` as a parameter to"
               ++ " the default executable."
       -- If there is a warning, print it together with the addition.
-      warn verbosity `traverse_` fmap (++ addition) maybeWarning
+      traverse_ (warn verbosity . (++ addition)) maybeWarning
       return (exe, xs)
   where
     pkg_descr = localPkgDescr lbi

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -239,6 +239,7 @@ logDirChange l (Just d) m = do
 -- program, so unsafePerformIO is safe here.
 numberOfProcessors :: Int
 numberOfProcessors = unsafePerformIO getNumProcessors
+{-# NOINLINE numberOfProcessors #-}
 
 -- | Determine the number of jobs to use given the value of the '-j' flag.
 determineNumJobs :: Flag (Maybe Int) -> Int

--- a/cabal-install/src/Distribution/Deprecated/ViewAsFieldDescr.hs
+++ b/cabal-install/src/Distribution/Deprecated/ViewAsFieldDescr.hs
@@ -5,7 +5,7 @@ module Distribution.Deprecated.ViewAsFieldDescr
 import Distribution.Client.Compat.Prelude hiding (get)
 import Prelude ()
 
-import qualified Data.List.NonEmpty as NE
+import Data.Foldable (minimumBy)
 import Distribution.ReadE (parsecToReadE)
 import Distribution.Simple.Command
 import Text.PrettyPrint (cat, comma, punctuate, text)
@@ -20,7 +20,7 @@ viewAsFieldDescr (OptionField _n []) =
   error "Distribution.command.viewAsFieldDescr: unexpected"
 viewAsFieldDescr (OptionField n (d : dd)) = FieldDescr n get set
   where
-    optDescr = head $ NE.sortBy cmp (d :| dd)
+    optDescr = minimumBy cmp (d :| dd)
 
     cmp :: OptDescr a -> OptDescr a -> Ordering
     ReqArg{} `cmp` ReqArg{} = EQ


### PR DESCRIPTION
See #9110. Apply hlint suggestions with a single count so that these warnings are no longer ignored and will be picked up by our CI linting.

I left one or two single count warnings that didn't have a small diff or that I didn't think would be otherwise easy to review.

Each applied suggestion is an individual commit but I'll squash these if this pull request is approved.

When reviewing #8889, we noticed that plenty of hlint suggestions were being ignored in `.hlint.yaml` that would have been triggered for new modules and new code of #8889.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
