### PR TITLE
Typo in Makefile .PHONY target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ custom-setup-tests :
 hackage-parsec-tests :
 	$(CABALRUN) hackage-tests -- parsec +RTS -s -qg -I0 -A64M -N${THREADS} -RTS ${TEST}
 
-.PHONY: hackage-rountrip-tests
+.PHONY: hackage-roundtrip-tests
 hackage-roundtrip-tests :
 	$(CABALRUN) hackage-tests -- roundtrip +RTS -s -qg -I0 -A64M -N${THREADS} -RTS ${TEST}
 


### PR DESCRIPTION
A follow on from #9845. Fix a typo in `.PHONY hackage-roundtrip-tests`.

---

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
