### PR TITLE
Update Hackage root keys

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -935,6 +935,8 @@ defaultHackageRemoteRepoKeys =
     "be75553f3c7ba1dbe298da81f1d1b05c9d39dd8ed2616c9bddf1525ca8c03e48"
   , -- Joachim Breitner (5iUgwqZCWrCJktqMx0bBMIuoIyT4A1RYGozzchRN9rA=)
     "d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522"
+  , -- Tikhon Jelvis (06nM6r1kOYt49YE5e1+j8VKiiYUFjFQ6HrOpPZu+fDE=)
+    "c7de58fc6a224b92b5b513f26fbb8b370f2d97c7cfe0075a951314a55734be93"
   ]
 
 -- | The required threshold of root key signatures for hackage.haskell.org

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -931,8 +931,6 @@ defaultHackageRemoteRepoKeys =
     "0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d"
   , -- Norman Ramsey (ZI8di3a9Un0s2RBrt5GwVRvfOXVuywADfXGPZfkiDb0=)
     "51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921"
-  , -- Mathieu Boespflug (ydN1nGGQ79K1Q0nN+ul+Ln8MxikTB95w0YdGd3v3kmg=)
-    "be75553f3c7ba1dbe298da81f1d1b05c9d39dd8ed2616c9bddf1525ca8c03e48"
   , -- Joachim Breitner (5iUgwqZCWrCJktqMx0bBMIuoIyT4A1RYGozzchRN9rA=)
     "d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522"
   , -- Tikhon Jelvis (06nM6r1kOYt49YE5e1+j8VKiiYUFjFQ6HrOpPZu+fDE=)

--- a/changelog.d/pr-11095.md
+++ b/changelog.d/pr-11095.md
@@ -1,0 +1,12 @@
+synopsis: Update Hackage root key set
+packages: cabal-install
+prs: #11095
+
+description: {
+
+One new [Hackage root keyholder](https://github.com/haskell-infra/hackage-root-keys/tree/master/root-keys) was added to the bootstrap set and one was removed.
+
+- Added Hackage root key for Tikhon Jelvis
+- Removed Hackage root key for Mathieu Boespflug
+
+}


### PR DESCRIPTION
Hackage Security has one new key and one key needing removal. The new root.json should go live on hackage in the next week.

The new root.json is here: https://github.com/haskell-infra/hackage-root-keys/pull/23 is you want to compare the key signatures.

See https://github.com/haskell/cabal/pull/9068 for a prior MR in this series.

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.
* [N/A] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [N/A] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)