### PR TITLE
Satisfy HLint suggestions for isDigit and isAscii

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -47,9 +47,6 @@
 - ignore: {name: "Use fromMaybe"} # 5 hints
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use infix"} # 20 hints
-- ignore: {name: "Use isAsciiLower"} # 2 hints
-- ignore: {name: "Use isAsciiUpper"} # 2 hints
-- ignore: {name: "Use isDigit"} # 2 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
 - ignore: {name: "Use list comprehension"} # 19 hints
 - ignore: {name: "Use list literal"} # 3 hints

--- a/Cabal-syntax/src/Distribution/Utils/Generic.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Generic.hs
@@ -85,6 +85,7 @@ module Distribution.Utils.Generic
 import Distribution.Compat.Prelude
 import Prelude ()
 
+import Data.Char (isAsciiLower, isAsciiUpper)
 import Distribution.Utils.String
 
 import Data.Bits (shiftL, (.&.), (.|.))
@@ -449,9 +450,7 @@ isAscii c = fromEnum c < 0x80
 
 -- | Ascii letters.
 isAsciiAlpha :: Char -> Bool
-isAsciiAlpha c =
-  ('a' <= c && c <= 'z')
-    || ('A' <= c && c <= 'Z')
+isAsciiAlpha c = (isAsciiLower c) || (isAsciiUpper c)
 
 -- | Ascii letters and digits.
 --

--- a/Cabal/src/Distribution/Simple/FileMonitor/Types.hs
+++ b/Cabal/src/Distribution/Simple/FileMonitor/Types.hs
@@ -39,6 +39,7 @@ import Distribution.Simple.Glob.Internal
 import qualified Distribution.Compat.CharParsing as P
 import Distribution.Parsec
 import Distribution.Pretty
+import Distribution.Utils.Generic (isAsciiAlpha)
 import qualified Text.PrettyPrint as Disp
 
 --------------------------------------------------------------------------------
@@ -211,7 +212,7 @@ instance Parsec FilePathRoot where
       root = FilePathRoot "/" <$ P.char '/'
       home = FilePathHomeDir <$ P.string "~/"
       drive = do
-        dr <- P.satisfy $ \c -> (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        dr <- P.satisfy isAsciiAlpha
         _ <- P.char ':'
         _ <- P.char '/' <|> P.char '\\'
         return (FilePathRoot (toUpper dr : ":\\"))

--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -629,14 +629,13 @@ gitProgram =
           -- or annoyingly "git version 2.17.1.windows.2" yes, really
           (_ : _ : ver : _) ->
             intercalate "."
-              . takeWhile (all isNum)
+              . takeWhile (all isDigit)
               . split
               $ ver
           _ -> ""
     }
   where
-    isNum c = c >= '0' && c <= '9'
-    isTypical c = isNum c || c == '.'
+    isTypical c = isDigit c || c == '.'
     split cs = case break (== '.') cs of
       (chunk, []) -> chunk : []
       (chunk, _ : rest) -> chunk : split rest
@@ -924,5 +923,4 @@ pijulProgram =
           _ -> ""
     }
   where
-    isNum c = c >= '0' && c <= '9'
-    isTypical c = isNum c || c == '.'
+    isTypical c = isDigit c || c == '.'


### PR DESCRIPTION
See #9110. After #11093 merged, I started on suggestions with a two count so that these warnings are no longer ignored and will be picked up by our CI linting.

I stopped short of doing all of these as the suggested is digit and is ASCII changes lead me to another change to reuse `isAsciiAlpha` and because I'm unsure about when and why base functions should be added to `module Distribution.Compat.Prelude`.

https://github.com/haskell/cabal/blob/9b26df8689a0d22751dfd2cd6e468d50974a048e/Cabal-syntax/src/Distribution/Compat/Prelude.hs#L6-L11

https://github.com/haskell/cabal/blob/9b26df8689a0d22751dfd2cd6e468d50974a048e/Cabal-syntax/src/Distribution/Compat/Prelude.hs#L137-L140

I also removed `isNum`, using `isDigit` instead in `module Distribution.Client.VCS`.

Each applied suggestion is an individual commit but I'll squash these if this pull request is approved.

---

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
