### PR TITLE
Follow hlint suggestion: use infix

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -45,7 +45,6 @@
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fromMaybe"} # 5 hints
 - ignore: {name: "Use fst"} # 2 hints
-- ignore: {name: "Use infix"} # 27 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
 - ignore: {name: "Use list comprehension"} # 19 hints
 - ignore: {name: "Use list literal"} # 3 hints

--- a/Cabal-syntax/src/Distribution/Types/VersionInterval/Legacy.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval/Legacy.hs
@@ -309,7 +309,7 @@ unionVersionIntervals
   -> VersionIntervals
   -> VersionIntervals
 unionVersionIntervals (VersionIntervals is0) (VersionIntervals is'0) =
-  checkInvariant (VersionIntervals (union is0 is'0))
+  checkInvariant (VersionIntervals (is0 `union` is'0))
   where
     union is [] = is
     union [] is' = is'
@@ -317,11 +317,11 @@ unionVersionIntervals (VersionIntervals is0) (VersionIntervals is'0) =
       -- @i < i'@ and separated: keep @i@.
       Left Nothing -> i : union is (i' : is')
       -- @i'' = i ∪ i'@ and @i@ ends first: drop @i@, replace @i'@ by @i''@.
-      Left (Just i'') -> union is (i'' : is')
+      Left (Just i'') -> is `union` (i'' : is')
       -- @i' < i@ and separated: keep @i'@.
       Right Nothing -> i' : union (i : is) is'
       -- @i'' = i ∪ i'@ and @i'@ ends first: drop @i'@, replace @i@ by @i''@.
-      Right (Just i'') -> union (i'' : is) is'
+      Right (Just i'') -> (i'' : is) `union` is'
 
 -- | Given two version intervals @i1@ and @i2@, return one of the following:
 --
@@ -364,17 +364,17 @@ intersectVersionIntervals
   -> VersionIntervals
   -> VersionIntervals
 intersectVersionIntervals (VersionIntervals is0) (VersionIntervals is'0) =
-  checkInvariant (VersionIntervals (intersect is0 is'0))
+  checkInvariant (VersionIntervals (is0 `intersect` is'0))
   where
     intersect _ [] = []
     intersect [] _ = []
     intersect (i : is) (i' : is') = case intersectInterval i i' of
       -- @i < i'@: throw out @i@
-      Left Nothing -> intersect is (i' : is')
+      Left Nothing -> is `intersect` (i' : is')
       -- @i'' = i /\ i'@ and @i@ ends first: replace @i@ by @i''@.
       Left (Just i'') -> i'' : intersect is (i' : is')
       -- @i' < i@: throw out @i'@
-      Right Nothing -> intersect (i : is) is'
+      Right Nothing -> (i : is) `intersect` is'
       -- @i'' = i /\ i'@ and @i'@ ends first: replace @i'@ by @i''@.
       Right (Just i'') -> i'' : intersect (i : is) is'
 

--- a/Cabal-syntax/src/Distribution/Types/VersionRange.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange.hs
@@ -96,12 +96,12 @@ foldVersionRange _any this later earlier union intersect = fold
 
     alg (ThisVersionF v) = this v
     alg (LaterVersionF v) = later v
-    alg (OrLaterVersionF v) = union (this v) (later v)
+    alg (OrLaterVersionF v) = this v `union` later v
     alg (EarlierVersionF v) = earlier v
-    alg (OrEarlierVersionF v) = union (this v) (earlier v)
+    alg (OrEarlierVersionF v) = this v `union` earlier v
     alg (MajorBoundVersionF v) = fold (majorBound v)
-    alg (UnionVersionRangesF v1 v2) = union v1 v2
-    alg (IntersectVersionRangesF v1 v2) = intersect v1 v2
+    alg (UnionVersionRangesF v1 v2) = v1 `union` v2
+    alg (IntersectVersionRangesF v1 v2) = v1 `intersect` v2
 
     majorBound v =
       intersectVersionRanges

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -423,7 +423,7 @@ checkPackageDescription
     -- But it is OK for executables to have the same name.
     nsubs <- asksCM (pnSubLibs . ccNames)
     checkP
-      (elem (prettyShow pn) (prettyShow <$> nsubs))
+      (prettyShow pn `elem` (prettyShow <$> nsubs))
       (PackageBuildImpossible $ IllegalLibraryName pn)
 
     -- § Fields check.

--- a/Cabal/src/Distribution/PackageDescription/Check/Conditional.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Conditional.hs
@@ -92,7 +92,7 @@ annotateCondTree fs ta (CondNode a c bs) =
     -- \*off* by default.
     isPkgFlagCond :: Condition ConfVar -> Bool
     isPkgFlagCond (Lit _) = False
-    isPkgFlagCond (Var (PackageFlag f)) = elem f defOffFlags
+    isPkgFlagCond (Var (PackageFlag f)) = f `elem` defOffFlags
     isPkgFlagCond (Var _) = False
     isPkgFlagCond (CNot cn) = not (isPkgFlagCond cn)
     isPkgFlagCond (CAnd ca cb) = isPkgFlagCond ca || isPkgFlagCond cb

--- a/Cabal/src/Distribution/PackageDescription/Check/Target.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Target.hs
@@ -692,7 +692,7 @@ checkAutogenModules ams bi = do
   -- PackageBuildImpossible and not merely PackageDistInexcusable.
   checkSpecVer
     CabalSpecV3_12
-    (elem autoInfoModuleName allModsForAuto)
+    (autoInfoModuleName `elem` allModsForAuto)
     (PackageBuildImpossible CVAutogenPackageInfoGuard)
   where
     allModsForAuto :: [ModuleName]

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -711,7 +711,7 @@ computeLocalBuildConfig cfg comp programDb = do
             -- rely on them. By the time that bug was fixed, ghci had
             -- been changed to read shared libraries instead of archive
             -- files (see next code block).
-            notElem (GHC.compilerBuildWay comp) [DynWay, ProfDynWay]
+            GHC.compilerBuildWay comp `notElem` [DynWay, ProfDynWay]
           CompilerId GHCJS _ ->
             not (GHCJS.isDynamic comp)
           _ -> False

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -726,7 +726,7 @@ extractRtsInfo lbi =
 -- threaded RTS. This is used to determine which RTS to link against when
 -- building a foreign library with a GHC without support for @-flink-rts@.
 hasThreaded :: BuildInfo -> Bool
-hasThreaded bi = elem "-threaded" ghc
+hasThreaded bi = "-threaded" `elem` ghc
   where
     PerCompilerFlavor ghc _ = options bi
 

--- a/Cabal/src/Distribution/Simple/GHC/Build/Utils.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Utils.hs
@@ -74,17 +74,21 @@ withDynFLib flib =
     ForeignLibTypeUnknown ->
       cabalBug "unknown foreign lib type"
 
+-- | Is the extension of the file in the list of extensions?
+extensionIn :: [String] -> FilePath -> Bool
+extensionIn exts fp = takeExtension fp `elem` exts
+
 -- | Is this file a C++ source file, i.e. ends with .cpp, .cxx, or .c++?
 isCxx :: FilePath -> Bool
-isCxx fp = elem (takeExtension fp) [".cpp", ".cxx", ".c++"]
+isCxx = extensionIn [".cpp", ".cxx", ".c++"]
 
 -- | Is this a C source file, i.e. ends with .c?
 isC :: FilePath -> Bool
-isC fp = elem (takeExtension fp) [".c"]
+isC = extensionIn [".c"]
 
 -- | FilePath has a Haskell extension: .hs or .lhs
 isHaskell :: FilePath -> Bool
-isHaskell fp = elem (takeExtension fp) [".hs", ".lhs"]
+isHaskell = extensionIn [".hs", ".lhs"]
 
 -- | Returns True if the modification date of the given source file is newer than
 -- the object file we last compiled for it, or if no object file exists yet.

--- a/Cabal/src/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Simple/LocalBuildInfo.hs
@@ -320,7 +320,7 @@ depLibraryPaths
     -- because you never have any internal libraries in this case;
     -- they're all external.
     let external_ipkgs = filter is_external (allPackages installed)
-        is_external ipkg = notElem (installedUnitId ipkg) internalDeps
+        is_external ipkg = installedUnitId ipkg `notElem` internalDeps
         -- First look for dynamic libraries in `dynamic-library-dirs`, and use
         -- `library-dirs` as a fall back.
         getDynDir pkg = case Installed.libraryDynDirs pkg of

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -331,7 +331,7 @@ installCommand =
     }
   where
     -- install doesn't take installDirs flags, since it always installs into the store in a fixed way.
-    notInstallDirOpt x = notElem (optionName x) installDirOptNames
+    notInstallDirOpt x = optionName x `notElem` installDirOptNames
     installDirOptNames = map optionName installDirsOptions
 
 -- | The @install@ command actually serves four different needs. It installs:

--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -179,7 +179,7 @@ updateAction flags@NixStyleFlags{..} extraArgs globalFlags = do
       unless (null updateRepoRequests) $ do
         let remoteRepoNames = map repoName repos
             unknownRepos =
-              [ r | (UpdateRequest r _) <- updateRepoRequests, notElem r remoteRepoNames
+              [ r | (UpdateRequest r _) <- updateRepoRequests, r `notElem` remoteRepoNames
               ]
         unless (null unknownRepos) $
           dieWithException verbosity $

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -782,7 +782,7 @@ checkPrintPlan
     -- likely to be broken. We exclude packages that are already broken.
     let newBrokenPkgs =
           filter
-            (\p -> notElem (Installed.installedUnitId p) excluded)
+            (\p -> Installed.installedUnitId p `notElem` excluded)
             (PackageIndex.reverseDependencyClosure installed reinstalledPkgs)
     let containsReinstalls = not (null reinstalledPkgs)
     let breaksPkgs = not (null newBrokenPkgs)

--- a/cabal-install/src/Distribution/Client/Types/AllowNewer.hs
+++ b/cabal-install/src/Distribution/Client/Types/AllowNewer.hs
@@ -214,7 +214,7 @@ isRelaxDeps RelaxDepsAll = True
 -- | A smarter 'RelaxedDepsSome', @*:*@ is the same as @all@.
 mkRelaxDepSome :: [RelaxedDep] -> RelaxDeps
 mkRelaxDepSome xs
-  | elem (RelaxedDep RelaxDepScopeAll RelaxDepModNone RelaxDepSubjectAll) xs =
+  | RelaxedDep RelaxDepScopeAll RelaxDepModNone RelaxDepSubjectAll `elem` xs =
       RelaxDepsAll
   | otherwise =
       RelaxDepsSome xs

--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -745,7 +745,7 @@ getDirectoryContentsRecursive ignore dir0 dir = do
         isdir <- doesDirectoryExist (dir0 </> dir </> entry)
         return (dir </> entry, isdir)
       | entry <- entries
-      , not (isPrefixOf "." entry)
+      , not ("." `isPrefixOf` entry)
       , (dir </> entry) `Set.notMember` ignore
       ]
   let subdirs = [d | (d, True) <- entries']


### PR DESCRIPTION
See #9110. Discharges and no longer ignores the "Use infix"  warning so that it will be picked up by our CI linting.

A follow on from #11135, from a code review suggestion from @ulysses4ever  to use `notElem` infix, https://github.com/haskell/cabal/pull/11135#discussion_r2260410277.

After following the suggestions, I made a couple of additional changes, adding an `extensionIn` function and reusing the `hasThreaded` function.

I'll squash commits before applying the merge label if this pull request is approved.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
