### PR TITLE
CI: don't run FreeBSD job on branches outside the haskell org

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -787,7 +787,7 @@ jobs:
     name: Test FreeBSD x86_64
     runs-on: [self-hosted, FreeBSD, X64]
     needs: ["build-freebsd-x86_64"]
-    if: ${{ inputs.test }}
+    if: ${{ inputs.test }} && contains(github.repository, 'haskell/')
     env:
       ADD_CABAL_ARGS: ""
       ARTIFACT: "x86_64-portbld-freebsd"


### PR DESCRIPTION
Investigating #11145 . No luck so far, and I'm out of ideas.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
