### PR TITLE
HLint list literals

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -48,8 +48,6 @@
 - ignore: {name: "Use infix"} # 27 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
 - ignore: {name: "Use list comprehension"} # 19 hints
-- ignore: {name: "Use list literal"} # 3 hints
-- ignore: {name: "Use list literal pattern"} # 11 hints
 - ignore: {name: "Use map once"} # 7 hints
 - ignore: {name: "Use map with tuple-section"} # 3 hints
 - ignore: {name: "Use mapMaybe"} # 13 hints

--- a/Cabal-syntax/src/Distribution/ModuleName.hs
+++ b/Cabal-syntax/src/Distribution/ModuleName.hs
@@ -116,7 +116,7 @@ components :: ModuleName -> [String]
 components mn = split (unModuleName mn)
   where
     split cs = case break (== '.') cs of
-      (chunk, []) -> chunk : []
+      (chunk, []) -> [chunk]
       (chunk, _ : rest) -> chunk : split rest
 
 -- | Convert a module name to a file path, but without any file extension.

--- a/Cabal-syntax/src/Distribution/Types/Version.hs
+++ b/Cabal-syntax/src/Distribution/Types/Version.hs
@@ -141,13 +141,13 @@ mkVersion :: [Int] -> Version
 -- TODO: add validity check; disallow 'mkVersion []' (we have
 -- 'nullVersion' for that)
 mkVersion [] = nullVersion
-mkVersion (v1 : [])
+mkVersion [v1]
   | inWord16VerRep1 v1 = PV0 (mkWord64VerRep1 v1)
   | otherwise = PV1 v1 []
   where
     inWord16VerRep1 x1 = inWord16 (x1 .|. (x1 + 1))
     mkWord64VerRep1 y1 = mkWord64VerRep (y1 + 1) 0 0 0
-mkVersion (v1 : vs@(v2 : []))
+mkVersion (v1 : vs@[v2])
   | inWord16VerRep2 v1 v2 = PV0 (mkWord64VerRep2 v1 v2)
   | otherwise = PV1 v1 vs
   where
@@ -159,7 +159,7 @@ mkVersion (v1 : vs@(v2 : []))
             .|. (x2 + 1)
         )
     mkWord64VerRep2 y1 y2 = mkWord64VerRep (y1 + 1) (y2 + 1) 0 0
-mkVersion (v1 : vs@(v2 : v3 : []))
+mkVersion (v1 : vs@[v2, v3])
   | inWord16VerRep3 v1 v2 v3 = PV0 (mkWord64VerRep3 v1 v2 v3)
   | otherwise = PV1 v1 vs
   where
@@ -173,7 +173,7 @@ mkVersion (v1 : vs@(v2 : v3 : []))
             .|. (x3 + 1)
         )
     mkWord64VerRep3 y1 y2 y3 = mkWord64VerRep (y1 + 1) (y2 + 1) (y3 + 1) 0
-mkVersion (v1 : vs@(v2 : v3 : v4 : []))
+mkVersion (v1 : vs@[v2, v3, v4])
   | inWord16VerRep4 v1 v2 v3 v4 = PV0 (mkWord64VerRep4 v1 v2 v3 v4)
   | otherwise = PV1 v1 vs
   where

--- a/Cabal-syntax/src/Distribution/Types/VersionRange.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange.hs
@@ -183,7 +183,7 @@ isAnyVersionLight _vr = False
 isWildcardRange :: Version -> Version -> Bool
 isWildcardRange ver1 ver2 = check (versionNumbers ver1) (versionNumbers ver2)
   where
-    check (n : []) (m : []) | n + 1 == m = True
+    check [n] [m] | n + 1 == m = True
     check (n : ns) (m : ms) | n == m = check ns ms
     check _ _ = False
 

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -230,7 +230,7 @@ getOpt' ordering optDescr (arg : args) = procNextOpt opt ordering
 
 -- take a look at the next cmd line arg and decide what to do with it
 getNext :: String -> [String] -> [OptDescr a] -> (OptKind a, [String])
-getNext ('-' : '-' : []) rest _ = (EndOfOpts, rest)
+getNext ['-', '-'] rest _ = (EndOfOpts, rest)
 getNext ('-' : '-' : xs) rest optDescr = longOpt xs rest optDescr
 getNext ('-' : x : xs) rest optDescr = shortOpt x xs rest optDescr
 getNext a rest _ = (NonOpt a, rest)

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -905,8 +905,8 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
         , if null (ghcOptInstantiatedWith opts)
             then []
             else
-              "-instantiated-with"
-                : intercalate
+              [ "-instantiated-with"
+              , intercalate
                   ","
                   ( map
                       ( \(n, m) ->
@@ -916,7 +916,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
                       )
                       (ghcOptInstantiatedWith opts)
                   )
-                : []
+              ]
         , concat [["-fno-code", "-fwrite-interface"] | flagBool ghcOptNoCode]
         , ["-hide-all-packages" | flagBool ghcOptHideAllPackages]
         , ["-Wmissing-home-modules" | flagBool ghcOptWarnMissingHomeModules]

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -1594,7 +1594,7 @@ createDirectoryIfMissingVerbose verbosity create_parents path0
     parents = reverse . scanl1 (</>) . splitDirectories . normalise
 
     createDirs [] = return ()
-    createDirs (dir : []) = createDir dir throwIO
+    createDirs [dir] = createDir dir throwIO
     createDirs (dir : dirs) =
       createDir dir $ \_ -> do
         createDirs dirs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -2104,5 +2104,5 @@ monoidFieldParsec name showF readF get' set =
 showTokenQ :: String -> Doc
 showTokenQ "" = Disp.empty
 showTokenQ x@('-' : '-' : _) = Disp.text (show x)
-showTokenQ x@('.' : []) = Disp.text (show x)
+showTokenQ x@['.'] = Disp.text (show x)
 showTokenQ x = showToken x

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -1496,9 +1496,9 @@ dieOnBuildFailures verbosity currentCommand plan buildOutcomes
     renderDependencyOf pkgid =
       case ultimateDeps pkgid of
         [] -> ""
-        (p1 : []) ->
+        [p1] ->
           " (which is required by " ++ elabPlanPackageName verbosity p1 ++ ")"
-        (p1 : p2 : []) ->
+        [p1, p2] ->
           " (which is required by "
             ++ elabPlanPackageName verbosity p1
             ++ " and "

--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -637,7 +637,7 @@ gitProgram =
   where
     isTypical c = isDigit c || c == '.'
     split cs = case break (== '.') cs of
-      (chunk, []) -> chunk : []
+      (chunk, []) -> [chunk]
       (chunk, _ : rest) -> chunk : split rest
 
 -- | VCS driver for Mercurial.


### PR DESCRIPTION
See #9110. Discharges and no longer ignores the "Use list literal" and "Use list literal pattern"  suggestions so that these will be suggested by our CI linting.

I picked these suggestions to bundle together in one pull request as they both improve readability of lists, if you agree that `[a, b]` is more readable than `a : b : []`.

I'll squash commits before applying the merge label if this pull request is approved.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
