### PR TITLE
Remove undesirable warnings about duplicate configs.

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -250,7 +250,7 @@ pathAction flags@NixStyleFlags{extraFlags = pathFlags'} cliTargetStrings globalF
         pure $ Just $ mkCompilerInfo configuredCompilerProg compiler
 
   paths <- for (fromFlagOrDefault [] $ pathDirectories pathFlags) $ \p -> do
-    t <- getPathLocation baseCtx p
+    t <- getPathLocation verbosity baseCtx p
     pure (pathName p, t)
 
   let pathOutputs =
@@ -272,20 +272,20 @@ pathAction flags@NixStyleFlags{extraFlags = pathFlags'} cliTargetStrings globalF
 -- | Find the FilePath location for common configuration paths.
 --
 -- TODO: this should come from a common source of truth to avoid code path divergence
-getPathLocation :: ProjectBaseContext -> ConfigPath -> IO FilePath
-getPathLocation _ ConfigPathCacheHome =
+getPathLocation :: Verbosity -> ProjectBaseContext -> ConfigPath -> IO FilePath
+getPathLocation _ _ ConfigPathCacheHome =
   defaultCacheHome
-getPathLocation baseCtx ConfigPathRemoteRepoCache =
+getPathLocation _ baseCtx ConfigPathRemoteRepoCache =
   pure $ buildSettingCacheDir (buildSettings baseCtx)
-getPathLocation baseCtx ConfigPathLogsDir =
+getPathLocation _ baseCtx ConfigPathLogsDir =
   pure $ cabalLogsDirectory (cabalDirLayout baseCtx)
-getPathLocation baseCtx ConfigPathStoreDir =
+getPathLocation _ baseCtx ConfigPathStoreDir =
   fromFlagOrDefault
     defaultStoreDir
     (pure <$> projectConfigStoreDir (projectConfigShared (projectConfig baseCtx)))
-getPathLocation baseCtx ConfigPathConfigFile =
-  getConfigFilePath normal (projectConfigConfigFile (projectConfigShared (projectConfig baseCtx)))
-getPathLocation baseCtx ConfigPathInstallDir =
+getPathLocation verbosity baseCtx ConfigPathConfigFile =
+  getConfigFilePath verbosity (projectConfigConfigFile (projectConfigShared (projectConfig baseCtx)))
+getPathLocation _ baseCtx ConfigPathInstallDir =
   fromFlagOrDefault
     defaultInstallPath
     (pure <$> cinstInstalldir (projectConfigClientInstallFlags $ projectConfigBuildOnly (projectConfig baseCtx)))

--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -284,7 +284,7 @@ getPathLocation baseCtx ConfigPathStoreDir =
     defaultStoreDir
     (pure <$> projectConfigStoreDir (projectConfigShared (projectConfig baseCtx)))
 getPathLocation baseCtx ConfigPathConfigFile =
-  getConfigFilePath (projectConfigConfigFile (projectConfigShared (projectConfig baseCtx)))
+  getConfigFilePath normal (projectConfigConfigFile (projectConfigShared (projectConfig baseCtx)))
 getPathLocation baseCtx ConfigPathInstallDir =
   fromFlagOrDefault
     defaultInstallPath

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1036,8 +1036,8 @@ getConfigFilePathAndSource verbosity configFileFlag =
       -- option).
       dir <- lookupEnv "CABAL_DIR"
       case dir of
-        Nothing -> return ()
-        Just _ -> warnOnTwoConfigs verbosity
+        Nothing -> warnOnTwoConfigs verbosity
+        Just _ -> return ()
       return $ Just cfg
 
     sources =

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -953,7 +953,6 @@ defaultHackageRemoteRepoKeyThreshold = 3
 -- use 'loadRawConfig'.
 loadConfig :: Verbosity -> Flag FilePath -> IO SavedConfig
 loadConfig verbosity configFileFlag = do
-  warnOnTwoConfigs verbosity
   config <- loadRawConfig verbosity configFileFlag
   extendToEffectiveConfig config
 
@@ -980,7 +979,7 @@ extendToEffectiveConfig config = do
 -- effective configuration.
 loadRawConfig :: Verbosity -> Flag FilePath -> IO SavedConfig
 loadRawConfig verbosity configFileFlag = do
-  (source, configFile) <- getConfigFilePathAndSource configFileFlag
+  (source, configFile) <- getConfigFilePathAndSource verbosity configFileFlag
   minp <- readConfigFile mempty configFile
   case minp of
     Nothing -> do
@@ -1023,17 +1022,28 @@ data ConfigFileSource
 
 -- | Returns the config file path, without checking that the file exists.
 -- The order of precedence is: input flag, CABAL_CONFIG, default location.
-getConfigFilePath :: Flag FilePath -> IO FilePath
-getConfigFilePath = fmap snd . getConfigFilePathAndSource
+getConfigFilePath :: Verbosity -> Flag FilePath -> IO FilePath
+getConfigFilePath verbosity configFilePath = fmap snd $ getConfigFilePathAndSource verbosity configFilePath
 
-getConfigFilePathAndSource :: Flag FilePath -> IO (ConfigFileSource, FilePath)
-getConfigFilePathAndSource configFileFlag =
+getConfigFilePathAndSource :: Verbosity -> Flag FilePath -> IO (ConfigFileSource, FilePath)
+getConfigFilePathAndSource verbosity configFileFlag =
   getSource sources
   where
+    defaultSource = do
+      cfg <- defaultConfigFile
+      -- We only warn on two configs when the user has not explicitly indicated
+      -- a preference (using any of CABAL_CONFIG, CABAL_DIR, or the --config
+      -- option).
+      dir <- lookupEnv "CABAL_DIR"
+      case dir of
+        Nothing -> return ()
+        Just _ -> warnOnTwoConfigs verbosity
+      return $ Just cfg
+
     sources =
       [ (CommandlineOption, return . flagToMaybe $ configFileFlag)
       , (EnvironmentVariable, lookup "CABAL_CONFIG" `liftM` getEnvironment)
-      , (Default, Just `liftM` defaultConfigFile)
+      , (Default, defaultSource)
       ]
 
     getSource [] = error "no config file path candidate found."
@@ -1991,7 +2001,7 @@ userConfigUpdate verbosity globalFlags extraLines = do
   extraConfig <- parseExtraLines verbosity extraLines
   newConfig <- initialSavedConfig
   commentConf <- commentSavedConfig
-  cabalFile <- getConfigFilePath $ globalConfigFile globalFlags
+  cabalFile <- getConfigFilePath verbosity $ globalConfigFile globalFlags
   let backup = cabalFile ++ ".backup"
   notice verbosity $ "Renaming " ++ cabalFile ++ " to " ++ backup ++ "."
   renameFile cabalFile backup

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -1465,7 +1465,7 @@ userConfigAction ucflags extraArgs globalFlags = do
       extraLines = fromFlag (userConfigAppendLines ucflags)
   case extraArgs of
     ("init" : _) -> do
-      path <- configFile
+      path <- getConfigFilePath verbosity (globalConfigFile globalFlags)
       fileExists <- doesFileExist path
       if (not fileExists || (fileExists && frc))
         then void $ createDefaultConfigFile verbosity extraLines path
@@ -1475,8 +1475,6 @@ userConfigAction ucflags extraArgs globalFlags = do
     -- Error handling.
     [] -> dieWithException verbosity SpecifySubcommand
     _ -> dieWithException verbosity $ UnknownUserConfigSubcommand extraArgs
-  where
-    configFile = getConfigFilePath (globalConfigFile globalFlags)
 
 -- | Used as an entry point when cabal-install needs to invoke itself
 -- as a setup script. This can happen e.g. when doing parallel builds.

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1009,7 +1009,7 @@ writeProjectConfigFile file =
 readGlobalConfig :: Verbosity -> Flag FilePath -> Rebuild ProjectConfig
 readGlobalConfig verbosity configFileFlag = do
   config <- liftIO (loadConfig verbosity configFileFlag)
-  configFile <- liftIO (getConfigFilePath configFileFlag)
+  configFile <- liftIO (getConfigFilePath verbosity configFileFlag)
   monitorFiles [monitorFileHashed configFile]
   return (convertLegacyGlobalConfig config)
 

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -376,7 +376,7 @@ rebuildProjectConfig
     let fileMonitorProjectConfig = newFileMonitor (distProjectCacheFile "config")
 
     fileMonitorProjectConfigKey <- do
-      configPath <- getConfigFilePath projectConfigConfigFile
+      configPath <- getConfigFilePath verbosity projectConfigConfigFile
       return
         ( configPath
         , distProjectFile ""


### PR DESCRIPTION
Now only warns about duplicate configs when a configuration file has not been explicitly provided by the user.

Fixes #11023.

One wart is that in the implementation of `cabal path` I could not figure out how to get my hands on a `Verbosity`, so I just went with `normal`.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

## Manual QA

https://github.com/haskell/cabal/pull/11181#issuecomment-3214775232

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
