### PR TITLE
HLint: use first and use second

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -28,11 +28,11 @@
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 28 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 88 hints
+- ignore: {name: "Use <$>"} # 89 hints
 - ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
-- ignore: {name: "Use =="} # 3 hints
+- ignore: {name: "Use =="} # 2 hints
 - ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
@@ -40,8 +40,7 @@
 - ignore: {name: "Use catMaybes"} # 4 hints
 - ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 37 hints
-- ignore: {name: "Use first"} # 5 hints
-- ignore: {name: "Use fmap"} # 24 hints
+- ignore: {name: "Use fmap"} # 23 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fromMaybe"} # 5 hints
 - ignore: {name: "Use fst"} # 2 hints
@@ -57,7 +56,6 @@
 - ignore: {name: "Use record patterns"} # 16 hints
 - ignore: {name: "Use replicateM_"} # 2 hints
 - ignore: {name: "Use rights"} # 2 hints
-- ignore: {name: "Use second"} # 7 hints
 - ignore: {name: "Use section"} # 18 hints
 - ignore: {name: "Use tuple-section"} # 28 hints
 - ignore: {name: "Use typeRep"} # 2 hints

--- a/Cabal-syntax/src/Distribution/Compat/Graph.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Graph.hs
@@ -128,7 +128,7 @@ instance Show a => Show (Graph a) where
   show = show . toList
 
 instance (IsNode a, Read a, Show (Key a)) => Read (Graph a) where
-  readsPrec d s = map (\(a, r) -> (fromDistinctList a, r)) (readsPrec d s)
+  readsPrec d s = map (first fromDistinctList) (readsPrec d s)
 
 instance (IsNode a, Binary a, Show (Key a)) => Binary (Graph a) where
   put x = put (toList x)

--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -40,6 +40,7 @@ module Distribution.Simple.BuildTarget
   , reportBuildTargetProblems
   ) where
 
+import Data.Bifunctor (second)
 import Distribution.Compat.Prelude
 import Prelude ()
 
@@ -407,7 +408,7 @@ reportBuildTargetProblems verbosity problems = do
     targets ->
       dieWithException verbosity $
         UnknownBuildTarget $
-          map (\(target, nosuch) -> (showUserBuildTarget target, nosuch)) targets
+          map (first showUserBuildTarget) targets
 
   case [(t, ts) | BuildTargetAmbiguous t ts <- problems] of
     [] -> return ()
@@ -652,7 +653,7 @@ matchComponentKindAndName cs ckind str =
   orNoSuchThing (showComponentKind ckind ++ " component") str $
     increaseConfidenceFor $
       matchInexactly
-        (\(ck, cn) -> (ck, caseFold cn))
+        (second caseFold)
         [((cinfoKind c, cinfoStrName c), c) | c <- cs]
         (ckind, str)
 

--- a/Cabal/src/Distribution/Utils/MapAccum.hs
+++ b/Cabal/src/Distribution/Utils/MapAccum.hs
@@ -1,5 +1,6 @@
 module Distribution.Utils.MapAccum (mapAccumM) where
 
+import Data.Bifunctor (second)
 import Distribution.Compat.Prelude
 import Prelude ()
 
@@ -7,7 +8,7 @@ import Prelude ()
 newtype StateM s m a = StateM {runStateM :: s -> m (s, a)}
 
 instance Functor m => Functor (StateM s m) where
-  fmap f (StateM x) = StateM $ \s -> fmap (\(s', a) -> (s', f a)) (x s)
+  fmap f (StateM x) = StateM $ \s -> fmap (second f) (x s)
 
 instance Monad m => Applicative (StateM s m) where
   pure x = StateM $ \s -> return (s, x)

--- a/cabal-install/src/Distribution/Client/IndexUtils/ActiveRepos.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils/ActiveRepos.hs
@@ -11,6 +11,7 @@ module Distribution.Client.IndexUtils.ActiveRepos
   , organizeByRepos
   ) where
 
+import Data.Bifunctor (second)
 import Distribution.Client.Compat.Prelude
 import Distribution.Client.Types.RepoName (RepoName (..))
 import Prelude ()
@@ -177,12 +178,10 @@ organizeByRepos (ActiveRepos xs0) sel ys0 =
     go :: [a] -> [ActiveRepoEntry] -> [a] -> Either String ([a], [(a, CombineStrategy)])
     go _rest [] ys = Right (ys, [])
     go rest (ActiveRepoRest s : xs) ys =
-      go rest xs ys <&> \(rest', result) ->
-        (rest', map (\x -> (x, s)) rest ++ result)
+      go rest xs ys <&> second (map (\x -> (x, s)) rest ++)
     go rest (ActiveRepo r s : xs) ys = do
       (z, zs) <- extract r ys
-      go rest xs zs <&> \(rest', result) ->
-        (rest', (z, s) : result)
+      go rest xs zs <&> second ((z, s) :)
 
     extract :: RepoName -> [a] -> Either String (a, [a])
     extract r = loop id

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -76,6 +76,7 @@ module Distribution.Client.ProjectConfig
   , maxNumFetchJobs
   ) where
 
+import Data.Bifunctor (second)
 import Distribution.Client.Compat.Prelude hiding (empty)
 import Distribution.Parsec.Source
 import Distribution.Simple.Utils
@@ -1681,7 +1682,7 @@ syncAndReadSourcePackagesRemoteRepos
               repoPaths
 
           mapGroup :: Ord k => [(k, v)] -> [(k, NonEmpty v)]
-          mapGroup = Map.toList . Map.fromListWith (<>) . map (\(k, v) -> (k, pure v))
+          mapGroup = Map.toList . Map.fromListWith (<>) . map (second pure)
 
           -- The repos in a group are given distinct names by simple enumeration
           -- foo, foo-2, foo-3 etc

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -853,7 +853,7 @@ availableTargetIndexes installPlan = AvailableTargetIndexes{..}
     availableTargetsByPackageNameAndComponentName =
       Map.mapKeysWith
         (++)
-        (\(pkgid, cname) -> (packageName pkgid, cname))
+        (first packageName)
         availableTargetsByPackageIdAndComponentName
 
     availableTargetsByPackageNameAndUnqualComponentName
@@ -952,7 +952,7 @@ availableTargetIndexesFromSourcePackages pkgSpecifiers = AvailableTargetIndexes{
     availableTargetsByPackageNameAndComponentName =
       Map.mapKeysWith
         (++)
-        (\(pkgid, cname) -> (packageName pkgid, cname))
+        (first packageName)
         availableTargetsByPackageIdAndComponentName
 
     availableTargetsByPackageNameAndUnqualComponentName

--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -100,6 +100,7 @@ import Control.Arrow ((&&&))
 import Control.Monad hiding
   ( mfilter
   )
+import Data.Bifunctor (second)
 #if MIN_VERSION_base(4,20,0)
 import Data.Functor as UZ (unzip)
 #else
@@ -827,7 +828,7 @@ reportTargetSelectorProblems verbosity problems = do
     targets ->
       dieWithException verbosity $
         NoSuchTargetSelectorErr $
-          map (\(target, nosuch) -> (showTargetString target, nosuch)) targets
+          map (first showTargetString) targets
 
   case [(t, ts) | TargetSelectorAmbiguous t ts <- problems] of
     [] -> return ()
@@ -2186,7 +2187,7 @@ matchComponentKindAndName cs ckind str =
     (map render cs)
     $ increaseConfidenceFor
     $ matchInexactly
-      (\(ck, cn) -> (ck, caseFold cn))
+      (second caseFold)
       (\c -> (cinfoKind c, cinfoStrName c))
       cs
       (ckind, str)

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Builder.hs
@@ -4,6 +4,7 @@ module UnitTests.Distribution.Solver.Modular.Builder
 
 import Distribution.Solver.Modular.Builder
 
+import Data.Bifunctor (second)
 import Test.Tasty
 import Test.Tasty.QuickCheck
 
@@ -15,7 +16,7 @@ tests =
 -- | Simpler splits implementation
 splits' :: [a] -> [(a, [a])]
 splits' [] = []
-splits' (x : xs) = (x, xs) : map (\(y, ys) -> (y, x : ys)) (splits' xs)
+splits' (x : xs) = (x, xs) : map (second (x :)) (splits' xs)
 
 splitsTest :: [Int] -> Property
 splitsTest xs = splits' xs === splits xs


### PR DESCRIPTION
See #9110. Discharges and no longer ignores the "Use first" and "Use second" suggestions so that these will be suggested by our CI linting.

These suggestions seem reasonable and don't reduce readability. Checking each replacement, it seems easy to find out from the surrounding code what the first or second element of each pair is.

I'll squash commits before applying the merge label if this pull request is approved (or use `squash+merge me`).

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
