### PR TITLE
Fix haddock typo: coversion

### DIFF
--- a/cabal-testsuite/src/Test/Cabal/NeedleHaystack.hs
+++ b/cabal-testsuite/src/Test/Cabal/NeedleHaystack.hs
@@ -157,7 +157,7 @@ data NeedleHaystack =
         }
 
 -- | Symmetric needle and haystack functions, the same conversion for each going
--- forward and the same coversion for each going backward.
+-- forward and the same conversion for each going backward.
 symNeedleHaystack :: (String -> String) -> (String -> String) -> NeedleHaystack
 symNeedleHaystack bwd fwd = let tx = TxFwdBwd bwd fwd in NeedleHaystack True False tx tx
 


### PR DESCRIPTION
Fixes a typo I introduced in #10646.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
