### PR TITLE
Add list of maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,11 +12,19 @@ a.k.a. The Cabal Maintainers Team:
 
 ### How we compose this list
 
-The main goal of the team is to make sure Cabal is keeping up with the ever-evolving Haskell ecosystem.
-In practical terms this means producing releases of the packages in this repository on a regular basis (we release at least as often as does GHC).
+The main goal of the team is to ensure that Cabal is keeping up with the ever-evolving Haskell ecosystem.
+In practical terms this means producing releases of the packages in this repository on a regular basis: we usually have to release at least as often as does GHC due to an intimate connection between the compiler and the build system.
+Hence, the people listed above (in chronological order by when they joined the team) are those who are currently available for carrying out the release procedures.
 
-The people on this list (in chronological order by when they joined the team) are currently carrying out the release procedures.
-Of course, releases don't happen in a vacuum, and successful development of Cabal requires coordination.
-For this reason, the team holds regular (biweekly) video calls with agenda prepared asynchronously in a Markdown document, which also holds the meeting notes. For the record, the meetings are open to everyone interested in Cabal, especially aspiring and returning Cabal contributors.
+Successful maintenance requires coordination, and the team engages in three main ways:
 
-If you want to become a Cabal maintainer as described above, i.e. contribute to the biweekly meetings (synchronously or asynchronously through the meeting document or the Matrix chat) and perform some of the release tasks, get in touch: open a GitHub discussion or send a message in our Matrix chat referenced in the README.
+- attending to issues and PRs on GitHub;
+
+- discussing Cabal on the [Matrix channel](https://matrix.to/#/#hackage:matrix.org);
+
+- meeting biweekly in video calls with agenda prepared asynchronously in a Markdown document, which also holds the meeting notes.
+
+Worth noting that the meetings are open to everyone interested in Cabal, especially aspiring and returning Cabal contributors. Ask on Matrix how to join.
+
+Most of the current team is volunteers, and we are happy to receive any help.
+If you want to participate in Cabal maintenance as defined above (e.g. take on some release tasks), get in touch: open a GitHub discussion or send a message on Matrix.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,5 +26,5 @@ Successful maintenance requires coordination, and the team engages in three main
 
 Worth noting that the meetings are open to everyone interested in Cabal, especially aspiring and returning Cabal contributors. Ask on Matrix how to join.
 
-Most of the current team is volunteers, and we are happy to receive any help.
+Most of the current team are volunteers, and we are happy to receive any help.
 If you want to participate in Cabal maintenance as defined above (e.g. take on some release tasks), get in touch: open a GitHub discussion or send a message on Matrix.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,22 @@
+## List of Maintainers 
+
+a.k.a. The Cabal Maintainers Team:
+
+* Mikolaj Konarski ([`@Mikolaj`](https://github.com/Mikolaj))
+
+* Francesco Ariis ([`@ffaf1`](https://github.com/ffaf1))
+
+* Artem Pelenitsyn ([`@ulysses4ever`](https://github.com/ulysses4ever))
+
+* Brandon Allbery ([`@geekosaur`](https://github.com/geekosaur))
+
+### How we compose this list
+
+The main goal of the team is to make sure Cabal is keeping up with the ever-evolving Haskell ecosystem.
+In practical terms this means producing releases of the packages in this repository on a regular basis (we release at least as often as does GHC).
+
+The people listed above (in chronological order by when they joined the team) are volunteers currently carrying out the release procedures.
+Of course, releases don't happen in vacuum, and successful development of Cabal requires coordination.
+For this reason, the team holds regular (biweekly) video calls with agenda prepared asynchronously in a Markdown document, which also holds the meeting notes. For the record, the meetings are open to everyone interested in Cabal, especially aspiring and returning Cabal contributors.
+
+If you want to become a Cabal maintainer as described above, i.e. contribute to the biweekly meetings (synchronously or asynchronously through the meeting document or the Matrix chat) and perform some of the release tasks, get in touch: open a GitHub discussion or send a message in our Matrix chat referenced in the README.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,7 +15,7 @@ a.k.a. The Cabal Maintainers Team:
 The main goal of the team is to make sure Cabal is keeping up with the ever-evolving Haskell ecosystem.
 In practical terms this means producing releases of the packages in this repository on a regular basis (we release at least as often as does GHC).
 
-The people listed above (in chronological order by when they joined the team) are volunteers currently carrying out the release procedures.
+The people on this list (in chronological order by when they joined the team) are currently carrying out the release procedures.
 Of course, releases don't happen in a vacuum, and successful development of Cabal requires coordination.
 For this reason, the team holds regular (biweekly) video calls with agenda prepared asynchronously in a Markdown document, which also holds the meeting notes. For the record, the meetings are open to everyone interested in Cabal, especially aspiring and returning Cabal contributors.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-## List of Maintainers 
+## List of Maintainers
 
 a.k.a. The Cabal Maintainers Team:
 
@@ -16,7 +16,7 @@ The main goal of the team is to make sure Cabal is keeping up with the ever-evol
 In practical terms this means producing releases of the packages in this repository on a regular basis (we release at least as often as does GHC).
 
 The people listed above (in chronological order by when they joined the team) are volunteers currently carrying out the release procedures.
-Of course, releases don't happen in vacuum, and successful development of Cabal requires coordination.
+Of course, releases don't happen in a vacuum, and successful development of Cabal requires coordination.
 For this reason, the team holds regular (biweekly) video calls with agenda prepared asynchronously in a Markdown document, which also holds the meeting notes. For the record, the meetings are open to everyone interested in Cabal, especially aspiring and returning Cabal contributors.
 
 If you want to become a Cabal maintainer as described above, i.e. contribute to the biweekly meetings (synchronously or asynchronously through the meeting document or the Matrix chat) and perform some of the release tasks, get in touch: open a GitHub discussion or send a message in our Matrix chat referenced in the README.

--- a/README.md
+++ b/README.md
@@ -116,3 +116,8 @@ Build for hacking and contributing to cabal
 -------------------------------------------
 
 Refer to [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Maintainers
+-------------------------------------------
+
+Refer to [MAINTAINERS.md](MAINTAINERS.md).


### PR DESCRIPTION
@Mikolaj @ffaf1 @geekosaur please, let me know what you think. My idea was to avoid formal criteria like "participated in K out of last N meetings" (there was a valid concern about the exclusionary nature of synchronous events) and instead to focus on release procedures (but meetings count too :-)). 

@mpickering do you want to be on this list? I think you absolutely qualify. Just wanted to ask you first.


---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
