### PR TITLE
Fix typo in `--disable-documentation`

### DIFF
--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.test.hs
@@ -1,5 +1,5 @@
 import Test.Cabal.Prelude
--- Test that `cabal haddock --disable-documention` works as expected and leads
+-- Test that `cabal haddock --disable-documentation` works as expected and leads
 -- to a warning if a local package makes an outer reference.
 main = cabalTest . withRepo "repo" $ do
     r <- cabal' "haddock" ["--disable-documentation", "B"]


### PR DESCRIPTION
Fixes a typo in a flag referenced in a comment.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
