### PR TITLE
Change source-package-repository in docs to source-repository-package

### DIFF
--- a/doc/how-to-source-packages.rst
+++ b/doc/how-to-source-packages.rst
@@ -142,7 +142,7 @@ download.
 
 We can also :ref:`take a dependency from a source code
 repository<pkg-consume-source>`. These are accessed via a version control system
-(VCS) such as Git and set up in the project with ``source-package-repository``
+(VCS) such as Git and set up in the project with ``source-repository-package``
 stanzas. With these, we can take dependencies on packages not published to
 Hackage, on revisions not yet published or on forks.  This is the easiest way to
 work with a fork, much easier than using a Git submodule.  A dependency taken


### PR DESCRIPTION
It appears to be either a typo or a leftover. It's the only instance of the word in the docs and is very close to a word that appears several times.

i don't believe this needs a separate issue because it looks like a simple typo fix to me

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
