### PR TITLE
gitlab ci: Use today's ci-images build; move to alpine3_22

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 variables:
   # Commit of ghc/ci-images repository from which to pull Docker images
-  DOCKER_REV: "df20b2eb2fcc1c93aed5ad047c65752fbd4c38d4"
+  DOCKER_REV: "be4ac2cd18f38e63b263e2a27c76a7c279385796"
 
   GHC_VERSION: 9.10.2
   CABAL_INSTALL_VERSION: 3.14.2.0
@@ -67,13 +67,13 @@ alpine-linux:
   parallel:
     matrix:
       - ARCH: [x86_64]
-        OS: [alpine3_12, alpine3_20]
+        OS: [alpine3_12, alpine3_22]
         TAG: x86_64-linux
       - ARCH: [i386]
-        OS: alpine3_20
+        OS: alpine3_22
         TAG: x86_64-linux
       - ARCH: [aarch64]
-        OS: [alpine3_18]
+        OS: [alpine3_22]
         TAG: aarch64-linux
   tags:
     - $TAG


### PR DESCRIPTION
* Background: Release CI has been implemented on GitHub, but my working assumption is that the previous GitLab CI will still be used for minor releases of 3.16 to ensure no breaking changes regarding platform availability.
* Situation: GitLab CI (may it soon RIP) is failing and will take a hot minute to fix again

    * An eager reaping process removed all the Docker images used by CI (I think? Ben Gamari may know).
    * The images can't be regenerated from the [same commit](https://gitlab.haskell.org/ghc/ci-images/-/pipelines/110688), because apt-get update fails during the run.
    * The easiest workaround—using the [latest commit](https://gitlab.haskell.org/ghc/ci-images/-/pipelines/114988)—would force a change in platforms, albeit not much of one.

* Possible solutions

    * Option 1: Declare GitLab bankruptcy and give up. Go whole-hog on the new GitHub CI, platform availability be damned.

    * Option 2: Accept some minor change in platform availability. The list would be:
        - i386-alpine3_20 replaced by i386-alpine3_22
        - x86_64-alpine3_20 replaced by x86_64-alpine3_22
        - aarch64-alpine3_18 replaced by aarch64-alpine3_22

        Pipeline example: ![](https://gitlab.haskell.org/haskell/cabal/badges/b/ci-images-bump/pipeline.svg)

    * Option 3: Something else that I realistically don't have time for and probably nobody else does, either.

This PR implements option 2. If merged, it should be backported to the 3.16 branch.