### PR TITLE
mergify's "waiting too long" check waits too long

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -86,7 +86,7 @@ pull_request_rules:
       - -merged
       - '#approved-reviews-by>=2'
       - '#changes-requested-reviews-by=0'
-      - updated-at<4 days ago
+      - updated-at<3 days ago
       - label=merge delay passed
       # oy
       # lifted these from branch protection imports


### PR DESCRIPTION
**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ only meaningful on `master`
