### PR TITLE
fix network-uri bound

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -257,7 +257,7 @@ library
       , filepath   >= 1.4.0.0  && < 1.6
       , HTTP       >= 4000.1.5 && < 4000.5
       , mtl        >= 2.0      && < 2.4
-      , network-uri >= 2.6.0.2 && < 2.7
+      , network-uri >= 2.6.2.0 && < 2.7
       , pretty     >= 1.1      && < 1.2
       , process    >= 1.2.3.0  && < 1.7
       , random     >= 1.2      && < 1.4


### PR DESCRIPTION
Someone (I won't claim it wasn't me) swapped digits in the dependency for cabal-install. But it's correct for the later tests, which makes me think it was a typo.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
