### PR TITLE
cabal-install: do not pass the executable name to cabal external commands

### DIFF
--- a/cabal-testsuite/PackageTests/ExternalCommand/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommand/cabal.test.hs
@@ -17,7 +17,6 @@ main = do
     addToPath (takeDirectory exe_path) $ do
       -- Test that the thing works at all
       res <- cabal_raw_action ["aaaa"] (\h -> () <$ Process.waitForProcess h)
-      assertOutputContains "aaaa" res
 
       -- Test that the extra arguments are passed on
       res <- cabal_raw_action ["aaaa", "--foobaz"] (\h -> () <$ Process.waitForProcess h)

--- a/cabal-testsuite/PackageTests/ExternalCommandEnv/setup-test/AAAA.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommandEnv/setup-test/AAAA.hs
@@ -4,7 +4,7 @@ import System.Environment
 import System.Process
 
 main = do
-  cabal_proc <- getEnv "CABAL"
+  cabal_proc <- getEnv "CABAL_EXTERNAL_CABAL_PATH"
   other_var <- getEnv "OTHER_VAR"
   putStrLn ("OTHER_VAR is set to: " ++ other_var)
   callProcess cabal_proc ["--version"]

--- a/cabal-testsuite/PackageTests/ExternalCommandExitCode/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommandExitCode/cabal.test.hs
@@ -18,7 +18,6 @@ main = do
     addToPath (takeDirectory exe_path) $ do
       -- Test that the thing works at all
       res <- fails $ cabal_raw_action ["aaaa"] (\h -> () <$ Process.waitForProcess h)
-      assertOutputContains "aaaa" res
       -- Check the exit code is the one returned by subcommand
       unless (resultExitCode res == ExitFailure 99) (assertFailure $ "Incorrect exit code: " ++ show (resultExitCode res))
 

--- a/cabal-testsuite/PackageTests/ExternalCommandHelp/setup-test/AAAA.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommandHelp/setup-test/AAAA.hs
@@ -5,5 +5,5 @@ import System.Environment
 main = do
   args <- getArgs
   case args of
-    ["aaaa" , "--help"] -> putStrLn "I am helping with the aaaa command"
+    ["--help"] -> putStrLn "I am helping with the aaaa command"
     _ -> putStrLn "aaaa"

--- a/changelog.d/pr-11232.md
+++ b/changelog.d/pr-11232.md
@@ -1,0 +1,24 @@
+---
+synopsis: Don't pass the executable name to external commands
+packages: [cabal-install]
+prs: 11232
+issues: [10275]
+significance: significant
+---
+
+Previously the executable name of the external command was passed to external commands as the first argument.
+
+This behaviour was adapted from cargo which does this because of reasons that are internal to rust that do not affect GHC Haskell, and are even orthogonal to patterns that see common use in Haskell.
+
+Additionally, it complicates the 'simple' case which is what we should optimize for when building such a feature - with this change, for any executable `cabal-foo` in your search-path, `cabal foo` will be a valid invocation of that command.
+
+The previous use case (one executable that serves multiple external subcommands) is still possible by the following means:
+
+- using a wrapper around the executable
+- using a symlink and check argv\[0\] in the executable
+
+Additionally, the variable `$CABAL` that was set by `cabal-install` was renamed to `CABAL_EXTERNAL_CABAL_PATH`. This has two reasons:
+1. it makes migration easier for users of the external command feature that were previously expecting the name of the executable
+   to appear in `argv[1]`
+2. it does not unnecessarily pollute the environment variable namespace as it turns out some other tools have been and are already
+   using this name, historically

--- a/doc/external-commands.rst
+++ b/doc/external-commands.rst
@@ -3,18 +3,26 @@ External Commands
 
 ``cabal-install`` provides a system for external commands, akin to the ones used by tools like ``git`` or ``cargo``.
 
-If you execute ``cabal <cmd>``, ``cabal-install`` will search the path for an executable named ``cabal-<cmd>`` and execute it. The name of the command is passed as the first argument and
-the remaining arguments are passed afterwards. An error will be thrown in case the custom command is not found. The exit code of cabal when calling an external command is the same as the exit code
+If you execute ``cabal <cmd>``, ``cabal-install`` will search the path for an executable named ``cabal-<cmd>`` and execute it. An error will be thrown in case the custom command is not found. The exit code of cabal when calling an external command is the same as the exit code
 of the command.
 
-The ``$CABAL`` environment variable is set to the path of the ``cabal-install`` executable
+The name of the command is *not* passed as the first argument as is done in ``cargo``, instead you will have to figure out the name via `argv[0]` as
+is the case in e.g. `git`.
+
+The ``$CABAL_EXTERNAL_CABAL_PATH`` environment variable is set to the path of the ``cabal-install`` executable
 which invoked the subcommand.
 
 It is strongly recommended that you implement your custom commands by calling the
-CLI via the ``$CABAL`` variable rather than linking against the ``Cabal`` library.
+CLI via the ``$CABAL_EXTERNAL_CABAL_PATH`` variable rather than linking against the ``Cabal`` library.
 There is no guarantee that the subcommand will link against the same version of the
 ``Cabal`` library as ``cabal-install`` so it would lead to unexpected results and
 incompatibilities.
+
+Historically, the `cabal-install` binary would pass the name of the executable which it is trying to invoke via the external command feature as
+the first argument to the executable itself. The main difference was that ``$CABAL_EXTERNAL_CABAL_PATH`` was called ``$CABAL``, which means that
+you can stay compatible with both versions, depending on which variable is set.
+
+Mind that if you were implementing external commands previously, you will not need to skip the first argument (the executable name) anymore.
 
 ``cabal-install`` can also display the help message of the external command.
 When ``cabal help <cmd>`` is invoked, then ``cabal-<cmd> <cmd> --help`` will be called so


### PR DESCRIPTION
Previously the executable name of the external command was passed to external commands as the first argument.

This behaviour was adapated from cargo which does this because of reasons that are internal to rust that do not affect GHC Haskell, and are even orthogonal to patterns that see common use in Haskell.

Additionally, it complicates the 'simple' case which is what we should optimize for when building such a feature.

The previous use case (one executable that serves multiple external subcommands) is still possible by the following means:
- using a wrapper around the executable
- using a symlink and check argv[0] in the executable

Survey of tools that can be affected by this change: https://github.com/haskell/cabal/pull/11232#issuecomment-3450823278

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)