### PR TITLE
indicate which of the joined tests failed

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -241,6 +241,9 @@ jobs:
             sh validate.sh $FLAGS -s "$test" || rc=1
             echo End "$test"
             echo ::endgroup::
+            if [ $rc -eq 1 ]; then
+              echo Some tests failed
+            fi
           done
           exit $rc
       # The above ensures all the tests get run, for a single platform+ghc.


### PR DESCRIPTION
So people don't have to open all of the collapsed test output to find any failures.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
