### PR TITLE
Retain comments in field parser

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -18,6 +18,11 @@ build-type:     Simple
 extra-doc-files:
   README.md ChangeLog.md
 
+flag cabal-parsec-debug
+  description: Enable debug build for the cabal field lexer/parser.
+  default:     False
+  manual:      True
+
 source-repository head
   type:     git
   location: https://github.com/haskell/cabal/
@@ -59,6 +64,11 @@ library
 
   if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
+
+  if flag(cabal-parsec-debug)
+    CPP-Options: -DCABAL_PARSEC_DEBUG
+    build-depends:
+      vector
 
   build-tool-depends:
     -- https://github.com/haskell/alex/issues/288

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -96,6 +96,7 @@ library
     Distribution.Fields
     Distribution.Fields.ConfVar
     Distribution.Fields.Field
+    Distribution.Fields.Field.Lens
     Distribution.Fields.Lexer
     Distribution.Fields.LexerMonad
     Distribution.Fields.ParseResult

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -18,11 +18,6 @@ build-type:     Simple
 extra-doc-files:
   README.md ChangeLog.md
 
-flag cabal-parsec-debug
-  description: Enable debug build for the cabal field lexer/parser.
-  default:     False
-  manual:      True
-
 source-repository head
   type:     git
   location: https://github.com/haskell/cabal/
@@ -64,11 +59,6 @@ library
 
   if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
-
-  if flag(cabal-parsec-debug)
-    CPP-Options: -DCABAL_PARSEC_DEBUG
-    build-depends:
-      vector
 
   build-tool-depends:
     -- https://github.com/haskell/alex/issues/288

--- a/Cabal-syntax/src/Distribution/Fields/Field.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Field.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- | Cabal-like file AST types: 'Field', 'Section' etc
 --
@@ -14,6 +17,12 @@ module Distribution.Fields.Field
   , fieldLineBS
   , SectionArg (..)
   , sectionArgAnn
+
+    -- * Comment
+  , Comment (..)
+  , WithComments (..)
+  , mapComments
+  , mapCommentedData
 
     -- * Name
   , FieldName
@@ -42,11 +51,26 @@ import qualified Data.Foldable1 as F1
 -- Cabal file
 -------------------------------------------------------------------------------
 
+data Comment ann = Comment !ByteString !ann
+  deriving (Show, Generic, Eq, Ord, Functor)
+
+data WithComments ann = WithComments
+  { justComments :: ![Comment ann]
+  , unComments :: !ann
+  }
+  deriving (Show, Generic, Eq, Ord, Functor)
+
+mapComments :: ([Comment ann] -> [Comment ann]) -> WithComments ann -> WithComments ann
+mapComments f (WithComments cs x) = WithComments (f cs) x
+
+mapCommentedData :: (ann -> ann) -> WithComments ann -> WithComments ann
+mapCommentedData f (WithComments cs x) = WithComments cs (f x)
+
 -- | A Cabal-like file consists of a series of fields (@foo: bar@) and sections (@library ...@).
 data Field ann
   = Field !(Name ann) [FieldLine ann]
   | Section !(Name ann) [SectionArg ann] [Field ann]
-  deriving (Eq, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
 -- | @since 3.12.0.0
 deriving instance Ord ann => Ord (Field ann)
@@ -71,7 +95,7 @@ fieldUniverse f@(Field _ _) = [f]
 --
 -- /Invariant:/ 'ByteString' has no newlines.
 data FieldLine ann = FieldLine !ann !ByteString
-  deriving (Eq, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
 -- | @since 3.12.0.0
 deriving instance Ord ann => Ord (FieldLine ann)
@@ -92,7 +116,7 @@ data SectionArg ann
     SecArgStr !ann !ByteString
   | -- | everything else, mm. operators (e.g. in if-section conditionals)
     SecArgOther !ann !ByteString
-  deriving (Eq, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
 -- | @since 3.12.0.0
 deriving instance Ord ann => Ord (SectionArg ann)
@@ -113,7 +137,7 @@ type FieldName = ByteString
 --
 -- /Invariant/: 'ByteString' is lower-case ASCII.
 data Name ann = Name !ann !FieldName
-  deriving (Eq, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
 -- | @since 3.12.0.0
 deriving instance Ord ann => Ord (Name ann)

--- a/Cabal-syntax/src/Distribution/Fields/Field.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Field.hs
@@ -51,12 +51,16 @@ import qualified Data.Foldable1 as F1
 -- Cabal file
 -------------------------------------------------------------------------------
 
+-- | Store a line comment from field syntax files. @ann@ is usually instantiated as 'Position'.
 data Comment ann = Comment !ByteString !ann
   deriving (Show, Generic, Eq, Ord, Functor)
 
+-- | Hold a list of comments along side some annotation.
 data WithComments ann = WithComments
   { justComments :: ![Comment ann]
+  -- ^ Extract the comments.
   , unComments :: !ann
+  -- ^ Extract the annotation.
   }
   deriving (Show, Generic, Eq, Ord, Functor)
 

--- a/Cabal-syntax/src/Distribution/Fields/Field.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Field.hs
@@ -21,8 +21,6 @@ module Distribution.Fields.Field
     -- * Comment
   , Comment (..)
   , WithComments (..)
-  , mapComments
-  , mapCommentedData
 
     -- * Name
   , FieldName
@@ -63,12 +61,6 @@ data WithComments ann = WithComments
   -- ^ Extract the annotation.
   }
   deriving (Show, Generic, Eq, Ord, Functor)
-
-mapComments :: ([Comment ann] -> [Comment ann]) -> WithComments ann -> WithComments ann
-mapComments f (WithComments cs x) = WithComments (f cs) x
-
-mapCommentedData :: (ann -> ann) -> WithComments ann -> WithComments ann
-mapCommentedData f (WithComments cs x) = WithComments cs (f x)
 
 -- | A Cabal-like file consists of a series of fields (@foo: bar@) and sections (@library ...@).
 data Field ann

--- a/Cabal-syntax/src/Distribution/Fields/Field.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Field.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 -- | Cabal-like file AST types: 'Field', 'Section' etc
 --

--- a/Cabal-syntax/src/Distribution/Fields/Field/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Field/Lens.hs
@@ -1,0 +1,12 @@
+module Distribution.Fields.Field.Lens where
+
+import Distribution.Compat.Lens
+import qualified Distribution.Fields.Field as T
+
+justComments :: Lens' (T.WithComments ann) [T.Comment ann]
+justComments f s = fmap (\x -> s{T.justComments=x}) (f (T.justComments s))
+{-# INLINE justComments #-}
+
+unComments :: Lens' (T.WithComments ann) ann
+unComments f s = fmap (\x -> s{T.unComments=x}) (f (T.unComments s))
+{-# INLINE unComments #-}

--- a/Cabal-syntax/src/Distribution/Fields/Field/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Field/Lens.hs
@@ -4,9 +4,9 @@ import Distribution.Compat.Lens
 import qualified Distribution.Fields.Field as T
 
 justComments :: Lens' (T.WithComments ann) [T.Comment ann]
-justComments f s = fmap (\x -> s{T.justComments=x}) (f (T.justComments s))
+justComments f s = fmap (\x -> s{T.justComments = x}) (f (T.justComments s))
 {-# INLINE justComments #-}
 
 unComments :: Lens' (T.WithComments ann) ann
-unComments f s = fmap (\x -> s{T.unComments=x}) (f (T.unComments s))
+unComments f s = fmap (\x -> s{T.unComments = x}) (f (T.unComments s))
 {-# INLINE unComments #-}

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -20,6 +20,8 @@ module Distribution.Fields.Parser
     -- $grammar
   , readFields
   , readFields'
+  , readFieldsWithComments
+  , readFieldsWithComments'
 #ifdef CABAL_PARSEC_DEBUG
 
     -- * Internal
@@ -27,6 +29,7 @@ module Distribution.Fields.Parser
   , parseStr
   , parseBS
 #endif
+  , formatError
   ) where
 {- FOURMOLU_ENABLE -}
 
@@ -49,11 +52,10 @@ import Text.Parsec.Pos
 import Text.Parsec.Prim hiding (many, (<|>))
 import Prelude ()
 
-#ifdef CABAL_PARSEC_DEBUG
-import qualified Data.Text                as T
-import qualified Data.Text.Encoding       as T
+import qualified Data.Bifunctor as Bi
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
-#endif
 
 -- $setup
 -- >>> import Data.Either (isLeft)
@@ -75,6 +77,9 @@ instance Stream LexState' Identity LToken where
     case tok of
       L _ EOF -> return Nothing
       _ -> return (Just (tok, st'))
+
+-- | A strict either for parser performance
+data Either' a b = Left' !a | Right' !b
 
 -- | Get lexer warnings accumulated so far
 getLexerWarnings :: Parser [LexWarning]
@@ -112,6 +117,7 @@ describeToken t = case t of
   Colon -> "\":\""
   OpenBrace -> "\"{\""
   CloseBrace -> "\"}\""
+  TokComment c -> "comment \"" ++ B8.unpack c ++ "\""
   --  SemiColon       -> "\";\""
   EOF -> "end of file"
   LexicalError is -> "character in input " ++ show (B8.head is)
@@ -131,6 +137,9 @@ tokColon = getToken $ \case Colon -> Just (); _ -> Nothing
 tokOpenBrace = getTokenWithPos $ \case L pos OpenBrace -> Just pos; _ -> Nothing
 tokCloseBrace = getToken $ \case CloseBrace -> Just (); _ -> Nothing
 tokFieldLine = getTokenWithPos $ \case L pos (TokFieldLine s) -> Just (FieldLine pos s); _ -> Nothing
+
+tokComment :: Parser (Comment Position)
+tokComment = getTokenWithPos $ \case L pos (TokComment c) -> Just (Comment c pos); _ -> Nothing
 
 colon, openBrace, closeBrace :: Parser ()
 sectionArg :: Parser (SectionArg Position)
@@ -164,6 +173,20 @@ indentOfAtLeast (IndentLevel i) = try $ do
 
 newtype LexerMode = LexerMode Int
 
+-- | Cabal's lexer is generated using Alex. It has multiple different states ("start-codes").
+-- Each state has its own rules and interprets the input stream differently.
+-- This has the benefit of providing more exact error message by having more
+-- knowledge about what symbol should follow in the input stream.
+--
+-- This lexer never switches to some of the states itself.
+-- Instead, the parser inspects the token stream it got, and switches the lexer state.
+-- Running the lexer on its own will not produce a correct token stream.
+--
+-- The parser instructs the lexer to change state using the function 'inLexerMode'.
+-- It runs a parser with the given mode, and then switches back to in_section.
+--
+-- To learn more about start-codes with Alex's documentation:
+-- https://haskell-alex.readthedocs.io/en/latest/syntax.html#start-codes
 inLexerMode :: LexerMode -> Parser p -> Parser p
 inLexerMode (LexerMode mode) p =
   do setLexerMode mode; x <- p; setLexerMode in_section; return x
@@ -171,39 +194,43 @@ inLexerMode (LexerMode mode) p =
 -----------------------
 -- Cabal file grammar
 --
+-- The non-terminals of the following grammar (symbols starting in uppercase)
+-- have their corresponding parser of the same name, starting with lowercase
+-- letter.
 
 -- $grammar
 --
 -- @
--- CabalStyleFile ::= SecElems
+-- CabalStyleFile             ::= Elements
 --
--- SecElems       ::= SecElem* '\\n'?
--- SecElem        ::= '\\n' SecElemLayout | SecElemBraces
--- SecElemLayout  ::= FieldLayout | FieldBraces | SectionLayout | SectionBraces
--- SecElemBraces  ::= FieldInline | FieldBraces |                 SectionBraces
--- FieldLayout    ::= name ':' line? ('\\n' line)*
--- FieldBraces    ::= name ':' '\\n'? '{' content '}'
--- FieldInline    ::= name ':' content
--- SectionLayout  ::= name arg* SecElems
--- SectionBraces  ::= name arg* '\\n'? '{' SecElems '}'
+-- Elements                   ::= Elements* '\\n'?
+-- Element                    ::= '\\n' ElementInLayoutContext
+--                              | ElementInNonLayoutContext
+-- ElementInLayoutContext     ::= FieldLayout | FieldBraces | SectionLayout | SectionBraces
+-- ElementInNonLayoutContext  ::= FieldInline | FieldBraces |                 SectionBraces
+-- FieldLayout                ::= name ':' line? ('\\n' line)*
+-- FieldBraces                ::= name ':' '\\n'? '{' content* '}'
+-- FieldInline                ::= name ':' content
+-- SectionLayout              ::= name arg* Elements
+-- SectionBraces              ::= name arg* '\\n'? '{' Elements '}'
 -- @
 --
 -- and the same thing but left factored...
 --
 -- @
--- SecElems              ::= SecElem*
--- SecElem               ::= '\\n' name SecElemLayout
---                         |      name SecElemBraces
--- SecElemLayout         ::= ':'   FieldLayoutOrBraces
---                         | arg*  SectionLayoutOrBraces
--- FieldLayoutOrBraces   ::= '\\n'? '{' content '}'
---                         | line? ('\\n' line)*
--- SectionLayoutOrBraces ::= '\\n'? '{' SecElems '\\n'? '}'
---                         | SecElems
--- SecElemBraces         ::= ':' FieldInlineOrBraces
---                         | arg* '\\n'? '{' SecElems '\\n'? '}'
--- FieldInlineOrBraces   ::= '\\n'? '{' content '}'
---                         | content
+-- Elements                   ::= Comments* (Element Comment*)*
+-- Element                    ::= '\\n' name ElementInLayoutContext
+--                              |      name ElementInNonLayoutContext
+-- ElementInLayoutContext     ::= ':'   FieldLayoutOrBraces
+--                              | arg*  SectionLayoutOrBraces
+-- FieldLayoutOrBraces        ::= '\\n'? '{' comment* (content comment*)* '}'
+--                              | comment* line? comment* ('\\n' line comment*)*
+-- SectionLayoutOrBraces      ::= '\\n'? '{' Elements '\\n'? '}'
+--                              | Elements
+-- ElementInNonLayoutContext  ::= ':' FieldInlineOrBraces
+--                              | arg* '\\n'? '{' Elements '\\n'? '}'
+-- FieldInlineOrBraces        ::= '\\n'? '{' content '}'
+--                              | content
 -- @
 --
 -- Note how we have several productions with the sequence:
@@ -223,18 +250,81 @@ inLexerMode (LexerMode mode) p =
 
 -- Top level of a file using cabal syntax
 --
-cabalStyleFile :: Parser [Field Position]
+cabalStyleFile :: Parser [Field (WithComments Position)]
 cabalStyleFile = do
   es <- elements zeroIndentLevel
   eof
-  return es
+  case es of
+    Left' _ -> pure [] -- We discard the comments here, because it is not a valid cabal file
+    Right' es' -> pure es'
+
+-- | Collect in annotation one or more comments after a parser succeeds
+-- Careful with the 'Functor' instance!
+-- If you use this with Field you might attach the same comments everywhere
+commentsAfter :: Functor f => Parser (f Position) -> Parser (f (WithComments Position))
+commentsAfter p = do
+  x <- p
+  postCmts <- many tokComment
+  pure $ fmap (WithComments postCmts) x
+
+noComments :: Functor f => f ann -> f (WithComments ann)
+noComments = fmap (WithComments mempty)
+
+-- | Returns 'Nothing' when there is no field to attach the comments to.
+prependCommentsFields :: [Comment ann] -> [Field (WithComments ann)] -> Maybe [Field (WithComments ann)]
+prependCommentsFields cs fs = case fs of
+  [] -> Nothing
+  (f : fs') -> Just $ prependCommentsField cs f : fs'
+
+-- | We attach the comments to the name (foremost child) of 'Field', this hence cannot fail.
+prependCommentsField :: [Comment ann] -> Field (WithComments ann) -> Field (WithComments ann)
+prependCommentsField cs f = case f of
+  (Field name fls) -> Field (mapComments (cs ++) <$> name) fls
+  (Section name args fs) -> Section (mapComments (cs ++) <$> name) args fs
+
+-- | Returns 'Nothing' when there is no field to attach the comments to.
+appendCommentsFields :: [Comment ann] -> [Field (WithComments ann)] -> Maybe [Field (WithComments ann)]
+appendCommentsFields cs fs = case fs of
+  [] -> Nothing
+  [f] -> Just [appendCommentsField cs f]
+  (f : fs') -> (f :) <$> appendCommentsFields cs fs'
+
+appendCommentsField :: [Comment ann] -> Field (WithComments ann) -> Field (WithComments ann)
+appendCommentsField cs f = case f of
+  (Field name fls) -> case appendCommentsFieldLines cs fls of
+    Nothing -> Field (mapComments (++ cs) <$> name) []
+    Just fls' -> Field name fls'
+  (Section name args fs) -> case appendCommentsFields cs fs of
+    Nothing -> Section (mapComments (++ cs) <$> name) args []
+    Just fs' -> Section name args fs'
+
+-- | Returns 'Nothing' when there is no field to attach the comments to.
+appendCommentsFieldLines :: [Comment ann] -> [FieldLine (WithComments ann)] -> Maybe [FieldLine (WithComments ann)]
+appendCommentsFieldLines cs fls = case fls of
+  [] -> Nothing
+  [fl] -> Just [mapComments (++ cs) <$> fl]
+  (f : fls') -> (f :) <$> appendCommentsFieldLines cs fls'
 
 -- Elements that live at the top level or inside a section, i.e. fields
--- and sections content
+-- and sections content.
 --
--- elements ::= element*
-elements :: IndentLevel -> Parser [Field Position]
-elements ilevel = many (element ilevel)
+-- This returns either many fields with their comments attached, or just the
+-- comments if there are no fields to attach them to. Only at the top level it
+-- is deemed correct to discard these comments, because in that case having no
+-- elements isn't a valid cabal file.
+--
+-- elements ::= comment* (element comment*)*
+elements :: IndentLevel -> Parser (Either' [Comment Position] [Field (WithComments Position)])
+elements ilevel = do
+  preCmts <- many tokComment
+  es <- many $ do
+    e <- element ilevel
+    postCmts <- many tokComment
+    pure $ appendCommentsField postCmts e
+
+  case prependCommentsFields preCmts es of
+    Nothing -> pure $ Left' preCmts
+    Just es' -> pure $ Right' es'
 
 -- An individual element, ie a field or a section. These can either use
 -- layout style or braces style. For layout style then it must start on
@@ -242,7 +332,7 @@ elements ilevel = many (element ilevel)
 --
 -- element ::= '\\n' name elementInLayoutContext
 --           |      name elementInNonLayoutContext
-element :: IndentLevel -> Parser (Field Position)
+element :: IndentLevel -> Parser (Field (WithComments Position))
 element ilevel =
   ( do
       ilevel' <- indentOfAtLeast ilevel
@@ -260,13 +350,16 @@ element ilevel =
 --
 -- elementInLayoutContext ::= ':'  fieldLayoutOrBraces
 --                          | arg* sectionLayoutOrBraces
-elementInLayoutContext :: IndentLevel -> Name Position -> Parser (Field Position)
+elementInLayoutContext :: IndentLevel -> Name Position -> Parser (Field (WithComments Position))
 elementInLayoutContext ilevel name =
   (do colon; fieldLayoutOrBraces ilevel name)
     <|> ( do
             args <- many sectionArg
             elems <- sectionLayoutOrBraces ilevel
-            return (Section name args elems)
+            case elems of
+              -- If there are no elements but comments, we attach them to the name (args can be multiple)
+              Left' onlyCmts -> return (Section (WithComments onlyCmts <$> name) (noComments <$> args) [])
+              Right' elems' -> return (Section (noComments name) (noComments <$> args) elems')
         )
 
 -- An element (field or section) that is valid in a non-layout context.
@@ -275,42 +368,52 @@ elementInLayoutContext ilevel name =
 --
 -- elementInNonLayoutContext ::= ':' FieldInlineOrBraces
 --                             | arg* '\\n'? '{' elements '\\n'? '}'
-elementInNonLayoutContext :: Name Position -> Parser (Field Position)
+elementInNonLayoutContext :: Name Position -> Parser (Field (WithComments Position))
 elementInNonLayoutContext name =
-  (do colon; fieldInlineOrBraces name)
+  (do colon; noComments <$> fieldInlineOrBraces name) -- inline field or braces can never have comments
     <|> ( do
             args <- many sectionArg
             openBrace
             elems <- elements zeroIndentLevel
             optional tokIndent
             closeBrace
-            return (Section name args elems)
+
+            case elems of
+              Left' elementCmts -> return (Section (WithComments elementCmts <$> name) (noComments <$> args) [])
+              Right' elems' -> return (Section (noComments name) (noComments <$> args) elems')
         )
 
 -- The body of a field, using either layout style or braces style.
 --
--- fieldLayoutOrBraces   ::= '\\n'? '{' content '}'
---                         | line? ('\\n' line)*
-fieldLayoutOrBraces :: IndentLevel -> Name Position -> Parser (Field Position)
+-- fieldLayoutOrBraces   ::= '\\n'? '{' comment* (content comment*)* '}'
+--                         | comment* line? comment* ('\\n' line comment*)*
+fieldLayoutOrBraces :: IndentLevel -> Name Position -> Parser (Field (WithComments Position))
 fieldLayoutOrBraces ilevel name = braces <|> fieldLayout
   where
+    braces :: Parser (Field (WithComments Position))
     braces = do
       openBrace
-      ls <- inLexerMode (LexerMode in_field_braces) (many fieldContent)
+      preCmts <- many tokComment
+      ls <- inLexerMode (LexerMode in_field_braces) (many $ commentsAfter fieldContent)
       closeBrace
-      return (Field name ls)
+      return $ Field (WithComments preCmts <$> name) ls
+
+    fieldLayout :: Parser (Field (WithComments Position))
     fieldLayout = inLexerMode (LexerMode in_field_layout) $ do
-      l <- optionMaybe fieldContent
-      ls <- many (do _ <- indentOfAtLeast ilevel; fieldContent)
-      return $ case l of
-        Nothing -> Field name ls
-        Just l' -> Field name (l' : ls)
+      preCmts <- many tokComment
+      l <- optionMaybe (commentsAfter fieldContent)
+      ls <- many (do _ <- indentOfAtLeast ilevel; commentsAfter fieldContent)
+      return
+        ( case l of
+            Nothing -> Field (WithComments preCmts <$> name) ls
+            Just l' -> Field (WithComments preCmts <$> name) (l' : ls)
+        )
 
 -- The body of a section, using either layout style or braces style.
 --
 -- sectionLayoutOrBraces ::= '\\n'? '{' elements \\n? '}'
 --                         | elements
-sectionLayoutOrBraces :: IndentLevel -> Parser [Field Position]
+sectionLayoutOrBraces :: IndentLevel -> Parser (Either' [Comment Position] [Field (WithComments Position)])
 sectionLayoutOrBraces ilevel =
   ( do
       openBrace
@@ -365,11 +468,17 @@ fieldInlineOrBraces name =
 -- >>> readFields' "\xc2\xa0 foo: bar"
 -- Right ([Field (Name (Position 1 3) "foo") [FieldLine (Position 1 8) "bar"]],[LexWarning LexWarningNBSP (Position 1 1)])
 readFields :: B8.ByteString -> Either ParseError [Field Position]
-readFields s = fmap fst (readFields' s)
+readFields = (fmap . map . fmap) unComments . readFieldsWithComments
 
 -- | Like 'readFields' but also return lexer warnings.
 readFields' :: B8.ByteString -> Either ParseError ([Field Position], [LexWarning])
-readFields' s = do
+readFields' = (fmap . Bi.first . map . fmap) unComments . readFieldsWithComments'
+
+readFieldsWithComments :: B8.ByteString -> Either ParseError [Field (WithComments Position)]
+readFieldsWithComments = fmap fst . readFieldsWithComments'
+
+readFieldsWithComments' :: B8.ByteString -> Either ParseError ([Field (WithComments Position)], [LexWarning])
+readFieldsWithComments' s = do
   parse parser "the input" lexSt
   where
     parser = do
@@ -387,16 +496,16 @@ readFields' s = do
 --
 -- To catch during parsing we would need to parse first field/section of a section
 -- and then parse the following ones (softly) requiring the exactly the same indentation.
-checkIndentation :: [Field Position] -> [LexWarning] -> [LexWarning]
+checkIndentation :: [Field (WithComments Position)] -> [LexWarning] -> [LexWarning]
 checkIndentation [] = id
-checkIndentation (Field name _ : fs') = checkIndentation' (nameAnn name) fs'
-checkIndentation (Section name _ fs : fs') = checkIndentation fs . checkIndentation' (nameAnn name) fs'
+checkIndentation (Field name _ : fs') = checkIndentation' (unComments $ nameAnn name) fs'
+checkIndentation (Section name _ fs : fs') = checkIndentation fs . checkIndentation' (unComments $ nameAnn name) fs'
 
 -- | We compare adjacent fields to reduce the amount of reported indentation warnings.
-checkIndentation' :: Position -> [Field Position] -> [LexWarning] -> [LexWarning]
+checkIndentation' :: Position -> [Field (WithComments Position)] -> [LexWarning] -> [LexWarning]
 checkIndentation' _ [] = id
-checkIndentation' pos (Field name _ : fs') = checkIndentation'' pos (nameAnn name) . checkIndentation' (nameAnn name) fs'
-checkIndentation' pos (Section name _ fs : fs') = checkIndentation'' pos (nameAnn name) . checkIndentation fs . checkIndentation' (nameAnn name) fs'
+checkIndentation' pos (Field name _ : fs') = checkIndentation'' pos (unComments $ nameAnn name) . checkIndentation' (unComments $ nameAnn name) fs'
+checkIndentation' pos (Section name _ fs : fs') = checkIndentation'' pos (unComments $ nameAnn name) . checkIndentation fs . checkIndentation' (unComments $ nameAnn name) fs'
 
 -- | Check that positions' columns are the same.
 checkIndentation'' :: Position -> Position -> [LexWarning] -> [LexWarning]
@@ -422,33 +531,40 @@ parseStr p = parseBS p . B8.pack
 
 parseBS  :: Show a => Parser a -> B8.ByteString -> IO ()
 parseBS p = parseTest' p "<input string>"
+#endif
 
 formatError :: B8.ByteString -> ParseError -> String
 formatError input perr =
-    unlines
-      [ "Parse error "++ show (errorPos perr) ++ ":"
-      , errLine
-      , indicator ++ errmsg ]
+  unlines
+    [ "Parse error " ++ show (errorPos perr) ++ ":"
+    , errLine
+    , indicator ++ errmsg
+    ]
   where
-    pos       = errorPos perr
-    ls        = lines' (T.decodeUtf8With T.lenientDecode input)
-    errLine   = T.unpack (ls !! (sourceLine pos - 1))
+    pos = errorPos perr
+    ls = lines' (T.decodeUtf8With T.lenientDecode input)
+    errLine = T.unpack (ls !! (sourceLine pos - 1))
     indicator = replicate (sourceColumn pos) ' ' ++ "^"
-    errmsg    = showErrorMessages "or" "unknown parse error"
-                                  "expecting" "unexpected" "end of file"
-                                  (errorMessages perr)
+    errmsg =
+      showErrorMessages
+        "or"
+        "unknown parse error"
+        "expecting"
+        "unexpected"
+        "end of file"
+        (errorMessages perr)
 
 -- | Handles windows/osx/unix line breaks uniformly
 lines' :: T.Text -> [T.Text]
 lines' s1
   | T.null s1 = []
   | otherwise = case T.break (\c -> c == '\r' || c == '\n') s1 of
-                  (l, s2) | Just (c,s3) <- T.uncons s2
-                         -> case T.uncons s3 of
-                              Just ('\n', s4) | c == '\r' -> l : lines' s4
-                              _               -> l : lines' s3
-                          | otherwise -> [l]
-#endif
+      (l, s2)
+        | Just (c, s3) <- T.uncons s2 ->
+            case T.uncons s3 of
+              Just ('\n', s4) | c == '\r' -> l : lines' s4
+              _ -> l : lines' s3
+        | otherwise -> [l]
 
 eof :: Parser ()
 eof = notFollowedBy anyToken <?> "end of file"

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -258,9 +258,7 @@ cabalStyleFile = do
     Right es' -> pure es'
 
 -- | Collect in annotation one or more comments after a parser succeeds
--- Careful with the 'Functor' instance!
--- If you use this with Field you might attach the same comments everywhere
-commentsAfter :: Functor f => Parser (f Position) -> Parser (f (WithComments Position))
+commentsAfter :: Parser (FieldLine Position) -> Parser (FieldLine (WithComments Position))
 commentsAfter p = do
   x <- p
   postCmts <- many tokComment

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -80,9 +80,6 @@ instance Stream LexState' Identity LToken where
       L _ EOF -> return Nothing
       _ -> return (Just (tok, st'))
 
--- | A strict either for parser performance
-data Either' a b = Left' !a | Right' !b
-
 -- | Get lexer warnings accumulated so far
 getLexerWarnings :: Parser [LexWarning]
 getLexerWarnings = do
@@ -257,8 +254,8 @@ cabalStyleFile = do
   es <- elements zeroIndentLevel
   eof
   case es of
-    Left' _ -> pure [] -- We discard the comments here, because it is not a valid cabal file
-    Right' es' -> pure es'
+    Left _ -> pure [] -- We discard the comments here, because it is not a valid cabal file
+    Right es' -> pure es'
 
 -- | Collect in annotation one or more comments after a parser succeeds
 -- Careful with the 'Functor' instance!
@@ -316,7 +313,7 @@ appendCommentsFieldLines cs fls = case fls of
 -- elements isn't a valid cabal file.
 --
 -- elements ::= comment* (element comment*)*
-elements :: IndentLevel -> Parser (Either' [Comment Position] [Field (WithComments Position)])
+elements :: IndentLevel -> Parser (Either [Comment Position] [Field (WithComments Position)])
 elements ilevel = do
   preCmts <- many tokComment
   es <- many $ do
@@ -325,8 +322,8 @@ elements ilevel = do
     pure $ appendCommentsField postCmts e
 
   case prependCommentsFields preCmts es of
-    Nothing -> pure $ Left' preCmts
-    Just es' -> pure $ Right' es'
+    Nothing -> pure $ Left preCmts
+    Just es' -> pure $ Right es'
 
 -- An individual element, ie a field or a section. These can either use
 -- layout style or braces style. For layout style then it must start on
@@ -360,8 +357,8 @@ elementInLayoutContext ilevel name =
             elems <- sectionLayoutOrBraces ilevel
             case elems of
               -- If there are no elements but comments, we attach them to the name (args can be multiple)
-              Left' onlyCmts -> return (Section (WithComments onlyCmts <$> name) (noComments <$> args) [])
-              Right' elems' -> return (Section (noComments name) (noComments <$> args) elems')
+              Left onlyCmts -> return (Section (WithComments onlyCmts <$> name) (noComments <$> args) [])
+              Right elems' -> return (Section (noComments name) (noComments <$> args) elems')
         )
 
 -- An element (field or section) that is valid in a non-layout context.
@@ -381,8 +378,8 @@ elementInNonLayoutContext name =
             closeBrace
 
             case elems of
-              Left' elementCmts -> return (Section (WithComments elementCmts <$> name) (noComments <$> args) [])
-              Right' elems' -> return (Section (noComments name) (noComments <$> args) elems')
+              Left elementCmts -> return (Section (WithComments elementCmts <$> name) (noComments <$> args) [])
+              Right elems' -> return (Section (noComments name) (noComments <$> args) elems')
         )
 
 -- The body of a field, using either layout style or braces style.
@@ -415,7 +412,7 @@ fieldLayoutOrBraces ilevel name = braces <|> fieldLayout
 --
 -- sectionLayoutOrBraces ::= '\\n'? '{' elements \\n? '}'
 --                         | elements
-sectionLayoutOrBraces :: IndentLevel -> Parser (Either' [Comment Position] [Field (WithComments Position)])
+sectionLayoutOrBraces :: IndentLevel -> Parser (Either [Comment Position] [Field (WithComments Position)])
 sectionLayoutOrBraces ilevel =
   ( do
       openBrace

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -177,9 +177,21 @@ newtype LexerMode = LexerMode Int
 -- This has the benefit of providing more exact error message by having more
 -- knowledge about what symbol should follow in the input stream.
 --
--- This lexer never switches to some of the states itself.
--- Instead, the parser inspects the token stream it got, and switches the lexer state.
--- Running the lexer on its own will not produce a correct token stream.
+-- The lexer states are as illustrated below.
+-- The lexer doesn't control the transitions between @in_section@, @in_field_layout@ and @in_field_braces@.
+-- Instead, the parser inspects the token stream it got, and switches the lexer state:
+-- these transitions are uniquely invoked with 'inLexerMode'.
+-- For this reason, running the lexer on its own will not produce a correct token stream.
+--
+-- @
+--                                                   .---> in_field_layout  <--->  bol_field_layout
+--                                                  /
+--                                                 /
+-- start (0) ---> bol_section <-->  in_section <--(
+--                                                 \
+--                                                  \
+--                                                   `---> in_field_braces  <--->  bol_field_braces
+-- @
 --
 -- The parser instructs the lexer to change state using the function 'inLexerMode'.
 -- It runs a parser with the given mode, and then switches back to in_section.

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -33,10 +33,12 @@ module Distribution.Fields.Parser
   ) where
 {- FOURMOLU_ENABLE -}
 
+import qualified Distribution.Compat.Lens as L
 import qualified Data.ByteString.Char8 as B8
 import Data.Functor.Identity
 import Distribution.Compat.Prelude
 import Distribution.Fields.Field
+import qualified Distribution.Fields.Field.Lens as L
 import Distribution.Fields.Lexer
 import Distribution.Fields.LexerMonad
   ( LexResult (..)
@@ -279,8 +281,8 @@ prependCommentsFields cs fs = case fs of
 -- | We attach the comments to the name (foremost child) of 'Field', this hence cannot fail.
 prependCommentsField :: [Comment ann] -> Field (WithComments ann) -> Field (WithComments ann)
 prependCommentsField cs f = case f of
-  (Field name fls) -> Field (mapComments (cs ++) <$> name) fls
-  (Section name args fs) -> Section (mapComments (cs ++) <$> name) args fs
+  (Field name fls) -> Field (L.over (traverse . L.justComments) (cs ++) name) fls
+  (Section name args fs) -> Section (L.over (traverse . L.justComments) (cs ++) name) args fs
 
 -- | Returns 'Nothing' when there is no field to attach the comments to.
 appendCommentsFields :: [Comment ann] -> [Field (WithComments ann)] -> Maybe [Field (WithComments ann)]
@@ -292,17 +294,17 @@ appendCommentsFields cs fs = case fs of
 appendCommentsField :: [Comment ann] -> Field (WithComments ann) -> Field (WithComments ann)
 appendCommentsField cs f = case f of
   (Field name fls) -> case appendCommentsFieldLines cs fls of
-    Nothing -> Field (mapComments (++ cs) <$> name) []
+    Nothing -> Field (L.over (traverse . L.justComments) (++ cs) name) []
     Just fls' -> Field name fls'
   (Section name args fs) -> case appendCommentsFields cs fs of
-    Nothing -> Section (mapComments (++ cs) <$> name) args []
+    Nothing -> Section (L.over (traverse . L.justComments) (++ cs) name) args []
     Just fs' -> Section name args fs'
 
 -- | Returns 'Nothing' when there is no field to attach the comments to.
 appendCommentsFieldLines :: [Comment ann] -> [FieldLine (WithComments ann)] -> Maybe [FieldLine (WithComments ann)]
 appendCommentsFieldLines cs fls = case fls of
   [] -> Nothing
-  [fl] -> Just [mapComments (++ cs) <$> fl]
+  [fl] -> Just [L.over (traverse . L.justComments) (++ cs) fl]
   (f : fls') -> (f :) <$> appendCommentsFieldLines cs fls'
 
 -- Elements that live at the top level or inside a section, i.e. fields

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -33,9 +33,9 @@ module Distribution.Fields.Parser
   ) where
 {- FOURMOLU_ENABLE -}
 
-import qualified Distribution.Compat.Lens as L
 import qualified Data.ByteString.Char8 as B8
 import Data.Functor.Identity
+import qualified Distribution.Compat.Lens as L
 import Distribution.Compat.Prelude
 import Distribution.Fields.Field
 import qualified Distribution.Fields.Field.Lens as L

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -355,8 +355,8 @@ elementInLayoutContext ilevel name =
             elems <- sectionLayoutOrBraces ilevel
             case elems of
               -- If there are no elements but comments, we attach them to the name (args can be multiple)
-              Left onlyCmts -> return (Section (WithComments onlyCmts <$> name) (noComments <$> args) [])
-              Right elems' -> return (Section (noComments name) (noComments <$> args) elems')
+              Left onlyCmts -> return (Section (WithComments onlyCmts <$> name) (map noComments args) [])
+              Right elems' -> return (Section (noComments name) (map noComments args) elems')
         )
 
 -- An element (field or section) that is valid in a non-layout context.
@@ -376,8 +376,8 @@ elementInNonLayoutContext name =
             closeBrace
 
             case elems of
-              Left elementCmts -> return (Section (WithComments elementCmts <$> name) (noComments <$> args) [])
-              Right elems' -> return (Section (noComments name) (noComments <$> args) elems')
+              Left elementCmts -> return (Section (WithComments elementCmts <$> name) (map noComments args) [])
+              Right elems' -> return (Section (noComments name) (map noComments args) elems')
         )
 
 -- The body of a field, using either layout style or braces style.
@@ -395,6 +395,7 @@ fieldLayoutOrBraces ilevel name = braces <|> fieldLayout
       closeBrace
       return $ Field (WithComments preCmts <$> name) ls
 
+    -- Here, we run 'fieldContent' twice separately because only the second time it is subject to the indentation constraint.
     fieldLayout :: Parser (Field (WithComments Position))
     fieldLayout = inLexerMode (LexerMode in_field_layout) $ do
       preCmts <- many tokComment

--- a/Cabal-syntax/src/Distribution/Parsec/Position.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Position.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
 module Distribution.Parsec.Position
   ( Position (..)
   , incPos
@@ -16,10 +19,11 @@ data Position
   = Position
       {-# UNPACK #-} !Int -- row
       {-# UNPACK #-} !Int -- column
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, Data)
 
 instance Binary Position
 instance NFData Position
+instance Structured Position
 
 -- | Shift position by n columns to the right.
 incPos :: Int -> Position -> Position

--- a/Cabal-syntax/src/Distribution/Parsec/Position.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Position.hs
@@ -23,7 +23,6 @@ data Position
 
 instance Binary Position
 instance NFData Position
-instance Structured Position
 
 -- | Shift position by n columns to the right.
 incPos :: Int -> Position -> Position

--- a/Cabal-syntax/src/Distribution/Parsec/Position.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Position.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric #-}
-
 module Distribution.Parsec.Position
   ( Position (..)
   , incPos
@@ -19,7 +16,7 @@ data Position
   = Position
       {-# UNPACK #-} !Int -- row
       {-# UNPACK #-} !Int -- column
-  deriving (Eq, Ord, Show, Generic, Data)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Binary Position
 instance NFData Position

--- a/Cabal-tests/tests/NoThunks.hs
+++ b/Cabal-tests/tests/NoThunks.hs
@@ -18,6 +18,7 @@ import Distribution.CabalSpecVersion          (CabalSpecVersion)
 import Distribution.Compat.NonEmptySet        (NonEmptySet)
 import Distribution.Compiler                  (CompilerFlavor, PerCompilerFlavor)
 import Distribution.Fields                    (runParseResult)
+import Distribution.Parsec.Position           (Position)
 import Distribution.ModuleName                (ModuleName)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, withSource)
 import Distribution.Parsec.Source
@@ -91,6 +92,7 @@ instance NoThunks PackageDescription
 instance NoThunks PackageFlag
 instance NoThunks PackageIdentifier
 instance NoThunks PackageName
+instance NoThunks Position
 instance NoThunks LegacyExeDependency
 instance NoThunks ExeDependency
 instance NoThunks PkgconfigName

--- a/Cabal-tests/tests/NoThunks.hs
+++ b/Cabal-tests/tests/NoThunks.hs
@@ -18,7 +18,6 @@ import Distribution.CabalSpecVersion          (CabalSpecVersion)
 import Distribution.Compat.NonEmptySet        (NonEmptySet)
 import Distribution.Compiler                  (CompilerFlavor, PerCompilerFlavor)
 import Distribution.Fields                    (runParseResult)
-import Distribution.Parsec.Position           (Position)
 import Distribution.ModuleName                (ModuleName)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, withSource)
 import Distribution.Parsec.Source
@@ -92,7 +91,6 @@ instance NoThunks PackageDescription
 instance NoThunks PackageFlag
 instance NoThunks PackageIdentifier
 instance NoThunks PackageName
-instance NoThunks Position
 instance NoThunks LegacyExeDependency
 instance NoThunks ExeDependency
 instance NoThunks PkgconfigName

--- a/Cabal-tests/tests/ParserTests.hs
+++ b/Cabal-tests/tests/ParserTests.hs
@@ -27,9 +27,7 @@ import Distribution.PackageDescription
   , condTestSuites
   , condBenchmarks
   )
-import Distribution.PackageDescription.Parsec
-  ( parseGenericPackageDescription
-  )
+import Distribution.PackageDescription.Parsec      (parseGenericPackageDescription)
 import Distribution.PackageDescription.PrettyPrint (showGenericPackageDescription)
 import Distribution.Parsec                         (PWarnType (..), PWarning (..), showPErrorWithSource, showPWarningWithSource)
 import Distribution.Pretty                         (prettyShow)
@@ -153,7 +151,7 @@ readFieldTest fname = ediffGolden goldenTest fname exprFile $ do
 #endif
 
 #ifdef MIN_VERSION_tree_diff
--- | Only assert the comment structure of a given cabal file.
+-- | Assert the comment structure of a given cabal file.
 commentTest :: FilePath -> TestTree
 commentTest fname = ediffGolden goldenTest fname exprFile $ do
   contents <- BS.readFile input
@@ -171,7 +169,7 @@ commentTest fname = ediffGolden goldenTest fname exprFile $ do
 #endif
 
 #ifdef MIN_VERSION_tree_diff
--- Extract comments to reduce the golden file's size, make it easier to verify reduce diff size.
+-- Extract comments to reduce the golden file's size and make it easier to verify.
 extractComments :: (Foldable f, Functor f) => [f (WithComments ann)] -> ([Comment ann], [f ann])
 extractComments = Bi.first mconcat . unzip . map extractCommentsStep
 #endif

--- a/Cabal-tests/tests/ParserTests.hs
+++ b/Cabal-tests/tests/ParserTests.hs
@@ -115,12 +115,12 @@ warningTest wt fp = testCase (show wt) $ do
 -- comment
 -------------------------------------------------------------------------------
 
-
-#ifdef MIN_VERSION_tree_diff
 -- Verify that comments are parsed correctly
 commentTests :: TestTree
 commentTests = testGroup "comments"
-    [ readFieldTest "layout-complex-indented-comments.cabal" -- Imported from hackage integration test
+    [
+#ifdef MIN_VERSION_tree_diff
+      readFieldTest "layout-complex-indented-comments.cabal" -- Imported from hackage integration test
     , readFieldTest "layout-comment-in-fieldline.cabal" -- Aligned leading comma after comment
 
     , commentTest "layout-nosections-before.cabal"
@@ -131,8 +131,10 @@ commentTests = testGroup "comments"
     , commentTest "layout-fieldline-is-flag.cabal"
 
     , commentTest "hasktorch.cabal" -- Taken from regression, has a lot of comments
+#endif
     ]
 
+#ifdef MIN_VERSION_tree_diff
 -- | Assert the field structure of a given Cabal file.
 readFieldTest :: FilePath -> TestTree
 readFieldTest fname = ediffGolden goldenTest fname exprFile $ do
@@ -148,7 +150,9 @@ readFieldTest fname = ediffGolden goldenTest fname exprFile $ do
   where
     input = "tests" </> "ParserTests" </> "comments" </> fname
     exprFile = replaceExtension input "expr"
+#endif
 
+#ifdef MIN_VERSION_tree_diff
 -- | Only assert the comment structure of a given cabal file.
 commentTest :: FilePath -> TestTree
 commentTest fname = ediffGolden goldenTest fname exprFile $ do
@@ -164,11 +168,15 @@ commentTest fname = ediffGolden goldenTest fname exprFile $ do
   where
     input = "tests" </> "ParserTests" </> "comments" </> fname
     exprFile = replaceExtension input "expr"
+#endif
 
+#ifdef MIN_VERSION_tree_diff
 -- Extract comments to reduce the golden file's size, make it easier to verify reduce diff size.
 extractComments :: (Foldable f, Functor f) => [f (WithComments ann)] -> ([Comment ann], [f ann])
 extractComments = Bi.first mconcat . unzip . map extractCommentsStep
+#endif
 
+#ifdef MIN_VERSION_tree_diff
 extractCommentsStep :: (Foldable f, Functor f) => f (WithComments ann) -> ([Comment ann], f ann)
 extractCommentsStep f = (foldMap justComments f, fmap unComments f)
 #endif

--- a/Cabal-tests/tests/ParserTests.hs
+++ b/Cabal-tests/tests/ParserTests.hs
@@ -10,10 +10,11 @@ import Test.Tasty
 import Test.Tasty.Golden.Advanced (goldenTest)
 import Test.Tasty.HUnit
 
-import Control.Monad                               (void)
+import Control.Monad                               (void, unless)
 import Data.Algorithm.Diff                         (PolyDiff (..), getGroupedDiff)
 import Data.Maybe                                  (isNothing)
 import Distribution.Fields                         (pwarning)
+import Distribution.Fields.Parser                  (readFieldsWithComments', formatError)
 import Distribution.PackageDescription
   ( GenericPackageDescription
   , packageDescription
@@ -26,10 +27,13 @@ import Distribution.PackageDescription
   , condTestSuites
   , condBenchmarks
   )
-import Distribution.PackageDescription.Parsec      (parseGenericPackageDescription)
+import Distribution.PackageDescription.Parsec
+  ( parseGenericPackageDescription
+  )
 import Distribution.PackageDescription.PrettyPrint (showGenericPackageDescription)
 import Distribution.Parsec                         (PWarnType (..), PWarning (..), showPErrorWithSource, showPWarningWithSource)
 import Distribution.Pretty                         (prettyShow)
+import Distribution.Fields.Field
 import Distribution.Fields.ParseResult
 import Distribution.Utils.Generic                  (fromUTF8BS, toUTF8BS)
 import System.Directory                            (setCurrentDirectory)
@@ -40,6 +44,7 @@ import Distribution.Parsec.Source
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.List.NonEmpty    as NE
+import qualified Data.Bifunctor        as Bi
 
 import qualified Distribution.InstalledPackageInfo as IPI
 
@@ -53,6 +58,7 @@ tests :: TestTree
 tests = testGroup "parsec tests"
     [ regressionTests
     , warningTests
+    , commentTests
     , errorTests
     , ipiTests
     ]
@@ -103,6 +109,69 @@ warningTest wt fp = testCase (show wt) $ do
   where
     isRight (Right _) = True
     isRight _         = False
+
+
+-------------------------------------------------------------------------------
+-- comment
+-------------------------------------------------------------------------------
+
+
+#ifdef MIN_VERSION_tree_diff
+-- Verify that comments are parsed correctly
+commentTests :: TestTree
+commentTests = testGroup "comments"
+    [ readFieldTest "layout-complex-indented-comments.cabal" -- Imported from hackage integration test
+    , readFieldTest "layout-comment-in-fieldline.cabal" -- Aligned leading comma after comment
+
+    , commentTest "layout-nosections-before.cabal"
+    , commentTest "layout-nosections-after.cabal"
+    , commentTest "layout-nosections-mixed.cabal"
+    , commentTest "layout-many-sections.cabal"
+    , commentTest "layout-interleaved-in-section.cabal"
+    , commentTest "layout-fieldline-is-flag.cabal"
+
+    , commentTest "hasktorch.cabal" -- Taken from regression, has a lot of comments
+    ]
+
+-- | Assert the field structure of a given Cabal file.
+readFieldTest :: FilePath -> TestTree
+readFieldTest fname = ediffGolden goldenTest fname exprFile $ do
+  contents <- BS.readFile input
+  let res = readFieldsWithComments' contents
+
+  case res of
+    Left perr -> fail $ formatError contents perr
+    Right (fs, warns) -> do
+      unless (null warns) (fail $ unlines (map show warns))
+      pure fs
+
+  where
+    input = "tests" </> "ParserTests" </> "comments" </> fname
+    exprFile = replaceExtension input "expr"
+
+-- | Only assert the comment structure of a given cabal file.
+commentTest :: FilePath -> TestTree
+commentTest fname = ediffGolden goldenTest fname exprFile $ do
+  contents <- BS.readFile input
+  let res = Bi.first (fst . extractComments) <$> readFieldsWithComments' contents
+
+  case res of
+    Left perr -> fail $ formatError contents perr
+    Right (cmts, warns) -> do
+      unless (null warns) (fail $ unlines (map show warns))
+      pure cmts
+
+  where
+    input = "tests" </> "ParserTests" </> "comments" </> fname
+    exprFile = replaceExtension input "expr"
+
+-- Extract comments to reduce the golden file's size, make it easier to verify reduce diff size.
+extractComments :: (Foldable f, Functor f) => [f (WithComments ann)] -> ([Comment ann], [f ann])
+extractComments = Bi.first mconcat . unzip . map extractCommentsStep
+
+extractCommentsStep :: (Foldable f, Functor f) => f (WithComments ann) -> ([Comment ann], f ann)
+extractCommentsStep f = (foldMap justComments f, fmap unComments f)
+#endif
 
 -------------------------------------------------------------------------------
 -- Errors

--- a/Cabal-tests/tests/ParserTests/comments/hasktorch.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/hasktorch.cabal
@@ -1,0 +1,558 @@
+cabal-version: 2.2
+-- ================================================================ --
+-- ======== This cabal file has been modified from dhall ========== --
+-- ======== This constitutes the 0.0.1.0 release.        ========== --
+-- ======== Dhall can generate this file, but will never ========== --
+-- ======== be able to upload to hackage. For more, see: ========== --
+-- ==== https://github.com/haskell/hackage-server/issues/795 ====== --
+-- ================================================================ --
+name: hasktorch
+version: 0.0.1.0
+license: BSD-3-Clause
+maintainer: Sam Stites <fnz@fgvgrf.vb>, Austin Huang <nhfgvau@nyhz.zvg.rqh> - cipher:ROT13
+author: Hasktorch dev team
+homepage: https://github.com/hasktorch/hasktorch#readme
+bug-reports: https://github.com/hasktorch/hasktorch/issues
+synopsis: Torch for tensors and neural networks in Haskell
+description:
+    Hasktorch is a library for tensors and neural networks in Haskell. It is an independent open source community project which leverages the core C libraries shared by Torch and PyTorch. This library leverages @cabal v2-build@ and @backpack@. *Note that this project is in early development and should only be used by contributing developers. Expect substantial changes to the library API as it evolves. Contributions and PRs are welcome (see details on github).*
+category: Tensors, Machine Learning, AI
+build-type: Simple
+
+source-repository head
+    type: git
+    location: https://github.com/hasktorch/hasktorch
+
+flag cuda
+    description:
+        build with THC support
+    default: False
+
+flag lite
+    description:
+        only build with Double and Long support
+    default: False
+
+library
+    exposed-modules:
+        Torch.Core.Exceptions
+        Torch.Core.Random
+        Torch.Core.LogAdd
+    reexported-modules: Torch.Types.Numeric,
+                        Torch.Long,
+                        Torch.Long.Dynamic,
+                        Torch.Long.Storage,
+                        Torch.Double,
+                        Torch.Double.Dynamic,
+                        Torch.Double.Storage,
+                        Torch.Double.NN,
+                        Torch.Double.NN.Activation,
+                        Torch.Double.NN.Backprop,
+                        Torch.Double.NN.Conv1d,
+                        Torch.Double.NN.Conv2d,
+                        Torch.Double.NN.Criterion,
+                        Torch.Double.NN.Layers,
+                        Torch.Double.NN.Linear,
+                        Torch.Double.NN.Math,
+                        Torch.Double.NN.Padding,
+                        Torch.Double.NN.Pooling,
+                        Torch.Double.NN.Sampling,
+                        Torch.Double.Dynamic.NN,
+                        Torch.Double.Dynamic.NN.Activation,
+                        Torch.Double.Dynamic.NN.Pooling,
+                        Torch.Double.Dynamic.NN.Criterion
+    hs-source-dirs: utils
+    default-language: Haskell2010
+    default-extensions: LambdaCase DataKinds TypeFamilies
+                        TypeSynonymInstances ScopedTypeVariables FlexibleContexts CPP
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        -- containers ==0.5.10 || >0.5.10,
+        -- deepseq ==1.3.0 || >1.3.0,
+        dimensions ==1.0 || >1.0,
+        -- managed (==1.0.0 || >1.0.0) && <1.1,
+        -- microlens ==0.4.8 || >0.4.8,
+        -- numeric-limits ==0.1.0 || >0.1.0,
+        safe-exceptions ==0.1.0 || >0.1.0,
+        singletons ==2.2 || >2.2,
+        text ==1.2.2 || >1.2.2,
+        -- typelits-witnesses ==0.2.3 || >0.2.3,
+        hasktorch-cpu -any,
+        hasktorch-ffi-th (==0.0.1 || >0.0.1) && <0.0.2,
+        hasktorch-types-th (==0.0.1 || >0.0.1) && <0.0.2
+
+    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --
+    -- BEGIN EDITS
+    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --
+    if !flag(lite)
+      reexported-modules:
+        Torch.Byte,
+        Torch.Byte.Dynamic,
+        Torch.Byte.Storage,
+        Torch.Char,
+        Torch.Char.Dynamic,
+        Torch.Char.Storage,
+        Torch.Short,
+        Torch.Short.Dynamic,
+        Torch.Short.Storage,
+        Torch.Int,
+        Torch.Int.Dynamic,
+        Torch.Int.Storage,
+        Torch.Float,
+        Torch.Float.Dynamic,
+        Torch.Float.Storage
+
+    if flag(cuda)
+      build-depends:
+        hasktorch-gpu -any
+      reexported-modules:
+        Torch.Cuda.Long,
+        Torch.Cuda.Long.Dynamic,
+        Torch.Cuda.Long.Storage,
+        Torch.Cuda.Double,
+        Torch.Cuda.Double.Dynamic,
+        Torch.Cuda.Double.Storage,
+        Torch.Cuda.Double.NN,
+        Torch.Cuda.Double.NN.Activation,
+        Torch.Cuda.Double.NN.Backprop,
+        Torch.Cuda.Double.NN.Conv1d,
+        Torch.Cuda.Double.NN.Conv2d,
+        Torch.Cuda.Double.NN.Criterion,
+        Torch.Cuda.Double.NN.Layers,
+        Torch.Cuda.Double.NN.Linear,
+        Torch.Cuda.Double.NN.Math,
+        Torch.Cuda.Double.NN.Padding,
+        Torch.Cuda.Double.NN.Pooling,
+        Torch.Cuda.Double.NN.Sampling,
+        Torch.Cuda.Double.Dynamic.NN,
+        Torch.Cuda.Double.Dynamic.NN.Activation,
+        Torch.Cuda.Double.Dynamic.NN.Pooling,
+        Torch.Cuda.Double.Dynamic.NN.Criterion
+      if !flag(lite)
+        reexported-modules:
+          Torch.Cuda.Byte,
+          Torch.Cuda.Byte.Dynamic,
+          Torch.Cuda.Byte.Storage,
+          Torch.Cuda.Char,
+          Torch.Cuda.Char.Dynamic,
+          Torch.Cuda.Char.Storage,
+          Torch.Cuda.Short,
+          Torch.Cuda.Short.Dynamic,
+          Torch.Cuda.Short.Storage,
+          Torch.Cuda.Int,
+          Torch.Cuda.Int.Dynamic,
+          Torch.Cuda.Int.Storage,
+          Torch.Cuda.Float,
+          Torch.Cuda.Float.Dynamic,
+          Torch.Cuda.Float.Storage
+    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --
+    -- END EDITS
+    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --
+
+library hasktorch-cpu
+    exposed-modules:
+        Torch.Long
+        Torch.Long.Dynamic
+        Torch.Long.Storage
+        Torch.Double
+        Torch.Double.Dynamic
+        Torch.Double.Storage
+    reexported-modules: Torch.Double.NN,
+                        Torch.Double.NN.Activation,
+                        Torch.Double.NN.Backprop,
+                        Torch.Double.NN.Conv1d,
+                        Torch.Double.NN.Conv2d,
+                        Torch.Double.NN.Criterion,
+                        Torch.Double.NN.Layers,
+                        Torch.Double.NN.Linear,
+                        Torch.Double.NN.Math,
+                        Torch.Double.NN.Padding,
+                        Torch.Double.NN.Pooling,
+                        Torch.Double.NN.Sampling,
+                        Torch.Double.Dynamic.NN,
+                        Torch.Double.Dynamic.NN.Activation,
+                        Torch.Double.Dynamic.NN.Pooling,
+                        Torch.Double.Dynamic.NN.Criterion,
+                        Torch.Float.NN,
+                        Torch.Float.NN.Activation,
+                        Torch.Float.NN.Backprop,
+                        Torch.Float.NN.Conv1d,
+                        Torch.Float.NN.Conv2d,
+                        Torch.Float.NN.Criterion,
+                        Torch.Float.NN.Layers,
+                        Torch.Float.NN.Linear,
+                        Torch.Float.NN.Math,
+                        Torch.Float.NN.Padding,
+                        Torch.Float.NN.Pooling,
+                        Torch.Float.NN.Sampling,
+                        Torch.Float.Dynamic.NN,
+                        Torch.Float.Dynamic.NN.Activation,
+                        Torch.Float.Dynamic.NN.Pooling,
+                        Torch.Float.Dynamic.NN.Criterion
+    hs-source-dirs: utils src
+    other-modules:
+        Torch.Core.Exceptions
+        Torch.Core.Random
+        Torch.Core.LogAdd
+    default-language: Haskell2010
+    default-extensions: LambdaCase DataKinds TypeFamilies
+                        TypeSynonymInstances ScopedTypeVariables FlexibleContexts CPP
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch-types-th (==0.0.1 || >0.0.1) && <0.0.2,
+        -- containers ==0.5.10 || >0.5.10,
+        -- deepseq ==1.3.0 || >1.3.0,
+        dimensions ==1.0 || >1.0,
+        hasktorch-ffi-th (==0.0.1 || >0.0.1) && <0.0.2,
+        hasktorch-types-th (==0.0.1 || >0.0.1) && <0.0.2,
+        -- managed (==1.0.0 || >1.0.0) && <1.1,
+        -- microlens ==0.4.8 || >0.4.8,
+        -- numeric-limits ==0.1.0 || >0.1.0,
+        safe-exceptions ==0.1.0 || >0.1.0,
+        singletons ==2.2 || >2.2,
+        text ==1.2.2 || >1.2.2,
+        -- typelits-witnesses ==0.2.3 || >0.2.3,
+        hasktorch-indef-floating -any,
+        hasktorch-indef-signed -any
+    mixins: hasktorch-indef-signed (Torch.Indef.Storage as Torch.Indef.Long.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Long.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Long.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Long.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Long.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Long.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Long.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Long.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Long.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Long.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Long.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Long.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Long.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Long.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Long.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Long.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Long.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Long.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Long.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Long.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Long.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Long.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Long.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Long.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Long.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Long.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Long.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Long.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Long.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Long.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Long.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Long.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Long.Types, Torch.Indef.Index as Torch.Long.Index, Torch.Indef.Mask as Torch.Long.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Long.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Long.Dynamic.Tensor.Math.Pointwise.Signed) requires (Torch.Sig.Index.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Mask.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Mask.MathReduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.State as Torch.Types.TH, Torch.Sig.Types.Global as Torch.Types.TH, Torch.Sig.Types as Torch.Types.TH.Long, Torch.Sig.Storage as Torch.FFI.TH.Long.Storage, Torch.Sig.Storage.Copy as Torch.FFI.TH.Long.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.TH.Long.FreeStorage, Torch.Sig.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.TH.Long.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Tensor.Index as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Masked as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math.Scan as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Mode as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.ScatterGather as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Sort as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.TopK as Torch.FFI.TH.Long.TensorMath, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.TH.Long.TensorMath),
+            hasktorch-indef-floating (Torch.Indef.Storage as Torch.Indef.Double.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Double.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Double.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Double.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Double.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Double.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Double.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Double.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Double.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Double.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Double.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Double.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Double.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Double.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Double.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Double.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Double.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Double.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Double.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Double.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Double.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Double.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Double.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Double.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Double.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Double.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Double.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Double.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Double.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Double.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Double.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Double.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Double.Types, Torch.Indef.Index as Torch.Double.Index, Torch.Indef.Mask as Torch.Double.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Double.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Double.Dynamic.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Blas as Torch.Indef.Double.Dynamic.Tensor.Math.Blas, Torch.Indef.Dynamic.Tensor.Math.Lapack as Torch.Indef.Double.Dynamic.Tensor.Math.Lapack, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Floating as Torch.Indef.Double.Dynamic.Tensor.Math.Pointwise.Floating, Torch.Indef.Dynamic.Tensor.Math.Reduce.Floating as Torch.Indef.Double.Dynamic.Tensor.Math.Reduce.Floating, Torch.Indef.Dynamic.Tensor.Math.Floating as Torch.Indef.Double.Dynamic.Tensor.Math.Floating, Torch.Indef.Static.Tensor.Math.Blas as Torch.Indef.Double.Tensor.Math.Blas, Torch.Indef.Static.Tensor.Math.Lapack as Torch.Indef.Double.Tensor.Math.Lapack, Torch.Indef.Static.Tensor.Math.Pointwise.Floating as Torch.Indef.Double.Tensor.Math.Pointwise.Floating, Torch.Indef.Static.Tensor.Math.Reduce.Floating as Torch.Indef.Double.Tensor.Math.Reduce.Floating, Torch.Indef.Static.Tensor.Math.Floating as Torch.Indef.Double.Tensor.Math.Floating, Torch.Indef.Static.Tensor.Random.TH as Torch.Indef.Double.Tensor.Random.TH, Torch.Indef.Static.Tensor.Math.Random.TH as Torch.Indef.Double.Tensor.Math.Random.TH, Torch.Indef.Dynamic.Tensor.Random.TH as Torch.Indef.Double.Dynamic.Tensor.Random.TH, Torch.Indef.Dynamic.Tensor.Math.Random.TH as Torch.Indef.Double.Dynamic.Tensor.Math.Random.TH, Torch.Undefined.Tensor.Random.THC as Torch.Undefined.Double.Tensor.Random.THC, Torch.Indef.Storage as Torch.Indef.Double.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Double.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Double.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Double.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Double.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Double.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Double.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Double.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Double.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Double.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Double.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Double.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Double.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Double.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Double.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Double.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Double.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Double.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Double.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Double.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Double.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Double.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Double.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Double.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Double.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Double.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Double.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Double.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Double.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Double.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Double.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Double.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Double.Types, Torch.Indef.Index as Torch.Double.Index, Torch.Indef.Mask as Torch.Double.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Double.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Double.Dynamic.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.NN as Torch.Double.Dynamic.NN, Torch.Indef.Dynamic.NN.Activation as Torch.Double.Dynamic.NN.Activation, Torch.Indef.Dynamic.NN.Pooling as Torch.Double.Dynamic.NN.Pooling, Torch.Indef.Dynamic.NN.Criterion as Torch.Double.Dynamic.NN.Criterion, Torch.Indef.Static.NN as Torch.Double.NN, Torch.Indef.Static.NN as Torch.Double.NN, Torch.Indef.Static.NN.Activation as Torch.Double.NN.Activation, Torch.Indef.Static.NN.Backprop as Torch.Double.NN.Backprop, Torch.Indef.Static.NN.Conv1d as Torch.Double.NN.Conv1d, Torch.Indef.Static.NN.Conv2d as Torch.Double.NN.Conv2d, Torch.Indef.Static.NN.Criterion as Torch.Double.NN.Criterion, Torch.Indef.Static.NN.Layers as Torch.Double.NN.Layers, Torch.Indef.Static.NN.Linear as Torch.Double.NN.Linear, Torch.Indef.Static.NN.Math as Torch.Double.NN.Math, Torch.Indef.Static.NN.Padding as Torch.Double.NN.Padding, Torch.Indef.Static.NN.Pooling as Torch.Double.NN.Pooling, Torch.Indef.Static.NN.Sampling as Torch.Double.NN.Sampling) requires (Torch.Sig.Index.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Mask.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Mask.MathReduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.State as Torch.Types.TH, Torch.Sig.Types.Global as Torch.Types.TH, Torch.Sig.Types as Torch.Types.TH.Double, Torch.Sig.Storage as Torch.FFI.TH.Double.Storage, Torch.Sig.Storage.Copy as Torch.FFI.TH.Double.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.TH.Double.FreeStorage, Torch.Sig.Tensor as Torch.FFI.TH.Double.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.TH.Double.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.TH.Double.FreeTensor, Torch.Sig.Tensor.Index as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Masked as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Scan as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Mode as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.ScatterGather as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Sort as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.TopK as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Pointwise.Floating as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Reduce.Floating as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Floating as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Blas as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Math.Lapack as Torch.FFI.TH.Double.TensorLapack, Torch.Sig.NN as Torch.FFI.TH.NN.Double, Torch.Sig.Types.NN as Torch.Types.TH, Torch.Sig.Tensor.Math.Random.TH as Torch.FFI.TH.Double.TensorMath, Torch.Sig.Tensor.Random.TH as Torch.FFI.TH.Double.TensorRandom, Torch.Sig.Tensor.Random.THC as Torch.Undefined.Double.Tensor.Random.THC)
+
+    if flag(lite)
+    else
+        exposed-modules:
+            Torch.Byte
+            Torch.Byte.Dynamic
+            Torch.Byte.Storage
+            Torch.Char
+            Torch.Char.Dynamic
+            Torch.Char.Storage
+            Torch.Short
+            Torch.Short.Dynamic
+            Torch.Short.Storage
+            Torch.Int
+            Torch.Int.Dynamic
+            Torch.Int.Storage
+            Torch.Float
+            Torch.Float.Dynamic
+            Torch.Float.Storage
+        build-depends:
+            hasktorch-indef-unsigned -any
+        mixins: hasktorch-indef-unsigned (Torch.Indef.Storage as Torch.Indef.Byte.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Byte.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Byte.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Byte.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Byte.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Byte.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Byte.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Byte.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Byte.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Byte.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Byte.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Byte.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Byte.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Byte.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Byte.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Byte.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Byte.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Byte.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Byte.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Byte.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Byte.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Byte.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Byte.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Byte.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Byte.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Byte.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Byte.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Byte.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Byte.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Byte.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Byte.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Byte.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Byte.Types, Torch.Indef.Index as Torch.Byte.Index, Torch.Indef.Mask as Torch.Byte.Mask) requires (Torch.Sig.Index.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Mask.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Mask.MathReduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.State as Torch.Types.TH, Torch.Sig.Types.Global as Torch.Types.TH, Torch.Sig.Types as Torch.Types.TH.Byte, Torch.Sig.Storage as Torch.FFI.TH.Byte.Storage, Torch.Sig.Storage.Copy as Torch.FFI.TH.Byte.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.TH.Byte.FreeStorage, Torch.Sig.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.TH.Byte.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Tensor.Index as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Masked as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Math as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Math.Scan as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Mode as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.ScatterGather as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.Sort as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.Tensor.TopK as Torch.FFI.TH.Byte.TensorMath),
+                hasktorch-indef-unsigned (Torch.Indef.Storage as Torch.Indef.Char.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Char.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Char.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Char.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Char.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Char.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Char.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Char.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Char.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Char.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Char.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Char.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Char.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Char.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Char.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Char.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Char.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Char.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Char.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Char.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Char.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Char.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Char.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Char.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Char.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Char.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Char.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Char.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Char.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Char.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Char.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Char.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Char.Types, Torch.Indef.Index as Torch.Char.Index, Torch.Indef.Mask as Torch.Char.Mask) requires (Torch.Sig.Index.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Mask.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Mask.MathReduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.State as Torch.Types.TH, Torch.Sig.Types.Global as Torch.Types.TH, Torch.Sig.Types as Torch.Types.TH.Char, Torch.Sig.Storage as Torch.FFI.TH.Char.Storage, Torch.Sig.Storage.Copy as Torch.FFI.TH.Char.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.TH.Char.FreeStorage, Torch.Sig.Tensor as Torch.FFI.TH.Char.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.TH.Char.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.TH.Char.FreeTensor, Torch.Sig.Tensor.Index as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Masked as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Math as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Math.Scan as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Mode as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.ScatterGather as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.Sort as Torch.FFI.TH.Char.TensorMath, Torch.Sig.Tensor.TopK as Torch.FFI.TH.Char.TensorMath),
+                hasktorch-indef-signed (Torch.Indef.Storage as Torch.Indef.Short.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Short.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Short.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Short.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Short.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Short.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Short.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Short.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Short.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Short.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Short.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Short.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Short.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Short.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Short.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Short.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Short.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Short.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Short.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Short.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Short.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Short.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Short.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Short.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Short.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Short.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Short.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Short.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Short.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Short.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Short.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Short.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Short.Types, Torch.Indef.Index as Torch.Short.Index, Torch.Indef.Mask as Torch.Short.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Short.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Short.Dynamic.Tensor.Math.Pointwise.Signed) requires (Torch.Sig.Index.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Mask.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Mask.MathReduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.State as Torch.Types.TH, Torch.Sig.Types.Global as Torch.Types.TH, Torch.Sig.Types as Torch.Types.TH.Short, Torch.Sig.Storage as Torch.FFI.TH.Short.Storage, Torch.Sig.Storage.Copy as Torch.FFI.TH.Short.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.TH.Short.FreeStorage, Torch.Sig.Tensor as Torch.FFI.TH.Short.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.TH.Short.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.TH.Short.FreeTensor, Torch.Sig.Tensor.Index as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Masked as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math.Scan as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Mode as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.ScatterGather as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Sort as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.TopK as Torch.FFI.TH.Short.TensorMath, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.TH.Short.TensorMath),
+                hasktorch-indef-signed (Torch.Indef.Storage as Torch.Indef.Int.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Int.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Int.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Int.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Int.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Int.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Int.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Int.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Int.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Int.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Int.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Int.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Int.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Int.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Int.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Int.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Int.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Int.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Int.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Int.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Int.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Int.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Int.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Int.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Int.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Int.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Int.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Int.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Int.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Int.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Int.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Int.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Int.Types, Torch.Indef.Index as Torch.Int.Index, Torch.Indef.Mask as Torch.Int.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Int.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Int.Dynamic.Tensor.Math.Pointwise.Signed) requires (Torch.Sig.Index.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Mask.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Mask.MathReduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.State as Torch.Types.TH, Torch.Sig.Types.Global as Torch.Types.TH, Torch.Sig.Types as Torch.Types.TH.Int, Torch.Sig.Storage as Torch.FFI.TH.Int.Storage, Torch.Sig.Storage.Copy as Torch.FFI.TH.Int.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.TH.Int.FreeStorage, Torch.Sig.Tensor as Torch.FFI.TH.Int.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.TH.Int.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.TH.Int.FreeTensor, Torch.Sig.Tensor.Index as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Masked as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math.Scan as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Mode as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.ScatterGather as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Sort as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.TopK as Torch.FFI.TH.Int.TensorMath, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.TH.Int.TensorMath),
+                hasktorch-indef-floating (Torch.Indef.Storage as Torch.Indef.Float.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Float.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Float.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Float.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Float.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Float.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Float.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Float.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Float.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Float.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Float.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Float.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Float.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Float.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Float.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Float.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Float.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Float.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Float.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Float.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Float.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Float.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Float.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Float.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Float.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Float.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Float.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Float.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Float.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Float.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Float.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Float.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Float.Types, Torch.Indef.Index as Torch.Float.Index, Torch.Indef.Mask as Torch.Float.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Float.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Float.Dynamic.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Blas as Torch.Indef.Float.Dynamic.Tensor.Math.Blas, Torch.Indef.Dynamic.Tensor.Math.Lapack as Torch.Indef.Float.Dynamic.Tensor.Math.Lapack, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Floating as Torch.Indef.Float.Dynamic.Tensor.Math.Pointwise.Floating, Torch.Indef.Dynamic.Tensor.Math.Reduce.Floating as Torch.Indef.Float.Dynamic.Tensor.Math.Reduce.Floating, Torch.Indef.Dynamic.Tensor.Math.Floating as Torch.Indef.Float.Dynamic.Tensor.Math.Floating, Torch.Indef.Static.Tensor.Math.Blas as Torch.Indef.Float.Tensor.Math.Blas, Torch.Indef.Static.Tensor.Math.Lapack as Torch.Indef.Float.Tensor.Math.Lapack, Torch.Indef.Static.Tensor.Math.Pointwise.Floating as Torch.Indef.Float.Tensor.Math.Pointwise.Floating, Torch.Indef.Static.Tensor.Math.Reduce.Floating as Torch.Indef.Float.Tensor.Math.Reduce.Floating, Torch.Indef.Static.Tensor.Math.Floating as Torch.Indef.Float.Tensor.Math.Floating, Torch.Indef.Static.Tensor.Random.TH as Torch.Indef.Float.Tensor.Random.TH, Torch.Indef.Static.Tensor.Math.Random.TH as Torch.Indef.Float.Tensor.Math.Random.TH, Torch.Indef.Dynamic.Tensor.Random.TH as Torch.Indef.Float.Dynamic.Tensor.Random.TH, Torch.Indef.Dynamic.Tensor.Math.Random.TH as Torch.Indef.Float.Dynamic.Tensor.Math.Random.TH, Torch.Undefined.Tensor.Random.THC as Torch.Undefined.Float.Tensor.Random.THC, Torch.Indef.Storage as Torch.Indef.Float.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Float.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Float.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Float.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Float.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Float.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Float.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Float.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Float.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Float.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Float.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Float.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Float.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Float.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Float.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Float.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Float.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Float.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Float.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Float.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Float.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Float.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Float.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Float.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Float.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Float.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Float.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Float.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Float.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Float.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Float.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Float.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Float.Types, Torch.Indef.Index as Torch.Float.Index, Torch.Indef.Mask as Torch.Float.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Float.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Float.Dynamic.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.NN as Torch.Float.Dynamic.NN, Torch.Indef.Dynamic.NN.Activation as Torch.Float.Dynamic.NN.Activation, Torch.Indef.Dynamic.NN.Pooling as Torch.Float.Dynamic.NN.Pooling, Torch.Indef.Dynamic.NN.Criterion as Torch.Float.Dynamic.NN.Criterion, Torch.Indef.Static.NN as Torch.Float.NN, Torch.Indef.Static.NN as Torch.Float.NN, Torch.Indef.Static.NN.Activation as Torch.Float.NN.Activation, Torch.Indef.Static.NN.Backprop as Torch.Float.NN.Backprop, Torch.Indef.Static.NN.Conv1d as Torch.Float.NN.Conv1d, Torch.Indef.Static.NN.Conv2d as Torch.Float.NN.Conv2d, Torch.Indef.Static.NN.Criterion as Torch.Float.NN.Criterion, Torch.Indef.Static.NN.Layers as Torch.Float.NN.Layers, Torch.Indef.Static.NN.Linear as Torch.Float.NN.Linear, Torch.Indef.Static.NN.Math as Torch.Float.NN.Math, Torch.Indef.Static.NN.Padding as Torch.Float.NN.Padding, Torch.Indef.Static.NN.Pooling as Torch.Float.NN.Pooling, Torch.Indef.Static.NN.Sampling as Torch.Float.NN.Sampling) requires (Torch.Sig.Index.Tensor as Torch.FFI.TH.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.TH.Long.FreeTensor, Torch.Sig.Mask.Tensor as Torch.FFI.TH.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.TH.Byte.FreeTensor, Torch.Sig.Mask.MathReduce as Torch.FFI.TH.Byte.TensorMath, Torch.Sig.State as Torch.Types.TH, Torch.Sig.Types.Global as Torch.Types.TH, Torch.Sig.Types as Torch.Types.TH.Float, Torch.Sig.Storage as Torch.FFI.TH.Float.Storage, Torch.Sig.Storage.Copy as Torch.FFI.TH.Float.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.TH.Float.FreeStorage, Torch.Sig.Tensor as Torch.FFI.TH.Float.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.TH.Float.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.TH.Float.FreeTensor, Torch.Sig.Tensor.Index as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Masked as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Scan as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Mode as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.ScatterGather as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Sort as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.TopK as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Pointwise.Floating as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Reduce.Floating as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Floating as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Blas as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Math.Lapack as Torch.FFI.TH.Float.TensorLapack, Torch.Sig.NN as Torch.FFI.TH.NN.Float, Torch.Sig.Types.NN as Torch.Types.TH, Torch.Sig.Tensor.Math.Random.TH as Torch.FFI.TH.Float.TensorMath, Torch.Sig.Tensor.Random.TH as Torch.FFI.TH.Float.TensorRandom, Torch.Sig.Tensor.Random.THC as Torch.Undefined.Float.Tensor.Random.THC)
+
+library hasktorch-gpu
+    exposed-modules:
+        Torch.Cuda.Long
+        Torch.Cuda.Long.Dynamic
+        Torch.Cuda.Long.Storage
+        Torch.Cuda.Double
+        Torch.Cuda.Double.Dynamic
+        Torch.Cuda.Double.Storage
+    reexported-modules: Torch.Cuda.Double.NN,
+                        Torch.Cuda.Double.NN.Activation,
+                        Torch.Cuda.Double.NN.Backprop,
+                        Torch.Cuda.Double.NN.Conv1d,
+                        Torch.Cuda.Double.NN.Conv2d,
+                        Torch.Cuda.Double.NN.Criterion,
+                        Torch.Cuda.Double.NN.Layers,
+                        Torch.Cuda.Double.NN.Linear,
+                        Torch.Cuda.Double.NN.Math,
+                        Torch.Cuda.Double.NN.Padding,
+                        Torch.Cuda.Double.NN.Pooling,
+                        Torch.Cuda.Double.NN.Sampling,
+                        Torch.Cuda.Double.Dynamic.NN,
+                        Torch.Cuda.Double.Dynamic.NN.Activation,
+                        Torch.Cuda.Double.Dynamic.NN.Pooling,
+                        Torch.Cuda.Double.Dynamic.NN.Criterion
+    cpp-options: -DCUDA -DHASKTORCH_INTERNAL_CUDA
+    hs-source-dirs: utils src
+    other-modules:
+        Torch.Core.Exceptions
+        Torch.Core.Random
+        Torch.Core.LogAdd
+    default-language: Haskell2010
+    default-extensions: LambdaCase DataKinds TypeFamilies
+                        TypeSynonymInstances ScopedTypeVariables FlexibleContexts CPP
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch-types-th (==0.0.1 || >0.0.1) && <0.0.2,
+        -- containers ==0.5.10 || >0.5.10,
+        -- deepseq ==1.3.0 || >1.3.0,
+        dimensions ==1.0 || >1.0,
+        hasktorch-ffi-th (==0.0.1 || >0.0.1) && <0.0.2,
+        hasktorch-types-th (==0.0.1 || >0.0.1) && <0.0.2,
+        -- managed (==1.0.0 || >1.0.0) && <1.1,
+        -- microlens ==0.4.8 || >0.4.8,
+        -- numeric-limits ==0.1.0 || >0.1.0,
+        safe-exceptions ==0.1.0 || >0.1.0,
+        singletons ==2.2 || >2.2,
+        text ==1.2.2 || >1.2.2,
+        -- typelits-witnesses ==0.2.3 || >0.2.3,
+        hasktorch-indef-floating -any,
+        hasktorch-indef-signed -any,
+        hasktorch-ffi-thc (==0.0.1 || >0.0.1) && <0.0.2,
+        hasktorch-types-thc (==0.0.1 || >0.0.1) && <0.0.2
+    mixins: hasktorch-indef-signed (Torch.Indef.Storage as Torch.Indef.Cuda.Long.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Cuda.Long.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Cuda.Long.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Cuda.Long.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Cuda.Long.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Cuda.Long.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Cuda.Long.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Cuda.Long.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Cuda.Long.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Cuda.Long.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Cuda.Long.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Cuda.Long.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Cuda.Long.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Cuda.Long.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Cuda.Long.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Cuda.Long.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Cuda.Long.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Cuda.Long.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Cuda.Long.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Cuda.Long.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Cuda.Long.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Cuda.Long.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Cuda.Long.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Cuda.Long.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Cuda.Long.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Cuda.Long.Types, Torch.Indef.Index as Torch.Cuda.Long.Index, Torch.Indef.Mask as Torch.Cuda.Long.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Long.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Long.Dynamic.Tensor.Math.Pointwise.Signed) requires (Torch.Sig.Index.Tensor as Torch.FFI.THC.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.THC.Long.Tensor, Torch.Sig.Mask.Tensor as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.MathReduce as Torch.FFI.THC.Byte.TensorMathReduce, Torch.Sig.State as Torch.FFI.THC.State, Torch.Sig.Types.Global as Torch.Types.THC, Torch.Sig.Types as Torch.Types.THC.Long, Torch.Sig.Storage as Torch.FFI.THC.Long.Storage, Torch.Sig.Storage.Copy as Torch.FFI.THC.Long.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.THC.Long.Storage, Torch.Sig.Tensor as Torch.FFI.THC.Long.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.THC.Long.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.THC.Long.Tensor, Torch.Sig.Tensor.Index as Torch.FFI.THC.Long.TensorIndex, Torch.Sig.Tensor.Masked as Torch.FFI.THC.Long.TensorMasked, Torch.Sig.Tensor.Math as Torch.FFI.THC.Long.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.THC.Long.TensorMathCompare, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.THC.Long.TensorMathCompareT, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.THC.Long.TensorMathPairwise, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.THC.Long.TensorMathPointwise, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.THC.Long.TensorMathReduce, Torch.Sig.Tensor.Math.Scan as Torch.FFI.THC.Long.TensorMathScan, Torch.Sig.Tensor.Mode as Torch.FFI.THC.Long.TensorMode, Torch.Sig.Tensor.ScatterGather as Torch.FFI.THC.Long.TensorScatterGather, Torch.Sig.Tensor.Sort as Torch.FFI.THC.Long.TensorSort, Torch.Sig.Tensor.TopK as Torch.FFI.THC.Long.TensorTopK, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.THC.Long.TensorMathPointwise),
+            hasktorch-indef-floating (Torch.Indef.Storage as Torch.Indef.Cuda.Double.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Cuda.Double.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Cuda.Double.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Cuda.Double.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Cuda.Double.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Cuda.Double.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Cuda.Double.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Cuda.Double.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Cuda.Double.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Cuda.Double.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Cuda.Double.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Cuda.Double.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Cuda.Double.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Cuda.Double.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Cuda.Double.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Cuda.Double.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Cuda.Double.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Cuda.Double.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Cuda.Double.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Cuda.Double.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Cuda.Double.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Cuda.Double.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Cuda.Double.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Cuda.Double.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Cuda.Double.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Cuda.Double.Types, Torch.Indef.Index as Torch.Cuda.Double.Index, Torch.Indef.Mask as Torch.Cuda.Double.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Double.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Blas as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Blas, Torch.Indef.Dynamic.Tensor.Math.Lapack as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Lapack, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Floating as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Pointwise.Floating, Torch.Indef.Dynamic.Tensor.Math.Reduce.Floating as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Reduce.Floating, Torch.Indef.Dynamic.Tensor.Math.Floating as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Floating, Torch.Indef.Static.Tensor.Math.Blas as Torch.Indef.Cuda.Double.Tensor.Math.Blas, Torch.Indef.Static.Tensor.Math.Lapack as Torch.Indef.Cuda.Double.Tensor.Math.Lapack, Torch.Indef.Static.Tensor.Math.Pointwise.Floating as Torch.Indef.Cuda.Double.Tensor.Math.Pointwise.Floating, Torch.Indef.Static.Tensor.Math.Reduce.Floating as Torch.Indef.Cuda.Double.Tensor.Math.Reduce.Floating, Torch.Indef.Static.Tensor.Math.Floating as Torch.Indef.Cuda.Double.Tensor.Math.Floating, Torch.Undefined.Tensor.Random.TH as Torch.Undefined.Cuda.Double.Tensor.Random.TH, Torch.Undefined.Tensor.Math.Random.TH as Torch.Undefined.Cuda.Double.Tensor.Math.Random.TH, Torch.Indef.Static.Tensor.Random.THC as Torch.Indef.Cuda.Double.Tensor.Random.THC, Torch.Indef.Dynamic.Tensor.Random.THC as Torch.Indef.Cuda.Double.Dynamic.Tensor.Random.THC, Torch.Indef.Storage as Torch.Indef.Cuda.Double.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Cuda.Double.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Cuda.Double.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Cuda.Double.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Cuda.Double.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Cuda.Double.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Cuda.Double.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Cuda.Double.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Cuda.Double.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Cuda.Double.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Cuda.Double.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Cuda.Double.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Cuda.Double.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Cuda.Double.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Cuda.Double.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Cuda.Double.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Cuda.Double.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Cuda.Double.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Cuda.Double.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Cuda.Double.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Cuda.Double.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Cuda.Double.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Cuda.Double.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Cuda.Double.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Cuda.Double.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Cuda.Double.Types, Torch.Indef.Index as Torch.Cuda.Double.Index, Torch.Indef.Mask as Torch.Cuda.Double.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Double.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Double.Dynamic.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.NN as Torch.Cuda.Double.Dynamic.NN, Torch.Indef.Dynamic.NN.Activation as Torch.Cuda.Double.Dynamic.NN.Activation, Torch.Indef.Dynamic.NN.Pooling as Torch.Cuda.Double.Dynamic.NN.Pooling, Torch.Indef.Dynamic.NN.Criterion as Torch.Cuda.Double.Dynamic.NN.Criterion, Torch.Indef.Static.NN as Torch.Cuda.Double.NN, Torch.Indef.Static.NN as Torch.Cuda.Double.NN, Torch.Indef.Static.NN.Activation as Torch.Cuda.Double.NN.Activation, Torch.Indef.Static.NN.Backprop as Torch.Cuda.Double.NN.Backprop, Torch.Indef.Static.NN.Conv1d as Torch.Cuda.Double.NN.Conv1d, Torch.Indef.Static.NN.Conv2d as Torch.Cuda.Double.NN.Conv2d, Torch.Indef.Static.NN.Criterion as Torch.Cuda.Double.NN.Criterion, Torch.Indef.Static.NN.Layers as Torch.Cuda.Double.NN.Layers, Torch.Indef.Static.NN.Linear as Torch.Cuda.Double.NN.Linear, Torch.Indef.Static.NN.Math as Torch.Cuda.Double.NN.Math, Torch.Indef.Static.NN.Padding as Torch.Cuda.Double.NN.Padding, Torch.Indef.Static.NN.Pooling as Torch.Cuda.Double.NN.Pooling, Torch.Indef.Static.NN.Sampling as Torch.Cuda.Double.NN.Sampling) requires (Torch.Sig.Index.Tensor as Torch.FFI.THC.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.THC.Long.Tensor, Torch.Sig.Mask.Tensor as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.MathReduce as Torch.FFI.THC.Byte.TensorMathReduce, Torch.Sig.State as Torch.FFI.THC.State, Torch.Sig.Types.Global as Torch.Types.THC, Torch.Sig.Types as Torch.Types.THC.Double, Torch.Sig.Storage as Torch.FFI.THC.Double.Storage, Torch.Sig.Storage.Copy as Torch.FFI.THC.Double.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.THC.Double.Storage, Torch.Sig.Tensor as Torch.FFI.THC.Double.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.THC.Double.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.THC.Double.Tensor, Torch.Sig.Tensor.Index as Torch.FFI.THC.Double.TensorIndex, Torch.Sig.Tensor.Masked as Torch.FFI.THC.Double.TensorMasked, Torch.Sig.Tensor.Math as Torch.FFI.THC.Double.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.THC.Double.TensorMathCompare, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.THC.Double.TensorMathCompareT, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.THC.Double.TensorMathPairwise, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.THC.Double.TensorMathPointwise, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.THC.Double.TensorMathReduce, Torch.Sig.Tensor.Math.Scan as Torch.FFI.THC.Double.TensorMathScan, Torch.Sig.Tensor.Mode as Torch.FFI.THC.Double.TensorMode, Torch.Sig.Tensor.ScatterGather as Torch.FFI.THC.Double.TensorScatterGather, Torch.Sig.Tensor.Sort as Torch.FFI.THC.Double.TensorSort, Torch.Sig.Tensor.TopK as Torch.FFI.THC.Double.TensorTopK, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.THC.Double.TensorMathPointwise, Torch.Sig.Tensor.Math.Pointwise.Floating as Torch.FFI.THC.Double.TensorMathPointwise, Torch.Sig.Tensor.Math.Reduce.Floating as Torch.FFI.THC.Double.TensorMathReduce, Torch.Sig.Tensor.Math.Floating as Torch.FFI.THC.Double.TensorMath, Torch.Sig.Tensor.Math.Blas as Torch.FFI.THC.Double.TensorMathBlas, Torch.Sig.Tensor.Math.Lapack as Torch.FFI.THC.Double.TensorMathMagma, Torch.Sig.NN as Torch.FFI.THC.NN.Double, Torch.Sig.Types.NN as Torch.Types.THC, Torch.Sig.Tensor.Math.Random.TH as Torch.Undefined.Cuda.Double.Tensor.Math.Random.TH, Torch.Sig.Tensor.Random.TH as Torch.Undefined.Cuda.Double.Tensor.Random.TH, Torch.Sig.Tensor.Random.THC as Torch.FFI.THC.Double.TensorRandom)
+
+    if flag(lite)
+    else
+        exposed-modules:
+            Torch.Cuda.Byte
+            Torch.Cuda.Byte.Dynamic
+            Torch.Cuda.Byte.Storage
+            Torch.Cuda.Char
+            Torch.Cuda.Char.Dynamic
+            Torch.Cuda.Char.Storage
+            Torch.Cuda.Short
+            Torch.Cuda.Short.Dynamic
+            Torch.Cuda.Short.Storage
+            Torch.Cuda.Int
+            Torch.Cuda.Int.Dynamic
+            Torch.Cuda.Int.Storage
+        build-depends:
+            hasktorch-indef-unsigned -any
+        mixins: hasktorch-indef-unsigned (Torch.Indef.Storage as Torch.Indef.Cuda.Byte.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Cuda.Byte.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Cuda.Byte.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Cuda.Byte.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Cuda.Byte.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Cuda.Byte.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Cuda.Byte.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Cuda.Byte.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Cuda.Byte.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Cuda.Byte.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Cuda.Byte.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Cuda.Byte.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Cuda.Byte.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Cuda.Byte.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Cuda.Byte.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Cuda.Byte.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Cuda.Byte.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Cuda.Byte.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Cuda.Byte.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Cuda.Byte.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Cuda.Byte.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Cuda.Byte.Types, Torch.Indef.Index as Torch.Cuda.Byte.Index, Torch.Indef.Mask as Torch.Cuda.Byte.Mask) requires (Torch.Sig.Index.Tensor as Torch.FFI.THC.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.THC.Long.Tensor, Torch.Sig.Mask.Tensor as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.MathReduce as Torch.FFI.THC.Byte.TensorMathReduce, Torch.Sig.State as Torch.FFI.THC.State, Torch.Sig.Types.Global as Torch.Types.THC, Torch.Sig.Types as Torch.Types.THC.Byte, Torch.Sig.Storage as Torch.FFI.THC.Byte.Storage, Torch.Sig.Storage.Copy as Torch.FFI.THC.Byte.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.THC.Byte.Storage, Torch.Sig.Tensor as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.THC.Byte.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Tensor.Index as Torch.FFI.THC.Byte.TensorIndex, Torch.Sig.Tensor.Masked as Torch.FFI.THC.Byte.TensorMasked, Torch.Sig.Tensor.Math as Torch.FFI.THC.Byte.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.THC.Byte.TensorMathCompare, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.THC.Byte.TensorMathCompareT, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.THC.Byte.TensorMathPairwise, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.THC.Byte.TensorMathPointwise, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.THC.Byte.TensorMathReduce, Torch.Sig.Tensor.Math.Scan as Torch.FFI.THC.Byte.TensorMathScan, Torch.Sig.Tensor.Mode as Torch.FFI.THC.Byte.TensorMode, Torch.Sig.Tensor.ScatterGather as Torch.FFI.THC.Byte.TensorScatterGather, Torch.Sig.Tensor.Sort as Torch.FFI.THC.Byte.TensorSort, Torch.Sig.Tensor.TopK as Torch.FFI.THC.Byte.TensorTopK),
+                hasktorch-indef-unsigned (Torch.Indef.Storage as Torch.Indef.Cuda.Char.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Cuda.Char.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Cuda.Char.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Cuda.Char.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Cuda.Char.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Cuda.Char.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Cuda.Char.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Cuda.Char.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Cuda.Char.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Cuda.Char.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Cuda.Char.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Cuda.Char.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Cuda.Char.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Cuda.Char.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Cuda.Char.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Cuda.Char.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Cuda.Char.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Cuda.Char.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Cuda.Char.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Cuda.Char.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Cuda.Char.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Cuda.Char.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Cuda.Char.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Cuda.Char.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Cuda.Char.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Cuda.Char.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Cuda.Char.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Cuda.Char.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Cuda.Char.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Cuda.Char.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Cuda.Char.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Cuda.Char.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Cuda.Char.Types, Torch.Indef.Index as Torch.Cuda.Char.Index, Torch.Indef.Mask as Torch.Cuda.Char.Mask) requires (Torch.Sig.Index.Tensor as Torch.FFI.THC.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.THC.Long.Tensor, Torch.Sig.Mask.Tensor as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.MathReduce as Torch.FFI.THC.Byte.TensorMathReduce, Torch.Sig.State as Torch.FFI.THC.State, Torch.Sig.Types.Global as Torch.Types.THC, Torch.Sig.Types as Torch.Types.THC.Char, Torch.Sig.Storage as Torch.FFI.THC.Char.Storage, Torch.Sig.Storage.Copy as Torch.FFI.THC.Char.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.THC.Char.Storage, Torch.Sig.Tensor as Torch.FFI.THC.Char.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.THC.Char.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.THC.Char.Tensor, Torch.Sig.Tensor.Index as Torch.FFI.THC.Char.TensorIndex, Torch.Sig.Tensor.Masked as Torch.FFI.THC.Char.TensorMasked, Torch.Sig.Tensor.Math as Torch.FFI.THC.Char.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.THC.Char.TensorMathCompare, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.THC.Char.TensorMathCompareT, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.THC.Char.TensorMathPairwise, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.THC.Char.TensorMathPointwise, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.THC.Char.TensorMathReduce, Torch.Sig.Tensor.Math.Scan as Torch.FFI.THC.Char.TensorMathScan, Torch.Sig.Tensor.Mode as Torch.FFI.THC.Char.TensorMode, Torch.Sig.Tensor.ScatterGather as Torch.FFI.THC.Char.TensorScatterGather, Torch.Sig.Tensor.Sort as Torch.FFI.THC.Char.TensorSort, Torch.Sig.Tensor.TopK as Torch.FFI.THC.Char.TensorTopK),
+                hasktorch-indef-signed (Torch.Indef.Storage as Torch.Indef.Cuda.Short.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Cuda.Short.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Cuda.Short.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Cuda.Short.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Cuda.Short.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Cuda.Short.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Cuda.Short.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Cuda.Short.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Cuda.Short.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Cuda.Short.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Cuda.Short.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Cuda.Short.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Cuda.Short.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Cuda.Short.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Cuda.Short.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Cuda.Short.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Cuda.Short.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Cuda.Short.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Cuda.Short.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Cuda.Short.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Cuda.Short.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Cuda.Short.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Cuda.Short.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Cuda.Short.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Cuda.Short.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Cuda.Short.Types, Torch.Indef.Index as Torch.Cuda.Short.Index, Torch.Indef.Mask as Torch.Cuda.Short.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Short.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Short.Dynamic.Tensor.Math.Pointwise.Signed) requires (Torch.Sig.Index.Tensor as Torch.FFI.THC.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.THC.Long.Tensor, Torch.Sig.Mask.Tensor as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.MathReduce as Torch.FFI.THC.Byte.TensorMathReduce, Torch.Sig.State as Torch.FFI.THC.State, Torch.Sig.Types.Global as Torch.Types.THC, Torch.Sig.Types as Torch.Types.THC.Short, Torch.Sig.Storage as Torch.FFI.THC.Short.Storage, Torch.Sig.Storage.Copy as Torch.FFI.THC.Short.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.THC.Short.Storage, Torch.Sig.Tensor as Torch.FFI.THC.Short.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.THC.Short.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.THC.Short.Tensor, Torch.Sig.Tensor.Index as Torch.FFI.THC.Short.TensorIndex, Torch.Sig.Tensor.Masked as Torch.FFI.THC.Short.TensorMasked, Torch.Sig.Tensor.Math as Torch.FFI.THC.Short.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.THC.Short.TensorMathCompare, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.THC.Short.TensorMathCompareT, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.THC.Short.TensorMathPairwise, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.THC.Short.TensorMathPointwise, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.THC.Short.TensorMathReduce, Torch.Sig.Tensor.Math.Scan as Torch.FFI.THC.Short.TensorMathScan, Torch.Sig.Tensor.Mode as Torch.FFI.THC.Short.TensorMode, Torch.Sig.Tensor.ScatterGather as Torch.FFI.THC.Short.TensorScatterGather, Torch.Sig.Tensor.Sort as Torch.FFI.THC.Short.TensorSort, Torch.Sig.Tensor.TopK as Torch.FFI.THC.Short.TensorTopK, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.THC.Short.TensorMathPointwise),
+                hasktorch-indef-signed (Torch.Indef.Storage as Torch.Indef.Cuda.Int.Storage, Torch.Indef.Storage.Copy as Torch.Indef.Cuda.Int.Storage.Copy, Torch.Indef.Static.Tensor as Torch.Indef.Cuda.Int.Tensor, Torch.Indef.Static.Tensor.Copy as Torch.Indef.Cuda.Int.Tensor.Copy, Torch.Indef.Static.Tensor.Index as Torch.Indef.Cuda.Int.Tensor.Index, Torch.Indef.Static.Tensor.Masked as Torch.Indef.Cuda.Int.Tensor.Masked, Torch.Indef.Static.Tensor.Math as Torch.Indef.Cuda.Int.Tensor.Math, Torch.Indef.Static.Tensor.Math.Compare as Torch.Indef.Cuda.Int.Tensor.Math.Compare, Torch.Indef.Static.Tensor.Math.CompareT as Torch.Indef.Cuda.Int.Tensor.Math.CompareT, Torch.Indef.Static.Tensor.Math.Pairwise as Torch.Indef.Cuda.Int.Tensor.Math.Pairwise, Torch.Indef.Static.Tensor.Math.Pointwise as Torch.Indef.Cuda.Int.Tensor.Math.Pointwise, Torch.Indef.Static.Tensor.Math.Reduce as Torch.Indef.Cuda.Int.Tensor.Math.Reduce, Torch.Indef.Static.Tensor.Math.Scan as Torch.Indef.Cuda.Int.Tensor.Math.Scan, Torch.Indef.Static.Tensor.Mode as Torch.Indef.Cuda.Int.Tensor.Mode, Torch.Indef.Static.Tensor.ScatterGather as Torch.Indef.Cuda.Int.Tensor.ScatterGather, Torch.Indef.Static.Tensor.Sort as Torch.Indef.Cuda.Int.Tensor.Sort, Torch.Indef.Static.Tensor.TopK as Torch.Indef.Cuda.Int.Tensor.TopK, Torch.Indef.Dynamic.Tensor as Torch.Indef.Cuda.Int.Dynamic.Tensor, Torch.Indef.Dynamic.Tensor.Copy as Torch.Indef.Cuda.Int.Dynamic.Tensor.Copy, Torch.Indef.Dynamic.Tensor.Index as Torch.Indef.Cuda.Int.Dynamic.Tensor.Index, Torch.Indef.Dynamic.Tensor.Masked as Torch.Indef.Cuda.Int.Dynamic.Tensor.Masked, Torch.Indef.Dynamic.Tensor.Math as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math, Torch.Indef.Dynamic.Tensor.Math.Compare as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math.Compare, Torch.Indef.Dynamic.Tensor.Math.CompareT as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math.CompareT, Torch.Indef.Dynamic.Tensor.Math.Pairwise as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math.Pairwise, Torch.Indef.Dynamic.Tensor.Math.Pointwise as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math.Pointwise, Torch.Indef.Dynamic.Tensor.Math.Reduce as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math.Reduce, Torch.Indef.Dynamic.Tensor.Math.Scan as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math.Scan, Torch.Indef.Dynamic.Tensor.Mode as Torch.Indef.Cuda.Int.Dynamic.Tensor.Mode, Torch.Indef.Dynamic.Tensor.ScatterGather as Torch.Indef.Cuda.Int.Dynamic.Tensor.ScatterGather, Torch.Indef.Dynamic.Tensor.Sort as Torch.Indef.Cuda.Int.Dynamic.Tensor.Sort, Torch.Indef.Dynamic.Tensor.TopK as Torch.Indef.Cuda.Int.Dynamic.Tensor.TopK, Torch.Indef.Types as Torch.Cuda.Int.Types, Torch.Indef.Index as Torch.Cuda.Int.Index, Torch.Indef.Mask as Torch.Cuda.Int.Mask, Torch.Indef.Static.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Int.Tensor.Math.Pointwise.Signed, Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed as Torch.Indef.Cuda.Int.Dynamic.Tensor.Math.Pointwise.Signed) requires (Torch.Sig.Index.Tensor as Torch.FFI.THC.Long.Tensor, Torch.Sig.Index.TensorFree as Torch.FFI.THC.Long.Tensor, Torch.Sig.Mask.Tensor as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.TensorFree as Torch.FFI.THC.Byte.Tensor, Torch.Sig.Mask.MathReduce as Torch.FFI.THC.Byte.TensorMathReduce, Torch.Sig.State as Torch.FFI.THC.State, Torch.Sig.Types.Global as Torch.Types.THC, Torch.Sig.Types as Torch.Types.THC.Int, Torch.Sig.Storage as Torch.FFI.THC.Int.Storage, Torch.Sig.Storage.Copy as Torch.FFI.THC.Int.StorageCopy, Torch.Sig.Storage.Memory as Torch.FFI.THC.Int.Storage, Torch.Sig.Tensor as Torch.FFI.THC.Int.Tensor, Torch.Sig.Tensor.Copy as Torch.FFI.THC.Int.TensorCopy, Torch.Sig.Tensor.Memory as Torch.FFI.THC.Int.Tensor, Torch.Sig.Tensor.Index as Torch.FFI.THC.Int.TensorIndex, Torch.Sig.Tensor.Masked as Torch.FFI.THC.Int.TensorMasked, Torch.Sig.Tensor.Math as Torch.FFI.THC.Int.TensorMath, Torch.Sig.Tensor.Math.Compare as Torch.FFI.THC.Int.TensorMathCompare, Torch.Sig.Tensor.Math.CompareT as Torch.FFI.THC.Int.TensorMathCompareT, Torch.Sig.Tensor.Math.Pairwise as Torch.FFI.THC.Int.TensorMathPairwise, Torch.Sig.Tensor.Math.Pointwise as Torch.FFI.THC.Int.TensorMathPointwise, Torch.Sig.Tensor.Math.Reduce as Torch.FFI.THC.Int.TensorMathReduce, Torch.Sig.Tensor.Math.Scan as Torch.FFI.THC.Int.TensorMathScan, Torch.Sig.Tensor.Mode as Torch.FFI.THC.Int.TensorMode, Torch.Sig.Tensor.ScatterGather as Torch.FFI.THC.Int.TensorScatterGather, Torch.Sig.Tensor.Sort as Torch.FFI.THC.Int.TensorSort, Torch.Sig.Tensor.TopK as Torch.FFI.THC.Int.TensorTopK, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.FFI.THC.Int.TensorMathPointwise)
+
+library hasktorch-indef-unsigned
+    reexported-modules: Torch.Indef.Index,
+                        Torch.Indef.Mask,
+                        Torch.Indef.Types,
+                        Torch.Indef.Storage,
+                        Torch.Indef.Storage.Copy,
+                        Torch.Indef.Dynamic.Print,
+                        Torch.Indef.Dynamic.Tensor,
+                        Torch.Indef.Dynamic.Tensor.Copy,
+                        Torch.Indef.Dynamic.Tensor.Index,
+                        Torch.Indef.Dynamic.Tensor.Masked,
+                        Torch.Indef.Dynamic.Tensor.Math,
+                        Torch.Indef.Dynamic.Tensor.Math.Compare,
+                        Torch.Indef.Dynamic.Tensor.Math.CompareT,
+                        Torch.Indef.Dynamic.Tensor.Math.Pairwise,
+                        Torch.Indef.Dynamic.Tensor.Math.Pointwise,
+                        Torch.Indef.Dynamic.Tensor.Math.Reduce,
+                        Torch.Indef.Dynamic.Tensor.Math.Scan,
+                        Torch.Indef.Dynamic.Tensor.Mode,
+                        Torch.Indef.Dynamic.Tensor.ScatterGather,
+                        Torch.Indef.Dynamic.Tensor.Sort,
+                        Torch.Indef.Dynamic.Tensor.TopK,
+                        Torch.Indef.Static.Tensor,
+                        Torch.Indef.Static.Tensor.Copy,
+                        Torch.Indef.Static.Tensor.Index,
+                        Torch.Indef.Static.Tensor.Masked,
+                        Torch.Indef.Static.Tensor.Math,
+                        Torch.Indef.Static.Tensor.Math.Compare,
+                        Torch.Indef.Static.Tensor.Math.CompareT,
+                        Torch.Indef.Static.Tensor.Math.Pairwise,
+                        Torch.Indef.Static.Tensor.Math.Pointwise,
+                        Torch.Indef.Static.Tensor.Math.Reduce,
+                        Torch.Indef.Static.Tensor.Math.Scan,
+                        Torch.Indef.Static.Tensor.Mode,
+                        Torch.Indef.Static.Tensor.ScatterGather,
+                        Torch.Indef.Static.Tensor.Sort,
+                        Torch.Indef.Static.Tensor.TopK
+    default-language: Haskell2010
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch-signatures-partial (==0.0.1 || >0.0.1) && <0.0.2,
+        hasktorch-indef -any
+    mixins: hasktorch-indef requires (Torch.Sig.NN as Torch.Undefined.NN, Torch.Sig.Types.NN as Torch.Undefined.Types.NN, Torch.Sig.Tensor.Math.Blas as Torch.Undefined.Tensor.Math.Blas, Torch.Sig.Tensor.Math.Floating as Torch.Undefined.Tensor.Math.Floating, Torch.Sig.Tensor.Math.Lapack as Torch.Undefined.Tensor.Math.Lapack, Torch.Sig.Tensor.Math.Pointwise.Signed as Torch.Undefined.Tensor.Math.Pointwise.Signed, Torch.Sig.Tensor.Math.Pointwise.Floating as Torch.Undefined.Tensor.Math.Pointwise.Floating, Torch.Sig.Tensor.Math.Reduce.Floating as Torch.Undefined.Tensor.Math.Reduce.Floating, Torch.Sig.Tensor.Math.Random.TH as Torch.Undefined.Tensor.Math.Random.TH, Torch.Sig.Tensor.Random.TH as Torch.Undefined.Tensor.Random.TH, Torch.Sig.Tensor.Random.THC as Torch.Undefined.Tensor.Random.THC)
+
+library hasktorch-indef-signed
+    reexported-modules: Torch.Indef.Index,
+                        Torch.Indef.Mask,
+                        Torch.Indef.Types,
+                        Torch.Indef.Storage,
+                        Torch.Indef.Storage.Copy,
+                        Torch.Indef.Dynamic.Print,
+                        Torch.Indef.Dynamic.Tensor,
+                        Torch.Indef.Dynamic.Tensor.Copy,
+                        Torch.Indef.Dynamic.Tensor.Index,
+                        Torch.Indef.Dynamic.Tensor.Masked,
+                        Torch.Indef.Dynamic.Tensor.Math,
+                        Torch.Indef.Dynamic.Tensor.Math.Compare,
+                        Torch.Indef.Dynamic.Tensor.Math.CompareT,
+                        Torch.Indef.Dynamic.Tensor.Math.Pairwise,
+                        Torch.Indef.Dynamic.Tensor.Math.Pointwise,
+                        Torch.Indef.Dynamic.Tensor.Math.Reduce,
+                        Torch.Indef.Dynamic.Tensor.Math.Scan,
+                        Torch.Indef.Dynamic.Tensor.Mode,
+                        Torch.Indef.Dynamic.Tensor.ScatterGather,
+                        Torch.Indef.Dynamic.Tensor.Sort,
+                        Torch.Indef.Dynamic.Tensor.TopK,
+                        Torch.Indef.Static.Tensor,
+                        Torch.Indef.Static.Tensor.Copy,
+                        Torch.Indef.Static.Tensor.Index,
+                        Torch.Indef.Static.Tensor.Masked,
+                        Torch.Indef.Static.Tensor.Math,
+                        Torch.Indef.Static.Tensor.Math.Compare,
+                        Torch.Indef.Static.Tensor.Math.CompareT,
+                        Torch.Indef.Static.Tensor.Math.Pairwise,
+                        Torch.Indef.Static.Tensor.Math.Pointwise,
+                        Torch.Indef.Static.Tensor.Math.Reduce,
+                        Torch.Indef.Static.Tensor.Math.Scan,
+                        Torch.Indef.Static.Tensor.Mode,
+                        Torch.Indef.Static.Tensor.ScatterGather,
+                        Torch.Indef.Static.Tensor.Sort,
+                        Torch.Indef.Static.Tensor.TopK,
+                        Torch.Indef.Static.Tensor.Math.Pointwise.Signed,
+                        Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed
+    default-language: Haskell2010
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch-signatures-partial (==0.0.1 || >0.0.1) && <0.0.2,
+        hasktorch-indef -any
+    mixins: hasktorch-indef requires (Torch.Sig.NN as Torch.Undefined.NN, Torch.Sig.Types.NN as Torch.Undefined.Types.NN, Torch.Sig.Tensor.Math.Blas as Torch.Undefined.Tensor.Math.Blas, Torch.Sig.Tensor.Math.Floating as Torch.Undefined.Tensor.Math.Floating, Torch.Sig.Tensor.Math.Lapack as Torch.Undefined.Tensor.Math.Lapack, Torch.Sig.Tensor.Math.Pointwise.Floating as Torch.Undefined.Tensor.Math.Pointwise.Floating, Torch.Sig.Tensor.Math.Reduce.Floating as Torch.Undefined.Tensor.Math.Reduce.Floating, Torch.Sig.Tensor.Math.Random.TH as Torch.Undefined.Tensor.Math.Random.TH, Torch.Sig.Tensor.Random.TH as Torch.Undefined.Tensor.Random.TH, Torch.Sig.Tensor.Random.THC as Torch.Undefined.Tensor.Random.THC)
+
+library hasktorch-indef-floating
+    reexported-modules: Torch.Indef.Index,
+                        Torch.Indef.Mask,
+                        Torch.Indef.Types,
+                        Torch.Indef.Storage,
+                        Torch.Indef.Storage.Copy,
+                        Torch.Indef.Dynamic.Print,
+                        Torch.Indef.Dynamic.Tensor,
+                        Torch.Indef.Dynamic.Tensor.Copy,
+                        Torch.Indef.Dynamic.Tensor.Index,
+                        Torch.Indef.Dynamic.Tensor.Masked,
+                        Torch.Indef.Dynamic.Tensor.Math,
+                        Torch.Indef.Dynamic.Tensor.Math.Compare,
+                        Torch.Indef.Dynamic.Tensor.Math.CompareT,
+                        Torch.Indef.Dynamic.Tensor.Math.Pairwise,
+                        Torch.Indef.Dynamic.Tensor.Math.Pointwise,
+                        Torch.Indef.Dynamic.Tensor.Math.Reduce,
+                        Torch.Indef.Dynamic.Tensor.Math.Scan,
+                        Torch.Indef.Dynamic.Tensor.Mode,
+                        Torch.Indef.Dynamic.Tensor.ScatterGather,
+                        Torch.Indef.Dynamic.Tensor.Sort,
+                        Torch.Indef.Dynamic.Tensor.TopK,
+                        Torch.Indef.Static.Tensor,
+                        Torch.Indef.Static.Tensor.Copy,
+                        Torch.Indef.Static.Tensor.Index,
+                        Torch.Indef.Static.Tensor.Masked,
+                        Torch.Indef.Static.Tensor.Math,
+                        Torch.Indef.Static.Tensor.Math.Compare,
+                        Torch.Indef.Static.Tensor.Math.CompareT,
+                        Torch.Indef.Static.Tensor.Math.Pairwise,
+                        Torch.Indef.Static.Tensor.Math.Pointwise,
+                        Torch.Indef.Static.Tensor.Math.Reduce,
+                        Torch.Indef.Static.Tensor.Math.Scan,
+                        Torch.Indef.Static.Tensor.Mode,
+                        Torch.Indef.Static.Tensor.ScatterGather,
+                        Torch.Indef.Static.Tensor.Sort,
+                        Torch.Indef.Static.Tensor.TopK,
+                        Torch.Indef.Static.Tensor.Math.Pointwise.Signed,
+                        Torch.Indef.Dynamic.Tensor.Math.Pointwise.Signed,
+                        Torch.Indef.Dynamic.Tensor.Math.Blas,
+                        Torch.Indef.Dynamic.Tensor.Math.Floating,
+                        Torch.Indef.Dynamic.Tensor.Math.Lapack,
+                        Torch.Indef.Dynamic.Tensor.Math.Pointwise.Floating,
+                        Torch.Indef.Dynamic.Tensor.Math.Reduce.Floating,
+                        Torch.Indef.Dynamic.Tensor.Random.TH,
+                        Torch.Indef.Dynamic.Tensor.Random.THC,
+                        Torch.Indef.Dynamic.Tensor.Math.Random.TH,
+                        Torch.Indef.Static.Tensor.Math.Blas,
+                        Torch.Indef.Static.Tensor.Math.Floating,
+                        Torch.Indef.Static.Tensor.Math.Lapack,
+                        Torch.Indef.Static.Tensor.Math.Pointwise.Floating,
+                        Torch.Indef.Static.Tensor.Math.Reduce.Floating,
+                        Torch.Indef.Static.Tensor.Random.TH,
+                        Torch.Indef.Static.Tensor.Random.THC,
+                        Torch.Indef.Static.Tensor.Math.Random.TH,
+                        Torch.Indef.Dynamic.NN,
+                        Torch.Indef.Dynamic.NN.Activation,
+                        Torch.Indef.Dynamic.NN.Pooling,
+                        Torch.Indef.Dynamic.NN.Criterion,
+                        Torch.Indef.Static.NN,
+                        Torch.Indef.Static.NN.Activation,
+                        Torch.Indef.Static.NN.Backprop,
+                        Torch.Indef.Static.NN.Conv1d,
+                        Torch.Indef.Static.NN.Conv2d,
+                        Torch.Indef.Static.NN.Criterion,
+                        Torch.Indef.Static.NN.Layers,
+                        Torch.Indef.Static.NN.Linear,
+                        Torch.Indef.Static.NN.Math,
+                        Torch.Indef.Static.NN.Padding,
+                        Torch.Indef.Static.NN.Pooling,
+                        Torch.Indef.Static.NN.Sampling,
+                        Torch.Undefined.Tensor.Math.Random.TH,
+                        Torch.Undefined.Tensor.Random.TH,
+                        Torch.Undefined.Tensor.Random.THC
+    default-language: Haskell2010
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch-indef -any,
+        hasktorch-signatures-partial (==0.0.1 || >0.0.1) && <0.0.2
+
+executable isdefinite-cpu
+    main-is: Noop.hs
+    hs-source-dirs: exe
+    default-language: Haskell2010
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch-cpu -any
+
+executable isdefinite-gpu
+    main-is: Noop.hs
+    hs-source-dirs: exe
+    default-language: Haskell2010
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch-gpu -any
+
+executable isdefinite
+    main-is: Noop.hs
+    hs-source-dirs: exe
+    default-language: Haskell2010
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch -any
+
+executable memcheck
+    main-is: Memcheck.hs
+    hs-source-dirs: exe
+    default-language: Haskell2010
+    build-depends:
+        base (==4.7 || >4.7) && <5,
+        hasktorch -any
+
+test-suite spec
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs: tests
+    other-modules:
+        Orphans
+        MemorySpec
+        RawLapackSVDSpec
+        GarbageCollectionSpec
+        Torch.Prelude.Extras
+        Torch.Core.LogAddSpec
+        Torch.Core.RandomSpec
+        Torch.Static.NN.AbsSpec
+        Torch.Static.NN.LinearSpec
+    default-language: Haskell2010
+    default-extensions: LambdaCase DataKinds TypeFamilies
+                        TypeSynonymInstances ScopedTypeVariables FlexibleContexts CPP
+    build-depends:
+        QuickCheck ==2.11 || >2.11,
+        backprop ==0.2.5 || >0.2.5,
+        base (==4.7 || >4.7) && <5,
+        dimensions ==1.0 || >1.0,
+        ghc-typelits-natnormalise -any,
+        hasktorch -any,
+        hspec ==2.4.4 || >2.4.4,
+        singletons ==2.2 || >2.2,
+        -- text ==1.2.2 || >1.2.2,
+        mtl ==2.2.2 || >2.2.2,
+        microlens-platform ==0.3.10 || >0.3.10,
+        monad-loops ==0.4.3 || >0.4.3,
+        time ==1.8.0 || >1.8.0,
+        transformers ==0.5.5 || >0.5.5,
+        generic-lens -any
+

--- a/Cabal-tests/tests/ParserTests/comments/hasktorch.expr
+++ b/Cabal-tests/tests/ParserTests/comments/hasktorch.expr
@@ -1,0 +1,97 @@
+[
+  Comment
+    "-- ================================================================ --"
+    (Position 2 1),
+  Comment
+    "-- ======== This cabal file has been modified from dhall ========== --"
+    (Position 3 1),
+  Comment
+    "-- ======== This constitutes the 0.0.1.0 release.        ========== --"
+    (Position 4 1),
+  Comment
+    "-- ======== Dhall can generate this file, but will never ========== --"
+    (Position 5 1),
+  Comment
+    "-- ======== be able to upload to hackage. For more, see: ========== --"
+    (Position 6 1),
+  Comment
+    "-- ==== https://github.com/haskell/hackage-server/issues/795 ====== --"
+    (Position 7 1),
+  Comment
+    "-- ================================================================ --"
+    (Position 8 1),
+  Comment
+    "        -- containers ==0.5.10 || >0.5.10,"
+    (Position 70 1),
+  Comment
+    "        -- deepseq ==1.3.0 || >1.3.0,"
+    (Position 71 1),
+  Comment
+    "        -- managed (==1.0.0 || >1.0.0) && <1.1,"
+    (Position 73 1),
+  Comment
+    "        -- microlens ==0.4.8 || >0.4.8,"
+    (Position 74 1),
+  Comment
+    "        -- numeric-limits ==0.1.0 || >0.1.0,"
+    (Position 75 1),
+  Comment
+    "        -- typelits-witnesses ==0.2.3 || >0.2.3,"
+    (Position 79 1),
+  Comment
+    "    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --"
+    (Position 84 1),
+  Comment
+    "    -- BEGIN EDITS"
+    (Position 85 1),
+  Comment
+    "    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --"
+    (Position 86 1),
+  Comment
+    "    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --"
+    (Position 148 1),
+  Comment
+    "    -- END EDITS"
+    (Position 149 1),
+  Comment
+    "    -- <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><> --"
+    (Position 150 1),
+  Comment
+    "        -- containers ==0.5.10 || >0.5.10,"
+    (Position 203 1),
+  Comment
+    "        -- deepseq ==1.3.0 || >1.3.0,"
+    (Position 204 1),
+  Comment
+    "        -- managed (==1.0.0 || >1.0.0) && <1.1,"
+    (Position 208 1),
+  Comment
+    "        -- microlens ==0.4.8 || >0.4.8,"
+    (Position 209 1),
+  Comment
+    "        -- numeric-limits ==0.1.0 || >0.1.0,"
+    (Position 210 1),
+  Comment
+    "        -- typelits-witnesses ==0.2.3 || >0.2.3,"
+    (Position 214 1),
+  Comment
+    "        -- containers ==0.5.10 || >0.5.10,"
+    (Position 282 1),
+  Comment
+    "        -- deepseq ==1.3.0 || >1.3.0,"
+    (Position 283 1),
+  Comment
+    "        -- managed (==1.0.0 || >1.0.0) && <1.1,"
+    (Position 287 1),
+  Comment
+    "        -- microlens ==0.4.8 || >0.4.8,"
+    (Position 288 1),
+  Comment
+    "        -- numeric-limits ==0.1.0 || >0.1.0,"
+    (Position 289 1),
+  Comment
+    "        -- typelits-witnesses ==0.2.3 || >0.2.3,"
+    (Position 293 1),
+  Comment
+    "        -- text ==1.2.2 || >1.2.2,"
+    (Position 551 1)]

--- a/Cabal-tests/tests/ParserTests/comments/layout-comment-in-fieldline.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-comment-in-fieldline.cabal
@@ -1,0 +1,11 @@
+Executable
+    Main-is:             Main.hs
+    hs-source-dirs:
+        src
+    ghc-options: -Wall
+    Build-Depends:   base
+                     -- , foo
+                     -- ^ This should be consumed after fieldContent
+                     , bar
+                     -- , comment
+                     , baz

--- a/Cabal-tests/tests/ParserTests/comments/layout-comment-in-fieldline.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-comment-in-fieldline.expr
@@ -1,0 +1,77 @@
+[
+  Section
+    (Name
+      WithComments {
+        justComments = [],
+        unComments = Position 1 1}
+      "executable")
+    []
+    [
+      Field
+        (Name
+          WithComments {
+            justComments = [],
+            unComments = Position 2 5}
+          "main-is")
+        [
+          FieldLine
+            WithComments {
+              justComments = [],
+              unComments = Position 2 26}
+            "Main.hs"],
+      Field
+        (Name
+          WithComments {
+            justComments = [],
+            unComments = Position 3 5}
+          "hs-source-dirs")
+        [
+          FieldLine
+            WithComments {
+              justComments = [],
+              unComments = Position 4 9}
+            "src"],
+      Field
+        (Name
+          WithComments {
+            justComments = [],
+            unComments = Position 5 5}
+          "ghc-options")
+        [
+          FieldLine
+            WithComments {
+              justComments = [],
+              unComments = Position 5 18}
+            "-Wall"],
+      Field
+        (Name
+          WithComments {
+            justComments = [],
+            unComments = Position 6 5}
+          "build-depends")
+        [
+          FieldLine
+            WithComments {
+              justComments =
+              [
+                Comment
+                  "                     -- , foo"
+                  (Position 7 1),
+                Comment
+                  "                     -- ^ This should be consumed after fieldContent"
+                  (Position 8 1)],
+              unComments = Position 6 22}
+            "base",
+          FieldLine
+            WithComments {
+              justComments = [
+                Comment
+                  "                     -- , comment"
+                  (Position 10 1)],
+              unComments = Position 9 22}
+            ", bar",
+          FieldLine
+            WithComments {
+              justComments = [],
+              unComments = Position 11 22}
+            ", baz"]]]

--- a/Cabal-tests/tests/ParserTests/comments/layout-complex-indented-comments.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-complex-indented-comments.cabal
@@ -1,0 +1,38 @@
+-- This is the configuration file for the 'cabal' command line tool.
+--
+-- The available configuration options are listed below.
+
+
+repository hackage.haskell.org
+  url: http://hackage.haskell.org/
+  -- secure: True
+  -- root-keys:
+
+-- ignore-expiry: False
+-- http-transport:
+remote-repo-cache: /home/foo/.cache/cabal/packages
+-- logs-dir: /home/foo/.cache/cabal/logs
+-- default-user-config:
+build-summary: /home/foo/.cache/cabal/logs/build.log
+-- build-log:
+remote-build-reporting: none
+-- report-planning-failure: False
+-- per-component: True
+jobs: $ncpus
+-- keep-going: False
+-- offline: False
+installdir: /home/foo/.local/bin
+-- token:
+-- username:
+
+haddock
+  -- keep-temp-files: False
+  -- hoogle: False
+
+init
+  -- interactive: False
+  -- quiet: False
+
+program-locations
+  -- alex-location:
+  -- ar-location:

--- a/Cabal-tests/tests/ParserTests/comments/layout-complex-indented-comments.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-complex-indented-comments.expr
@@ -1,0 +1,175 @@
+[
+  Section
+    (Name
+      WithComments {
+        justComments =
+        [
+          Comment
+            "-- This is the configuration file for the 'cabal' command line tool."
+            (Position 1 1),
+          Comment "--" (Position 2 1),
+          Comment
+            "-- The available configuration options are listed below."
+            (Position 3 1)],
+        unComments = Position 6 1}
+      "repository")
+    [
+      SecArgName
+        WithComments {
+          justComments = [],
+          unComments = Position 6 12}
+        "hackage.haskell.org"]
+    [
+      Field
+        (Name
+          WithComments {
+            justComments = [],
+            unComments = Position 7 3}
+          "url")
+        [
+          FieldLine
+            WithComments {
+              justComments = [
+                Comment
+                  "  -- secure: True"
+                  (Position 8 1),
+                Comment
+                  "  -- root-keys:"
+                  (Position 9 1),
+                Comment
+                  "-- ignore-expiry: False"
+                  (Position 11 1),
+                Comment
+                  "-- http-transport:"
+                  (Position 12 1)],
+              unComments = Position 7 8}
+            "http://hackage.haskell.org/"]],
+  Field
+    (Name
+      WithComments {
+        justComments = [],
+        unComments = Position 13 1}
+      "remote-repo-cache")
+    [
+      FieldLine
+        WithComments {
+          justComments = [
+            Comment
+              "-- logs-dir: /home/foo/.cache/cabal/logs"
+              (Position 14 1),
+            Comment
+              "-- default-user-config:"
+              (Position 15 1)],
+          unComments = Position 13 20}
+        "/home/foo/.cache/cabal/packages"],
+  Field
+    (Name
+      WithComments {
+        justComments = [],
+        unComments = Position 16 1}
+      "build-summary")
+    [
+      FieldLine
+        WithComments {
+          justComments = [
+            Comment
+              "-- build-log:"
+              (Position 17 1)],
+          unComments = Position 16 16}
+        "/home/foo/.cache/cabal/logs/build.log"],
+  Field
+    (Name
+      WithComments {
+        justComments = [],
+        unComments = Position 18 1}
+      "remote-build-reporting")
+    [
+      FieldLine
+        WithComments {
+          justComments = [
+            Comment
+              "-- report-planning-failure: False"
+              (Position 19 1),
+            Comment
+              "-- per-component: True"
+              (Position 20 1)],
+          unComments = Position 18 25}
+        "none"],
+  Field
+    (Name
+      WithComments {
+        justComments = [],
+        unComments = Position 21 1}
+      "jobs")
+    [
+      FieldLine
+        WithComments {
+          justComments = [
+            Comment
+              "-- keep-going: False"
+              (Position 22 1),
+            Comment
+              "-- offline: False"
+              (Position 23 1)],
+          unComments = Position 21 7}
+        "$ncpus"],
+  Field
+    (Name
+      WithComments {
+        justComments = [],
+        unComments = Position 24 1}
+      "installdir")
+    [
+      FieldLine
+        WithComments {
+          justComments = [
+            Comment
+              "-- token:"
+              (Position 25 1),
+            Comment
+              "-- username:"
+              (Position 26 1)],
+          unComments = Position 24 13}
+        "/home/foo/.local/bin"],
+  Section
+    (Name
+      WithComments {
+        justComments = [
+          Comment
+            "  -- keep-temp-files: False"
+            (Position 29 1),
+          Comment
+            "  -- hoogle: False"
+            (Position 30 1)],
+        unComments = Position 28 1}
+      "haddock")
+    []
+    [],
+  Section
+    (Name
+      WithComments {
+        justComments = [
+          Comment
+            "  -- interactive: False"
+            (Position 33 1),
+          Comment
+            "  -- quiet: False"
+            (Position 34 1)],
+        unComments = Position 32 1}
+      "init")
+    []
+    [],
+  Section
+    (Name
+      WithComments {
+        justComments = [
+          Comment
+            "  -- alex-location:"
+            (Position 37 1),
+          Comment
+            "  -- ar-location:"
+            (Position 38 1)],
+        unComments = Position 36 1}
+      "program-locations")
+    []
+    []]

--- a/Cabal-tests/tests/ParserTests/comments/layout-fieldline-is-flag.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-fieldline-is-flag.cabal
@@ -1,0 +1,13 @@
+cabal-version:       2.2
+name:                common
+version:             0
+synopsis:            Common-stanza demo
+build-type:          Simple
+
+test-suite doctests
+  type:                exitcode-stdio-1.0
+  main-is:             doctests.hs
+  x-doctest-options:   --preserve-it
+    -- The previous thing shouldn't be parsed as a comment because it's a flag
+    -- This however, is a comment
+  ghc-options:         -Wall -threaded

--- a/Cabal-tests/tests/ParserTests/comments/layout-fieldline-is-flag.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-fieldline-is-flag.expr
@@ -1,0 +1,7 @@
+[
+  Comment
+    "    -- The previous thing shouldn't be parsed as a comment because it's a flag"
+    (Position 11 1),
+  Comment
+    "    -- This however, is a comment"
+    (Position 12 1)]

--- a/Cabal-tests/tests/ParserTests/comments/layout-interleaved-in-section.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-interleaved-in-section.cabal
@@ -1,0 +1,24 @@
+cabal-version:       2.2
+name:                common
+version:             0
+synopsis:            Common-stanza demo
+build-type:          Simple
+
+source-repository head
+  Type:     git
+  Location: https://github.com/hvr/-.git
+
+common deps
+  build-depends:
+    -- foo
+    base >=4.10 && <4.11,
+    -- bar
+    containers
+    -- baz
+
+library
+  import: deps
+  default-language: Haskell2010
+  exposed-modules:  ElseIf
+  build-depends:
+    ghc-prim

--- a/Cabal-tests/tests/ParserTests/comments/layout-interleaved-in-section.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-interleaved-in-section.expr
@@ -1,0 +1,10 @@
+[
+  Comment
+    "    -- foo"
+    (Position 13 1),
+  Comment
+    "    -- bar"
+    (Position 15 1),
+  Comment
+    "    -- baz"
+    (Position 17 1)]

--- a/Cabal-tests/tests/ParserTests/comments/layout-many-sections.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-many-sections.cabal
@@ -1,0 +1,31 @@
+cabal-version:       2.2
+name:                common
+version:             0
+  -- comment 1
+synopsis:            Common-stanza demo demo
+build-type:          Simple
+
+source-repository head
+  Type:     git
+    -- comment 2
+  Location: https://github.com/hvr/-.git
+
+common windows
+  if os(windows)
+    build-depends: Win32
+
+common deps
+  build-depends:
+    base >=4.10 && <4.11,
+    containers
+
+library
+  import: deps
+
+    -- comment 3
+  default-language: Haskell2010
+  exposed-modules:  ElseIf
+-- comment 4
+
+  build-depends:
+    ghc-prim

--- a/Cabal-tests/tests/ParserTests/comments/layout-many-sections.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-many-sections.expr
@@ -1,0 +1,13 @@
+[
+  Comment
+    "  -- comment 1"
+    (Position 4 1),
+  Comment
+    "    -- comment 2"
+    (Position 10 1),
+  Comment
+    "    -- comment 3"
+    (Position 25 1),
+  Comment
+    "-- comment 4"
+    (Position 28 1)]

--- a/Cabal-tests/tests/ParserTests/comments/layout-nosections-after.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-nosections-after.cabal
@@ -1,0 +1,8 @@
+name: comment-after-nameless-field
+version: 1
+cabal-version: >= 1.8
+-- comment after
+
+library
+  build-depends:
+    base >= 4

--- a/Cabal-tests/tests/ParserTests/comments/layout-nosections-after.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-nosections-after.expr
@@ -1,0 +1,4 @@
+[
+  Comment
+    "-- comment after"
+    (Position 4 1)]

--- a/Cabal-tests/tests/ParserTests/comments/layout-nosections-before.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-nosections-before.cabal
@@ -1,0 +1,8 @@
+-- comment before
+name: comment-before-nameless-field
+version: 1
+cabal-version: >= 1.8
+
+library
+  build-depends:
+    base >= 4

--- a/Cabal-tests/tests/ParserTests/comments/layout-nosections-before.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-nosections-before.expr
@@ -1,0 +1,4 @@
+[
+  Comment
+    "-- comment before"
+    (Position 1 1)]

--- a/Cabal-tests/tests/ParserTests/comments/layout-nosections-mixed.cabal
+++ b/Cabal-tests/tests/ParserTests/comments/layout-nosections-mixed.cabal
@@ -1,0 +1,12 @@
+-- comment before
+
+name: comment-after-nameless-field
+    -- comment within
+version: 1
+    -- another comment within
+cabal-version: >= 1.8
+-- comment after
+
+library
+  build-depends:
+    base >= 4

--- a/Cabal-tests/tests/ParserTests/comments/layout-nosections-mixed.expr
+++ b/Cabal-tests/tests/ParserTests/comments/layout-nosections-mixed.expr
@@ -1,0 +1,13 @@
+[
+  Comment
+    "-- comment before"
+    (Position 1 1),
+  Comment
+    "    -- comment within"
+    (Position 4 1),
+  Comment
+    "    -- another comment within"
+    (Position 6 1),
+  Comment
+    "-- comment after"
+    (Position 8 1)]

--- a/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
+++ b/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
@@ -14,9 +14,11 @@ import Data.TreeDiff.Instances.CabalVersion ()
 import Distribution.Backpack                       (OpenModule, OpenUnitId)
 import Distribution.CabalSpecVersion               (CabalSpecVersion)
 import Distribution.Compiler                       (CompilerFlavor, CompilerId, PerCompilerFlavor)
+import Distribution.Fields.Field                   (Field, Name, FieldLine, SectionArg, Comment, WithComments)
 import Distribution.InstalledPackageInfo           (AbiDependency, ExposedModule, InstalledPackageInfo)
 import Distribution.ModuleName                     (ModuleName)
 import Distribution.PackageDescription
+import Distribution.Parsec.Position                (Position)
 import Distribution.Simple.Compiler                (DebugInfoLevel, OptimisationLevel, ProfDetailLevel)
 import Distribution.Simple.InstallDirs
 import Distribution.Simple.InstallDirs.Internal
@@ -85,6 +87,12 @@ instance ToExpr GenericPackageDescription where
               ]
           )
 
+instance (ToExpr ann) => ToExpr (Comment ann)
+instance (ToExpr ann) => ToExpr (WithComments ann)
+instance (ToExpr ann) => ToExpr (Field ann)
+instance (ToExpr ann) => ToExpr (FieldLine ann)
+instance (ToExpr ann) => ToExpr (Name ann)
+instance (ToExpr ann) => ToExpr (SectionArg ann)
 instance ToExpr AbiDependency
 instance ToExpr AbiHash
 instance ToExpr Arch
@@ -138,6 +146,7 @@ instance ToExpr PkgconfigDependency
 instance ToExpr PkgconfigName
 instance ToExpr PkgconfigVersion
 instance ToExpr PkgconfigVersionRange
+instance ToExpr Position
 instance ToExpr ProfDetailLevel
 instance ToExpr RepoKind
 instance ToExpr RepoType

--- a/changelog.d/pr-11252.md
+++ b/changelog.d/pr-11252.md
@@ -1,0 +1,19 @@
+---
+synopsis: Retain comments in field parser
+packages: [Cabal-syntax]
+prs: 11252
+---
+
+This lays the foundation for Cabal-exactprint to consume user comments.
+
+The parser of the envelope format ("field parser") now annotates each of the
+parsed fields with its preceding and succeeding comments, along with the
+existing source location annotation 'Position'.
+
+This change is orthogonal to the final chosen exactprint implementation, or the
+algebra we use to modify existing fields and/or generate new fields. Instead,
+it merely makes the user comments available to any consumer that reads cabal
+fields, the envelope format.
+
+readFields* functions now have their counterparts that parses with comments,
+named readFieldsWithComments*.


### PR DESCRIPTION
This is the first part of the exact print parser. In this PR I changed the lexer so instead of dropping the comments it emits them to the parser which is further stored in `GenericPackageDescription`.

Please let me know your thoughts!

---

Checklist below:


**This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
