### PR TITLE
cabal: filtering GHC args

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2379,6 +2379,17 @@ elaborateInstallPlan
                     ]
                 )
                 (perPkgOptionMapMappend pkgid packageConfigProgramArgs)
+            elabNormalisedProgramArgs =
+              Map.unionWith
+                (++)
+                ( Map.fromList
+                    [ (programId prog, args)
+                    | prog <- configuredPrograms compilerprogdb
+                    , let args = programOverrideArgs $ addHaddockIfDocumentationEnabled prog
+                    , not (null args)
+                    ]
+                )
+                (perPkgOptionMapMappend pkgid packageConfigProgramArgs)
             elabProgramPathExtra = perPkgOptionNubList pkgid packageConfigProgramPathExtra
             elabConfiguredPrograms = configuredPrograms compilerprogdb
             elabConfigureScriptArgs = perPkgOptionList pkgid packageConfigConfigureArgs
@@ -4513,7 +4524,7 @@ packageHashConfigInputs shared@ElaboratedSharedConfig{..} pkg =
     , pkgHashStripLibs = stripLibs
     , pkgHashStripExes = stripExes
     , pkgHashDebugInfo = withDebugInfo
-    , pkgHashProgramArgs = elabProgramArgs
+    , pkgHashProgramArgs = elabNormalisedProgramArgs
     , pkgHashExtraLibDirs = elabExtraLibDirs
     , pkgHashExtraLibDirsStatic = elabExtraLibDirsStatic
     , pkgHashExtraFrameworkDirs = elabExtraFrameworkDirs

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -274,6 +274,7 @@ data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
   , elabDumpBuildInfo :: DumpBuildInfo
   , elabProgramPaths :: Map String FilePath
   , elabProgramArgs :: Map String [String]
+  , elabNormalisedProgramArgs :: Map String [String]
   , elabProgramPathExtra :: [FilePath]
   , elabConfiguredPrograms :: [ConfiguredProgram]
   , elabConfigureScriptArgs :: [String]
@@ -345,7 +346,7 @@ normaliseConfiguredPackage
   -> ElaboratedConfiguredPackage
   -> ElaboratedConfiguredPackage
 normaliseConfiguredPackage ElaboratedSharedConfig{pkgConfigCompilerProgs} pkg =
-  pkg{elabProgramArgs = Map.mapMaybeWithKey lookupFilter (elabProgramArgs pkg)}
+  pkg{elabNormalisedProgramArgs = Map.mapMaybeWithKey lookupFilter (elabProgramArgs pkg)}
   where
     knownProgramDb = addKnownPrograms builtinPrograms pkgConfigCompilerProgs
 

--- a/changelog.d/pr-11259.md
+++ b/changelog.d/pr-11259.md
@@ -1,0 +1,5 @@
+---
+synopsis: Do not filter program arguments (e.g. for ghc, etc)
+packages: [Cabal]
+prs: 11259
+---


### PR DESCRIPTION
This PR changes how cabal is normalising program flags.  Instead of
normalising them for program invocation, it normalises them just for caching
purposes.  This allows us to pass any GHC flag without cabal, surprisingly
removing it.  This allows one to pass things like `-freverse-errors`,
`-Rghc-timing`, and many others.

I am not deeply familiar with cabal's codebase, so please excuse if I am doing something silly.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
