### PR TITLE
work around apparent pip 25.3 bug

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -57,7 +57,7 @@ build-and-check-requirements: requirements.txt check-requirements
 # See https://modelpredict.com/wht-requirements-txt-is-not-enough
 requirements.txt: requirements.in $(PYTHON_VIRTUALENV_ACTIVATE)
 	. $(PYTHON_VIRTUALENV_ACTIVATE) \
-	  && pip install --upgrade pip \
+	  && pip install --upgrade 'pip!=25.3' \
 	  && pip install pip-tools \
 	  && pip-compile requirements.in
 


### PR DESCRIPTION
https://stackoverflow.com/questions/79802659/trying-to-solve-a-pip-compile-stack-trace-error claims this is a bug in pip 25.3. Try downgrading pip before attempting to rebuild the manual.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
