### PR TITLE
Preflight checks for 3.16.1.0

### DIFF
--- a/Cabal-QuickCheck/Cabal-QuickCheck.cabal
+++ b/Cabal-QuickCheck/Cabal-QuickCheck.cabal
@@ -16,7 +16,7 @@ library
     , bytestring
     , Cabal         ^>=3.17.0.0
     , Cabal-syntax  ^>=3.17.0.0
-    , QuickCheck    >= 2.13.2 && < 2.17
+    , QuickCheck    >= 2.13.2 && < 2.18
 
   exposed-modules:
     Test.QuickCheck.GenericArbitrary

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -391,7 +391,7 @@ test-suite unit-tests
       , tasty-expected-failure
       , tasty-hunit >= 0.10
       , tree-diff
-      , QuickCheck >= 2.14.3 && <2.17
+      , QuickCheck >= 2.14.3 && <2.18
 
 -- Tests for the project file parser
 test-suite parser-tests
@@ -500,5 +500,5 @@ test-suite long-tests
     , tasty-expected-failure
     , tasty-hunit >= 0.10
     , tasty-quickcheck <0.12
-    , QuickCheck >= 2.14 && <2.17
+    , QuickCheck >= 2.14 && <2.18
     , pretty-show >= 1.6.15


### PR DESCRIPTION
Nothing much to do:

- I did not bump `cabal-version` as this is a minor release.
- I verified `cabal build --allow-newer -cQuickCheck==2.17.1.0 …` works with the relevant targets.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? no ~~If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~
