### PR TITLE
Preflight checks 3.16 (backport #11275)

### DIFF
--- a/Cabal-QuickCheck/Cabal-QuickCheck.cabal
+++ b/Cabal-QuickCheck/Cabal-QuickCheck.cabal
@@ -16,7 +16,7 @@ library
     , bytestring
     , Cabal         ^>=3.14.0.0
     , Cabal-syntax  ^>=3.14.0.0
-    , QuickCheck    ^>=2.13.2 || ^>=2.14
+    , QuickCheck    >= 2.13.2 && < 2.18
 
   exposed-modules:
     Test.QuickCheck.GenericArbitrary

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -353,7 +353,7 @@ test-suite unit-tests
           tasty-expected-failure,
           tasty-hunit >= 0.10,
           tree-diff,
-          QuickCheck >= 2.14.3 && <2.16
+          QuickCheck >= 2.14.3 && <2.18
 
 
 -- Tests to run with a limited stack and heap size
@@ -438,5 +438,5 @@ test-suite long-tests
         tasty-expected-failure,
         tasty-hunit >= 0.10,
         tasty-quickcheck <0.12,
-        QuickCheck >= 2.14 && <2.16,
+        QuickCheck >= 2.14 && <2.18,
         pretty-show >= 1.6.15


### PR DESCRIPTION
Backport #11275

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? No. ~~If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~
