### PR TITLE
loosen `text` bound on `cabal-validate`

### DIFF
--- a/cabal-validate/cabal-validate.cabal
+++ b/cabal-validate/cabal-validate.cabal
@@ -42,6 +42,7 @@ executable cabal-validate
         , filepath >=1 && <2
         , optparse-applicative >=0.18 && <1
         , terminal-size >=0.3 && <1
-        , text >=2 && <3
+          -- https://github.com/haskell/cabal/pull/11280#issuecomment-3534506424
+        , text >=1.2 && <3
         , time >=1 && <2
         , typed-process >=0.2 && <1


### PR DESCRIPTION
It drags the entire project up to `text-2.x`, including for older ghcs where it's not available as a bootlib. See https://github.com/haskell/cabal/pull/11280#issuecomment-3534506424.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
