### PR TITLE
Move `3.16` to `ubuntu-latest`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         sys:
           - { os: windows-latest, shell: "C:/msys64/usr/bin/bash.exe -e {0}" }
-          - { os: ubuntu-22.04, shell: bash }
+          - { os: ubuntu-latest, shell: bash }
           - { os: macos-latest, shell: bash }
         # If you remove something from here, then add it to the old-ghcs job.
         # Also a removed GHC from here means that we are actually dropping


### PR DESCRIPTION
For unknown reasons, GitHub's `ubuntu-22.04` randomly breaks `validate` for older supported ghcs with shared object versioning errors for `GLIBC` (`alex`) and `GLIBCXX` (`text`). Force 3.16 up to `ubuntu-latest`, which doesn't show the problem (it hasn't happened on `master` or PRs targeting it, only on `3.16` branch).

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
