### PR TITLE
Tighten the dependency on `containers` by lib:Cabal

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -43,7 +43,7 @@ library
     , array      >= 0.4.0.1  && < 0.6
     , base       >= 4.13     && < 5
     , bytestring >= 0.10.0.0 && < 0.13
-    , containers >= 0.5.0.0  && < 0.9
+    , containers >= 0.5.8.2  && < 0.9
     , deepseq    >= 1.3.0.1  && < 1.7
     , directory  >= 1.2      && < 1.4
     , filepath   >= 1.3.0.1  && < 1.6


### PR DESCRIPTION
See #11303.

This needs to be accompanied by appropriate Hackage revisions.