### PR TITLE
Remove redundant OPTIONS_GHC pragmas from templates

### DIFF
--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
@@ -22,7 +22,6 @@ render z_root = execWriter $ do
       return ()
     else do
       return ()
-  tell "{-# OPTIONS_GHC -Wno-missing-import-lists #-}\n"
   tell "{-# OPTIONS_GHC -w #-}\n"
   tell "\n"
   tell "{-|\n"

--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -43,15 +43,6 @@ render z_root = execWriter $ do
     return ()
   else do
     return ()
-  if (zSupportsCpp z_root)
-  then do
-    tell "#if __GLASGOW_HASKELL__ >= 810\n"
-    tell "{-# OPTIONS_GHC -Wno-prepositive-qualified-module #-}\n"
-    tell "#endif\n"
-    return ()
-  else do
-    return ()
-  tell "{-# OPTIONS_GHC -Wno-missing-import-lists #-}\n"
   tell "{-# OPTIONS_GHC -w #-}\n"
   tell "\n"
   tell "{-|\n"

--- a/templates/Paths_pkg.template.hs
+++ b/templates/Paths_pkg.template.hs
@@ -7,12 +7,6 @@
 {% if not absolute %}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {% endif %}
-{% if supportsCpp %}
-#if __GLASGOW_HASKELL__ >= 810
-{-# OPTIONS_GHC -Wno-prepositive-qualified-module #-}
-#endif
-{% endif %}
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 {-# OPTIONS_GHC -w #-}
 
 {-|


### PR DESCRIPTION
There are two things that I lack the context and background to comprehend.

1. For what reason would these pragmas be needed in the first place?
2. What was the rational for changing these in https://github.com/haskell/cabal/commit/f47768ae15e2bfc14ac2a2a43afe85d522c470f0?  Was it simply an oversight, or are we at the point where "a subjective urge for tidiness" takes precedences over providing value to the user and backwards compatibility?

- [x] squash commits (I did this through GitHub UI from mobile..)