### PR TITLE
add `--full-version` and compiler info

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -100,6 +100,7 @@ library
     Distribution.Compat.Prelude.Internal
     Distribution.Compat.Process
     Distribution.Compat.Stack
+    Distribution.Compat.SysInfo
     Distribution.Compat.Time
     Distribution.Make
     Distribution.PackageDescription.Check

--- a/Cabal/src/Distribution/Compat/SysInfo.hs
+++ b/Cabal/src/Distribution/Compat/SysInfo.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE CPP #-}
+
+module Distribution.Compat.SysInfo
+  ( fullCompilerVersion
+  ) where
+
+import Data.Version (Version)
+import qualified System.Info as SI
+
+fullCompilerVersion :: Version
+#if MIN_VERSION_base(4,15,0)
+fullCompilerVersion = SI.fullCompilerVersion
+#else
+fullCompilerVersion = SI.compilerVersion
+#endif

--- a/Cabal/src/Distribution/Make.hs
+++ b/Cabal/src/Distribution/Make.hs
@@ -105,6 +105,7 @@ defaultMainHelperWithHandles verbHandles args = do
       case commandParse of
         _
           | fromFlag (globalVersion flags) -> printVersion
+          | fromFlag (globalFullVersion flags) -> printFullVersion
           | fromFlag (globalNumericVersion flags) -> printNumericVersion
         CommandHelp help -> printHelp help
         CommandList opts -> printOptionsList opts
@@ -122,6 +123,16 @@ defaultMainHelperWithHandles verbHandles args = do
       hPutStrLn outHandle $
         "Cabal library version "
           ++ prettyShow cabalVersion
+    printFullVersion =
+      hPutStrLn outHandle $
+        "Cabal library version "
+          ++ prettyShow cabalVersion
+          ++ cabalGitInfo'
+          ++ "\nwith "
+          ++ cabalCompilerInfo
+    cabalGitInfo'
+      | null cabalGitInfo = []
+      | otherwise = ' ' : cabalGitInfo
     progs = defaultProgramDb
     commands =
       [ configureCommand progs `commandAddAction` configureAction verbHandles

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -329,6 +329,7 @@ defaultMainHelperWithHandles verbHandles hooks args =
         case commandParse of
           _
             | fromFlag (globalVersion globalFlags) -> printVersion
+            | fromFlag (globalFullVersion globalFlags) -> printFullVersion
             | fromFlag (globalNumericVersion globalFlags) -> printNumericVersion
           CommandHelp help -> printHelp help
           CommandList opts -> printOptionsList opts
@@ -347,7 +348,16 @@ defaultMainHelperWithHandles verbHandles hooks args =
       hPutStrLn outHandle $
         "Cabal library version "
           ++ prettyShow cabalVersion
-
+    printFullVersion =
+      hPutStrLn outHandle $
+        "Cabal library version "
+          ++ prettyShow cabalVersion
+          ++ cabalGitInfo'
+          ++ "\nwith "
+          ++ cabalCompilerInfo
+    cabalGitInfo'
+      | null cabalGitInfo = []
+      | otherwise = ' ' : cabalGitInfo
     progs = addKnownPrograms (hookedPrograms hooks) defaultProgramDb
     addAction
       :: CommandUI flags

--- a/Cabal/src/Distribution/Simple/Setup/Global.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Global.hs
@@ -44,6 +44,7 @@ import Distribution.Utils.Path
 -- | Flags that apply at the top level, not to any sub-command.
 data GlobalFlags = GlobalFlags
   { globalVersion :: Flag Bool
+  , globalFullVersion :: Flag Bool
   , globalNumericVersion :: Flag Bool
   , globalWorkingDir :: Flag (SymbolicPath CWD (Dir Pkg))
   }
@@ -53,6 +54,7 @@ defaultGlobalFlags :: GlobalFlags
 defaultGlobalFlags =
   GlobalFlags
     { globalVersion = Flag False
+    , globalFullVersion = Flag False
     , globalNumericVersion = Flag False
     , globalWorkingDir = NoFlag
     }
@@ -100,6 +102,13 @@ globalCommand commands =
             "Print version information"
             globalVersion
             (\v flags -> flags{globalVersion = v})
+            trueArg
+        , option
+            []
+            ["full-version"]
+            "Print the version, Git revision if available, and compiler information"
+            globalFullVersion
+            (\v flags -> flags{globalFullVersion = v})
             trueArg
         , option
             []

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -33,6 +33,7 @@
 module Distribution.Simple.Utils
   ( cabalVersion
   , cabalGitInfo
+  , cabalCompilerInfo
 
     -- * logging and errors
   , dieNoVerbosity
@@ -213,6 +214,7 @@ import Distribution.Compat.Internal.TempFile
 import Distribution.Compat.Lens (Lens', over)
 import Distribution.Compat.Prelude
 import Distribution.Compat.Stack
+import Distribution.Compat.SysInfo as SIC
 import Distribution.ModuleName as ModuleName
 import Distribution.Simple.Errors
 import Distribution.Simple.PreProcess.Types
@@ -244,6 +246,7 @@ import Data.Typeable
 
 import qualified Control.Exception as Exception
 import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
+import qualified Data.Version as DV
 import Distribution.Compat.Process (proc)
 import Foreign.C.Error (Errno (..), ePIPE)
 import qualified GHC.IO.Exception as GHC
@@ -294,6 +297,7 @@ import System.IO.Error
 import System.IO.Unsafe
   ( unsafeInterleaveIO
   )
+import qualified System.Info as SI
 import qualified System.Process as Process
 import qualified Text.PrettyPrint as Disp
 
@@ -331,19 +335,34 @@ cabalGitInfo = if giHash' == ""
                  else concat [ "(commit "
                              , giHash'
                              , branchInfo
-                             , ", "
-                             , either (const "") giCommitDate gi'
+                             , either (const "") ((", " ++) . giCommitDate) gi'
                              , ")"
                              ]
   where
     gi' = $$tGitInfoCwdTry
     giHash' = take 7 . either (const "") giHash $ gi'
+    branch = either id giBranch gi'
     branchInfo | isLeft gi' = ""
-               | either id giBranch gi' == "master" = ""
-               | otherwise = " on " <> either id giBranch gi'
+               | branch == "master" = ""
+               | otherwise = " on " <> branch
 #else
 cabalGitInfo = ""
 #endif
+
+-- |
+-- `Cabal` compiler information, reported by `--version-full` but otherwise
+-- unused.
+cabalCompilerInfo :: String
+cabalCompilerInfo =
+  concat
+    [ SI.compilerName
+    , " "
+    , intercalate "." (map show (DV.versionBranch SIC.fullCompilerVersion))
+    , " on "
+    , SI.os
+    , " "
+    , SI.arch
+    ]
 
 -- ----------------------------------------------------------------------------
 -- Exception and logging utils

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -359,6 +359,7 @@ instance Semigroup SavedConfig where
       combinedSavedGlobalFlags =
         GlobalFlags
           { globalVersion = combine globalVersion
+          , globalFullVersion = combine globalFullVersion
           , globalNumericVersion = combine globalNumericVersion
           , globalConfigFile = combine globalConfigFile
           , globalConstraintsFile = combine globalConstraintsFile

--- a/cabal-install/src/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/src/Distribution/Client/GlobalFlags.hs
@@ -81,6 +81,7 @@ import qualified Hackage.Security.Util.Pretty as Sec
 -- | Flags that apply at the top level, not to any sub-command.
 data GlobalFlags = GlobalFlags
   { globalVersion :: Flag Bool
+  , globalFullVersion :: Flag Bool
   , globalNumericVersion :: Flag Bool
   , globalConfigFile :: Flag FilePath
   , globalConstraintsFile :: Flag FilePath
@@ -103,6 +104,7 @@ defaultGlobalFlags :: GlobalFlags
 defaultGlobalFlags =
   GlobalFlags
     { globalVersion = Flag False
+    , globalFullVersion = Flag False
     , globalNumericVersion = Flag False
     , globalConfigFile = mempty
     , globalConstraintsFile = mempty

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -226,6 +226,7 @@ import Distribution.Simple.Program.Db (reconfigurePrograms)
 import qualified Distribution.Simple.Setup as Cabal
 import Distribution.Simple.Utils
   ( VerboseException
+  , cabalCompilerInfo
   , cabalGitInfo
   , cabalVersion
   , createDirectoryIfMissingVerbose
@@ -351,6 +352,8 @@ mainWorker args = do
           _
             | fromFlagOrDefault False (globalVersion globalFlags) ->
                 printVersion
+            | fromFlagOrDefault False (globalFullVersion globalFlags) ->
+                printFullVersion
             | fromFlagOrDefault False (globalNumericVersion globalFlags) ->
                 printNumericVersion
           CommandHelp help -> printCommandHelp help
@@ -424,11 +427,22 @@ mainWorker args = do
       putStrLn $
         "cabal-install version "
           ++ display cabalInstallVersion
+          ++ "\ncompiled using version "
+          ++ display cabalVersion
+          ++ " of the Cabal library "
+    printFullVersion =
+      putStrLn $
+        "cabal-install version "
+          ++ display cabalInstallVersion
           ++ cabalInstallGitInfo'
           ++ "\ncompiled using version "
           ++ display cabalVersion
           ++ " of the Cabal library "
           ++ cabalGitInfo'
+          ++ "\nwith "
+          -- it's impossible for cabal-install to have been built with a different compiler
+          -- from Cabal, so just reuse its info
+          ++ cabalCompilerInfo
       where
         cabalInstallGitInfo'
           | null cabalInstallGitInfo = ""

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -984,6 +984,7 @@ convertToLegacySharedConfig
       globalFlags =
         GlobalFlags
           { globalVersion = mempty
+          , globalFullVersion = mempty
           , globalNumericVersion = mempty
           , globalConfigFile = projectConfigConfigFile
           , globalConstraintsFile = mempty

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -491,6 +491,13 @@ globalCommand commands =
           trueArg
       , option
           []
+          ["full-version"]
+          "Print full version information with git revision (if available) and compiler"
+          globalFullVersion
+          (\v flags -> flags{globalFullVersion = v})
+          trueArg
+      , option
+          []
           ["numeric-version"]
           "Print just the version number"
           globalNumericVersion

--- a/cabal-install/src/Distribution/Client/Version.hs
+++ b/cabal-install/src/Distribution/Client/Version.hs
@@ -9,7 +9,11 @@ module Distribution.Client.Version
   , cabalInstallGitInfo
   ) where
 
+import Data.List (intercalate)
+import qualified Data.Version as DV
+import qualified Distribution.Compat.SysInfo as SIC
 import Distribution.Version
+import qualified System.Info as SI
 
 import qualified Paths_cabal_install as PackageInfo
 
@@ -29,6 +33,20 @@ cabalInstallVersion :: Version
 cabalInstallVersion = mkVersion' PackageInfo.version
 
 -- |
+-- `cabal-install` compiler information.
+cabalInstallCompilerInfo :: String
+cabalInstallCompilerInfo =
+  concat
+    [ SI.compilerName
+    , " "
+    , intercalate "." (map show (DV.versionBranch SIC.fullCompilerVersion))
+    , " on "
+    , SI.os
+    , " "
+    , SI.arch
+    ]
+
+-- |
 -- `cabal-install` Git information. Only filled in if built in a Git tree in
 -- development mode and Template Haskell is available.
 cabalInstallGitInfo :: String
@@ -38,16 +56,16 @@ cabalInstallGitInfo = if giHash' == ""
                         else concat [ "(commit "
                                     , giHash'
                                     , branchInfo
-                                    , ", "
-                                    , either (const "") giCommitDate gi'
+                                    , either (const "") ((", " ++) . giCommitDate) gi'
                                     , ")"
                                     ]
   where
     gi' = $$tGitInfoCwdTry
     giHash' = take 7 . either (const "") giHash $ gi'
+    branch = either id giBranch gi'
     branchInfo | isLeft gi' = ""
-               | either id giBranch gi' == "master" = ""
-               | otherwise = " on " <> either id giBranch gi'
+               | branch == "master" = ""
+               | otherwise = " on " <> branch
 #else
 cabalInstallGitInfo = ""
 #endif

--- a/changelog.d/pr-11339
+++ b/changelog.d/pr-11339
@@ -1,0 +1,13 @@
+---
+synopsis: Add `--version-full` option and move additional version information to it
+packages: [Cabal, cabal-install]
+prs: 11339
+---
+
+A new option `--version-full` has been added to `cabal` and `Setup.hs`. The previously added git revision information has been moved to it, and compiler and host information added to it.
+
+The `--version` option now reports the same information it originally did, in case scripts were relying on its output.
+
+Git revision information still is not provided for release builds, largely to avoid bootstrapping issues when building GHC. (Both cabal-install (not distributed, but used by hadrian) and the Cabal library are built as part of GHC builds.)
+
+This _shouldn't_ affect most people, unless someone has been relying on the output of `--version` instead of using `--numeric-version`; but they would have been forced to support both output forms, and that only if supporting unreleased cabal builds.


### PR DESCRIPTION
I'm not sure if this counts as a significant change or not, since it's a new out-of-the-way command line option

```
hilfy «cabal+more-version-info¤@a11e10471» Z$ $(cabal list-bin cabal) --full-version
Warning: this is a debug build of cabal-install with assertions enabled.
cabal-install version 3.17.0.0 (commit 475bba6 on more-version-info, Wed Jan 21 01:42:37 2026 +0000)
compiled using version 3.17.0.0 of the Cabal library (in-tree)
with ghc 9.10.3 on linux x86_64
```
The information added by this change is the last line. If a development GHC version is used to build `cabal`, the version will include a datestamp (e.g. `9.14.0.20251128`).

The original output of `--version` has been restored; all new information now lives under `--full-version`.

The reason for this is a perplexing cabal bug report on the FP Discord that turned out to be the user running a Linux build of cabal on FreeBSD. Cabal tends to trust `System.Info` for local system information for some things, but it's hardcoded to the system cabal was built on, not the one it's running on. (I think this can only arise on FreeBSD, although presumably a lesser form might happen on older Apple Silicon Macs running an Intel build via Rosetta2.)

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---
QA notes:

- Verify that `--version` is back to what it was before any of the git revision changes, including spaces
- Verify that `--full-version` includes git information (if supported) and compiler information
- Verify that `cabal exec cabal -- act-as-setup -- --full-version` includes git (if available) and compiler information
- If you're in a position to install the new `Cabal` library and have a `Setup.hs` sitting around, verify that `runhaskell Setup.hs -- --full-version` works and includes them
  * I'm not sure this is actually doable; can you force it to use a different `Cabal` than comes with the current `ghc`?
- If you happen to have a FreeBSD system, verify that
  * a native FreeBSD build has the correct information
  * a Linux build via the [Linuxulator](https://docs.freebsd.org/en/books/handbook/linuxemu/) (if you have it configured) shows Linux information