### PR TITLE
fix some backward compatibility bugs in `GIT_REV`

### DIFF
--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -418,7 +418,6 @@ mainWorker args = do
       putStrLn $
         "cabal-install version "
           ++ display cabalInstallVersion
-          ++ " "
           ++ cabalInstallGitInfo
           ++ "\ncompiled using version "
           ++ display cabalVersion
@@ -426,6 +425,7 @@ mainWorker args = do
           ++ cabalGitInfo'
       where
         cabalGitInfo'
+          | cabalGitInfo == "" && cabalInstallGitInfo == "" = ""
           | cabalGitInfo == cabalInstallGitInfo = "(in-tree)"
           | otherwise = cabalGitInfo
 

--- a/cabal-install/src/Distribution/Client/Version.hs
+++ b/cabal-install/src/Distribution/Client/Version.hs
@@ -30,7 +30,7 @@ cabalInstallVersion = mkVersion' PackageInfo.version
 
 -- |
 -- `cabal-install` Git information. Only filled in if built in a Git tree in
--- developmnent mode and Template Haskell is available.
+-- development mode and Template Haskell is available.
 cabalInstallGitInfo :: String
 #ifdef GIT_REV
 cabalInstallGitInfo = if giHash' == ""


### PR DESCRIPTION
It was incorrectly displaying `(in-tree)` when there was no git information. Also, the spacing was slightly incompatible with older versions.

This should restore 100% compatibility with older versions of `cabal-install`, for scripts that parse `cabal --version` output.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
