### PR TITLE
Don't warn on `mhs-options` (fixes #11341)

### DIFF
--- a/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
@@ -726,6 +726,8 @@ optionsFieldGrammar =
     <* knownField "jhc-options"
     <* knownField "hugs-options"
     <* knownField "nhc98-options"
+    -- NOTE: These are used by MicroCabal for MicroHs
+    <* knownField "mhs-options"
   where
     extract :: CompilerFlavor -> ALens' BuildInfo [String]
     extract flavor = L.options . lookupLens flavor

--- a/changelog.d/pr-11344
+++ b/changelog.d/pr-11344
@@ -1,0 +1,4 @@
+synopsis: Don't warn on mhs-options
+packages: Cabal-syntax
+issues: #11341
+prs: #11344


### PR DESCRIPTION
This addresses #11341.



---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
