### PR TITLE
Recognise SetupHooks.hs

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -833,7 +833,9 @@ checkSetupExists _ =
     ( \ops -> do
         ba <- doesFileExist ops "Setup.hs"
         bb <- doesFileExist ops "Setup.lhs"
-        return (not $ ba || bb)
+        bc <- doesFileExist ops "SetupHooks.hs"
+        bd <- doesFileExist ops "SetupHooks.lhs"
+        return (not $ ba || bb || bc || bd)
     )
     (PackageDistInexcusable MissingSetupFile)
 

--- a/Cabal/src/Distribution/PackageDescription/Check/Warning.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Warning.hs
@@ -1463,7 +1463,8 @@ ppExplanation (UnknownFile fieldname file) =
     ++ quote (getSymbolicPath file)
     ++ " which does not exist."
 ppExplanation MissingSetupFile =
-  "The package is missing a Setup.hs or Setup.lhs script."
+  "The package is missing a Setup.hs or Setup.lhs or SetupHooks.hs "
+    ++ "or SetupHooks.lhs script."
 ppExplanation MissingConfigureScript =
   "The 'build-type' is 'Configure' but there is no 'configure' script. "
     ++ "You probably need to run 'autoreconf -i' to generate it."

--- a/cabal-testsuite/PackageTests/Check/PackageFiles/NoSetupFile/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/PackageFiles/NoSetupFile/cabal.out
@@ -1,4 +1,5 @@
 # cabal check
 The following errors will cause portability problems on other environments:
-Error: [missing-setup] The package is missing a Setup.hs or Setup.lhs script.
+Error: [missing-setup] The package is missing a Setup.hs or Setup.lhs or
+SetupHooks.hs or SetupHooks.lhs script.
 Error: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/SetupHooks/SetupHooks.hs
+++ b/cabal-testsuite/PackageTests/Check/SetupHooks/SetupHooks.hs
@@ -1,0 +1,6 @@
+module SetupHooks where
+
+import Distribution.Simple.SetupHooks ( SetupHooks, noSetupHooks )
+
+setupHooks :: SetupHooks
+setupHooks = noSetupHooks

--- a/cabal-testsuite/PackageTests/Check/SetupHooks/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/SetupHooks/cabal.out
@@ -1,0 +1,2 @@
+# cabal check
+No errors or warnings could be found in the package.

--- a/cabal-testsuite/PackageTests/Check/SetupHooks/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/SetupHooks/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+-- SetupHooks.hs is a valid setup script.
+main = cabalTest $
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/SetupHooks/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/SetupHooks/pkg.cabal
@@ -1,0 +1,24 @@
+cabal-version: 3.14
+name: pkg
+version: 0.1.0.0
+synopsis: pkg
+description: pkg description
+license: GPL-3.0-or-later
+author: Joris Dral
+maintainer: joris@well-typed.com
+build-type: Hooks
+category: Data
+
+common warnings
+  ghc-options: -Wall
+
+library
+  import: warnings
+  exposed-modules: MyLib
+  build-depends: base ^>=4.18.3.0
+  default-language: Haskell2010
+
+custom-setup
+  setup-depends:
+    Cabal-hooks >=3.14 && <3.17,
+    base >=4.18 && <5

--- a/changelog.d/pr-11351
+++ b/changelog.d/pr-11351
@@ -1,0 +1,8 @@
+---
+synopsis: Recognise SetupHooks.hs
+packages: [cabal-install]
+prs: 11351
+issues: 11349
+---
+
+`cabal check` now recogsnises `SetupHooks.hs` as a valid setup script.

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -1521,7 +1521,7 @@ A list of all warnings with their constructor:
 - ``no-cabal-file``: no ``.cabal`` file found in folder.
 - ``multiple-cabal-file``: multiple ``.cabal`` files found in folder.
 - ``unknown-file``: path refers to a file which does not exist.
-- ``missing-setup``: missing ``Setup.hs`` or ``Setup.lsh``.
+- ``missing-setup``: missing ``Setup.hs`` or ``Setup.lhs`` or ``SetupHooks.hs``  or ``SetupHooks.lhs``.
 - ``missing-conf-script``: missing ``configure`` script with ``build-type: Configure``.
 - ``unknown-directory``: paths refer to a directory which does not exist.
 - ``no-repository``: missing ``source-repository`` section.


### PR DESCRIPTION
Closes #11349
`cabal check` now recognises SetupHooks.hs as a valid setup script.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

**QA NOTES**

Download the repro in #11349, run `cabal check`.