### PR TITLE
Clean GHCup metadata script

### DIFF
--- a/scripts/release/create-release-metadata-for-ghcup.sh
+++ b/scripts/release/create-release-metadata-for-ghcup.sh
@@ -67,6 +67,10 @@ cat <<EOF > /dev/stdout
               dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-windows.zip
               dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-windows.zip" | awk '{ print $1 }')
         A_32:
+          Linux_UnknownLinux:
+            unknown_versioning: &cabal-${RELEASE//./}-32
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-i386-linux-alpine3_12.tar.xz
+              dlHash: $(sha256sum "cabal-install-$RELEASE-i386-linux-alpine3_12.tar.xz" | awk '{ print $1 }')
           Linux_Alpine:
             unknown_versioning: *cabal-${RELEASE//./}-32
         A_ARM64:


### PR DESCRIPTION
We don't release a number of binaries. Axe them from the metadata script.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~
