### PR TITLE
Profiling documentation needs -- to function

### DIFF
--- a/doc/how-to-enable-profiling.rst
+++ b/doc/how-to-enable-profiling.rst
@@ -54,7 +54,7 @@ Second, run your application with the right runtime system flags and let it crea
 
 .. code-block:: console
 
-    $ cabal run my-app +RTS -pj -RTS
+    $ cabal run my-app -- +RTS -pj -RTS
     <app builds, runs and finishes>
 
 When the application finishes, a profiling JSON report (due to option ``-pj``)


### PR DESCRIPTION
I've followed the exact documentation for enabling profiling and running a program _with_ profiling, but it didn't work. It told me the program needs to have been compiled with `-prof`.

Turns out the problem is in the documentation: without the additional `--` in the command line, I think cabal is trying to run itself with profiling. At least not my application. With the `--` it works.

Does this make sense?