### PR TITLE
Don't use lists in footnotes

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -3455,8 +3455,10 @@ a few options:
 .. rubric:: Footnotes
 
 .. [#old-style-build-tool-depends]
-   Some packages (ab)use :pkg-field:`build-depends` on old-style builds, but this has a few major drawbacks:
-
-   - using Nix-style builds it's considered an error if you depend on a exe-only package via build-depends: the solver will refuse it.
-   - it may or may not place the executable on ``PATH``.
-   - it does not ensure the correct version of the package is installed, so you might end up overwriting versions with each other.
+   Some packages (ab)use :pkg-field:`build-depends` on old-style builds, but
+   this has a few major drawbacks. First, with Nix-style builds it's considered
+   an error if you depend on a exe-only package via ``build-depends``: the
+   solver will refuse it.  Next, ``build-depends`` may or may not place the
+   executable on ``PATH``.  Finally, ``build-depends`` does not ensure the
+   correct version of the package is installed, so you might end up overwriting
+   versions with each other.


### PR DESCRIPTION
Fixes #11246. With the read the docs theme at versions `>=0.18` we can't use lists within footnotes. I removed the list and put its elements inline as sentences within the footnote paragraph.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
