### PR TITLE
Bump sphinx and rtd theme

### DIFF
--- a/.github/workflows/users-guide.yml
+++ b/.github/workflows/users-guide.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v6

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,9 @@ sphinx:
   configuration: doc/conf.py
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.8"
+    python: "3.13"
   jobs:
     post_create_environment:
       - pip install pip-tools

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,9 +63,6 @@ html_theme = 'sphinx_rtd_theme'
 if on_rtd:
     html_style = None
     using_rtd_theme = True
-else:
-    import sphinx_rtd_theme
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -1,5 +1,5 @@
-sphinx == 5.3.0
-sphinx_rtd_theme >= 1.2
+sphinx == 8.2.3
+sphinx_rtd_theme >= 3.0.2
 sphinx-jsonschema
 sphinxnotes-strike
 # Pygments>=2.7.4 suggested by CVE-2021-20270 CVE-2021-27291
@@ -14,5 +14,3 @@ jinja2 >= 3.1.4
 idna >= 3.7
 # CVE-2024-35195
 requests >= 2.32.0
-# https://github.com/haskell/cabal/issues/11246
-docutils <0.18


### PR DESCRIPTION
Fixes #11020. Bump the sphinx and rtd theme versions and remove the constraint on docutils that was in conflict. This allows building with `Python-3.13.7`, the version shipping with `Ubuntu-25.10`.

I heeded the warning fix, suggesting that `html_theme_path` not be set.

```
$ make users-guide --always-make
...
Running Sphinx v8.2.3
WARNING: Calling get_html_theme_path is deprecated. If you are calling it to
define html_theme_path, you are safe to remove that code.
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
