### PR TITLE
Clarify documentation for Distribution.Compat.ResponseFile

### DIFF
--- a/Cabal/src/Distribution/Compat/ResponseFile.hs
+++ b/Cabal/src/Distribution/Compat/ResponseFile.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-
--- Compatibility layer for GHC.ResponseFile
--- Implementation from base 4.12.0 is used.
--- http://hackage.haskell.org/package/base-4.12.0.0/src/LICENSE
 module Distribution.Compat.ResponseFile (expandResponse, escapeArgs) where
 
 import Distribution.Compat.Prelude
@@ -16,12 +10,12 @@ import System.FilePath
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error
 
--- | The arg file / response file parser.
---
--- This is not a well-documented capability, and is a bit eccentric
--- (try @cabal \@foo \@bar@ to see what that does), but is crucial
--- for allowing complex arguments to cabal and cabal-install when
--- using command prompts with strongly-limited argument length.
+-- | This is a more elaborate version of 'GHC.ResponseFile.expandResponse',
+-- which not only substitute @\@foo@ with the contents of file @foo@,
+-- but performs such substitution recursively.
+-- In doing so we keep closer to the reference implementation
+-- of @expandargv@ in @argv.c@ from @binutils@, although this additional functionality
+-- likely remains unused by Haskell tooling.
 expandResponse :: [String] -> IO [String]
 expandResponse = go recursionLimit "."
   where


### PR DESCRIPTION
Relevant links:
* https://github.com/haskell/cabal/commit/4e1b2c9352b54c4fe64cf66bfaaee07b1aa483c7
* https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob;f=libiberty/argv.c;h=6444896f995a8e4abfb6a1edc510f3a4bbe1a30b;hb=HEAD#l342
* https://hackage.haskell.org/package/ghc-internal-9.1401.0/docs/src/GHC.Internal.ResponseFile.html#expandResponse
* https://gitlab.haskell.org/ghc/ghc/-/commit/866525a1765715b8b9902e1bd53b9af1c7a93a30
* https://github.com/haskell/haddock/commit/d510c45790432249fe7027b1ed70ce1c06fdd824

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).