### PR TITLE
Simplify calling conventions in favor of CApi

### DIFF
--- a/Cabal/src/Distribution/Compat/Environment.hs
+++ b/Cabal/src/Distribution/Compat/Environment.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
@@ -61,15 +62,7 @@ setEnv_ key value = withCWString key $ \k -> withCWString value $ \v -> do
   _ = callStack -- TODO: attach CallStack to exception
 
 {- FOURMOLU_DISABLE -}
-# if defined(i386_HOST_ARCH)
-#  define WINDOWS_CCONV stdcall
-# elif defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
-#  define WINDOWS_CCONV ccall
-# else
-#  error Unknown mingw32 arch
-# endif /* i386_HOST_ARCH */
-
-foreign import WINDOWS_CCONV unsafe "windows.h SetEnvironmentVariableW"
+foreign import capi unsafe "windows.h SetEnvironmentVariableW"
   c_SetEnvironmentVariable :: LPTSTR -> LPTSTR -> Prelude.IO Bool
 #else
 setEnv_ key value = do
@@ -80,7 +73,7 @@ setEnv_ key value = do
  where
   _ = callStack -- TODO: attach CallStack to exception
 
-foreign import ccall unsafe "setenv"
+foreign import capi unsafe "setenv"
    c_setenv :: CString -> CString -> CInt -> Prelude.IO CInt
 #endif /* mingw32_HOST_OS */
 {- FOURMOLU_ENABLE -}

--- a/Cabal/src/Distribution/Compat/GetShortPathName.hs
+++ b/Cabal/src/Distribution/Compat/GetShortPathName.hs
@@ -1,6 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
-
------------------------------------------------------------------------------
 
 -- |
 -- Module      :  Distribution.Compat.GetShortPathName
@@ -22,14 +21,7 @@ import qualified System.Win32 as Win32
 import System.Win32          (LPCTSTR, LPTSTR, DWORD)
 import Foreign.Marshal.Array (allocaArray)
 
-{- FOURMOLU_DISABLE -}
-#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
-#define WINAPI ccall
-#else
-#define WINAPI stdcall
-#endif
-
-foreign import WINAPI unsafe "windows.h GetShortPathNameW"
+foreign import capi unsafe "windows.h GetShortPathNameW"
   c_GetShortPathName :: LPCTSTR -> LPTSTR -> DWORD -> Prelude.IO DWORD
 
 -- | On Windows, retrieves the short path form of the specified path. On
@@ -58,4 +50,3 @@ getShortPathName :: FilePath -> IO FilePath
 getShortPathName path = return path
 
 #endif
-{- FOURMOLU_ENABLE -}

--- a/Cabal/src/Distribution/Compat/Time.hs
+++ b/Cabal/src/Distribution/Compat/Time.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -93,14 +94,7 @@ getModTime path = allocaBytes size_WIN32_FILE_ATTRIBUTE_DATA $ \info -> do
             .|. (fromIntegral (dwLow :: DWORD))
       return $! ModTime (qwTime :: Word64)
 
-{- FOURMOLU_DISABLE -}
-#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
-#define CALLCONV ccall
-#else
-#define CALLCONV stdcall
-#endif
-
-foreign import CALLCONV "windows.h GetFileAttributesExW"
+foreign import capi "windows.h GetFileAttributesExW"
   c_getFileAttributesEx :: LPCTSTR -> Int32 -> LPVOID -> Prelude.IO BOOL
 
 getFileAttributesEx :: String -> LPVOID -> IO BOOL
@@ -131,7 +125,6 @@ extractFileTime :: FileStatus -> ModTime
 extractFileTime x = posixTimeToModTime (modificationTimeHiRes x)
 
 #endif
-{- FOURMOLU_ENABLE -}
 
 windowsTick, secToUnixEpoch :: Word64
 windowsTick = 10000000

--- a/Cabal/src/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/src/Distribution/Simple/InstallDirs.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -550,14 +551,7 @@ csidl_PROGRAM_FILES = 0x0026
 -- csidl_PROGRAM_FILES_COMMON :: CInt
 -- csidl_PROGRAM_FILES_COMMON = 0x002b
 
-{- FOURMOLU_DISABLE -}
-#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
-#define CALLCONV ccall
-#else
-#define CALLCONV stdcall
-#endif
-
-foreign import CALLCONV unsafe "shlobj.h SHGetFolderPathW"
+foreign import capi unsafe "shlobj.h SHGetFolderPathW"
             c_SHGetFolderPath :: Ptr ()
                               -> CInt
                               -> Ptr ()
@@ -565,7 +559,6 @@ foreign import CALLCONV unsafe "shlobj.h SHGetFolderPathW"
                               -> CWString
                               -> Prelude.IO CInt
 #endif
-{- FOURMOLU_ENABLE -}
 
 -- ---------------------------------------------------------------------------
 -- FieldGrammar

--- a/cabal-install/src/Distribution/Client/Win32SelfUpgrade.hs
+++ b/cabal-install/src/Distribution/Client/Win32SelfUpgrade.hs
@@ -1,8 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
-
------------------------------------------------------------------------------
-
------------------------------------------------------------------------------
 
 -- |
 -- Module      :  Distribution.Client.Win32SelfUpgrade
@@ -165,17 +162,10 @@ deleteOldExeFile verbosity oldPID tmpPath = do
 
 -- A bunch of functions sadly not provided by the Win32 package.
 
-{- FOURMOLU_DISABLE -}
-#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
-#define CALLCONV ccall
-#else
-#define CALLCONV stdcall
-#endif
-
-foreign import CALLCONV unsafe "windows.h GetCurrentProcessId"
+foreign import capi unsafe "windows.h GetCurrentProcessId"
   getCurrentProcessId :: IO DWORD
 
-foreign import CALLCONV unsafe "windows.h WaitForSingleObject"
+foreign import capi unsafe "windows.h WaitForSingleObject"
   waitForSingleObject_ :: HANDLE -> DWORD -> IO DWORD
 
 waitForSingleObject :: HANDLE -> DWORD -> IO ()
@@ -186,7 +176,7 @@ waitForSingleObject handle timeout =
     bad result   = not (result == 0 || result == wAIT_TIMEOUT)
     wAIT_TIMEOUT = 0x00000102
 
-foreign import CALLCONV unsafe "windows.h CreateEventW"
+foreign import capi unsafe "windows.h CreateEventW"
   createEvent_ :: Ptr () -> BOOL -> BOOL -> LPCTSTR -> IO HANDLE
 
 createEvent :: String -> IO HANDLE
@@ -195,7 +185,7 @@ createEvent name = do
     Win32.withTString name $
       createEvent_ nullPtr False False
 
-foreign import CALLCONV unsafe "windows.h OpenEventW"
+foreign import capi unsafe "windows.h OpenEventW"
   openEvent_ :: DWORD -> BOOL -> LPCTSTR -> IO HANDLE
 
 openEvent :: String -> IO HANDLE
@@ -207,7 +197,7 @@ openEvent name = do
     eVENT_MODIFY_STATE :: DWORD
     eVENT_MODIFY_STATE = 0x0002
 
-foreign import CALLCONV unsafe "windows.h SetEvent"
+foreign import capi unsafe "windows.h SetEvent"
   setEvent_ :: HANDLE -> IO BOOL
 
 setEvent :: HANDLE -> IO ()
@@ -229,4 +219,3 @@ deleteOldExeFile :: Verbosity -> Int -> FilePath -> IO ()
 deleteOldExeFile verbosity _ _ = dieWithException verbosity Win32SelfUpgradeNotNeeded
 
 #endif
-{- FOURMOLU_ENABLE -}


### PR DESCRIPTION
**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
