### PR TITLE
Re-enable ProfShared test on ubuntu 9.0.2 validate job

### DIFF
--- a/cabal-testsuite/PackageTests/ProfShared/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ProfShared/setup.test.hs
@@ -11,9 +11,6 @@ main = do
         -- Tests are not robust against missing dynamic libraries yet. Would
         -- be better to fix this.
         skipIfNoSharedLibraries
-        -- Skip on GHC 9.0.2 / Ubuntu configuration due to test failure
-        ghc902 <- isGhcVersion "== 9.0.2"
-        skipIf "GHC 9.0.2 on Linux, https://github.com/haskell/cabal/issues/11387" (ghc902 && isLinux)
 
     let analyse_result expected r = do
 


### PR DESCRIPTION
See https://github.com/haskell-actions/setup/issues/136 for the cause of this test starting to fail.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.


---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
