### PR TITLE
Ignore args that look like a response file

### DIFF
--- a/Cabal/src/Distribution/Compat/ResponseFile.hs
+++ b/Cabal/src/Distribution/Compat/ResponseFile.hs
@@ -27,7 +27,7 @@ expandResponse = go recursionLimit "."
       | otherwise = const $ hPutStrLn stderr "Error: response file recursion limit exceeded." >> exitFailure
 
     expand :: Int -> FilePath -> String -> IO [String]
-    expand n dir arg@('@' : f) = readRecursively n (dir </> f) `catchIOError` const (print "?" >> return [arg])
+    expand n dir arg@('@' : f) = readRecursively n (dir </> f) `catchIOError` const (return [arg])
     expand _n _dir x = return [x]
 
     readRecursively :: Int -> FilePath -> IO [String]


### PR DESCRIPTION
Fixes #11393

Related: #11406

If an argument looks like a response file (e.g. `@foo`) but it doesn't exist, ignore it and leave as-is.

The current behavior already did this, but printed out a question mark, for some reason.