### PR TITLE
Include cabal-testsuite/src for formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ FORMAT_DIRS := \
 	Cabal \
 	Cabal-syntax \
 	cabal-install \
+	cabal-testsuite/src \
 	cabal-validate
 
 FORMAT_DIRS_TODO := \
@@ -46,7 +47,6 @@ FORMAT_DIRS_TODO := \
 	cabal-dev-scripts \
 	cabal-install-solver \
 	cabal-testsuite/main \
-	cabal-testsuite/src \
 	cabal-testsuite/static \
 	solver-benchmarks
 

--- a/cabal-testsuite/src/Test/Cabal/CheckArMetadata.hs
+++ b/cabal-testsuite/src/Test/Cabal/CheckArMetadata.hs
@@ -1,4 +1,7 @@
 ----------------------------------------------------------------------------
+----------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+
 -- |
 -- Module      :  Test.Cabal.CheckArMetadata
 -- Created     :   8 July 2017
@@ -7,10 +10,6 @@
 -- One of the crucial properties of .a files is that they must be
 -- deterministic - i.e. they must not include creation date as their
 -- contents to facilitate deterministic builds.
-----------------------------------------------------------------------------
-
-{-# LANGUAGE OverloadedStrings #-}
-
 module Test.Cabal.CheckArMetadata (checkMetadata) where
 
 import Test.Cabal.Prelude
@@ -20,22 +19,28 @@ import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isSpace)
 import System.IO
 
-import Distribution.Package               (getHSLibraryName)
+import Distribution.Package (getHSLibraryName)
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo, localUnitId)
 
 -- Almost a copypasta of Distribution.Simple.Program.Ar.wipeMetadata
 checkMetadata :: LocalBuildInfo -> FilePath -> IO ()
-checkMetadata lbi dir = withBinaryFile path ReadMode $ \ h ->
+checkMetadata lbi dir = withBinaryFile path ReadMode $ \h ->
   hFileSize h >>= checkArchive h
   where
     path = dir </> "lib" ++ getHSLibraryName (localUnitId lbi) ++ ".a"
 
-    checkError msg = assertFailure (
-        "PackageTests.DeterministicAr.checkMetadata: " ++ msg ++
-        " in " ++ path) >> undefined
+    checkError msg =
+      assertFailure
+        ( "PackageTests.DeterministicAr.checkMetadata: "
+            ++ msg
+            ++ " in "
+            ++ path
+        )
+        >> undefined
     archLF = "!<arch>\x0a" -- global magic, 8 bytes
     x60LF = "\x60\x0a" -- header magic, 2 bytes
-    metadata = BS.concat
+    metadata =
+      BS.concat
         [ "0           " -- mtime, 12 bytes
         , "0     " -- UID, 6 bytes
         , "0     " -- GID, 6 bytes
@@ -46,36 +51,39 @@ checkMetadata lbi dir = withBinaryFile path ReadMode $ \ h ->
     -- http://en.wikipedia.org/wiki/Ar_(Unix)#File_format_details
     checkArchive :: Handle -> Integer -> IO ()
     checkArchive h archiveSize = do
-        global <- BS.hGet h (BS.length archLF)
-        unless (global == archLF) $ checkError "Bad global header"
-        checkHeader (toInteger $ BS.length archLF)
-
+      global <- BS.hGet h (BS.length archLF)
+      unless (global == archLF) $ checkError "Bad global header"
+      checkHeader (toInteger $ BS.length archLF)
       where
         checkHeader :: Integer -> IO ()
         checkHeader offset = case compare offset archiveSize of
-            EQ -> return ()
-            GT -> checkError (atOffset "Archive truncated")
-            LT -> do
-                header <- BS.hGet h headerSize
-                unless (BS.length header == headerSize) $
-                    checkError (atOffset "Short header")
-                let magic = BS.drop 58 header
-                unless (magic == x60LF) . checkError . atOffset $
-                    "Bad magic " ++ show magic ++ " in header"
+          EQ -> return ()
+          GT -> checkError (atOffset "Archive truncated")
+          LT -> do
+            header <- BS.hGet h headerSize
+            unless (BS.length header == headerSize) $
+              checkError (atOffset "Short header")
+            let magic = BS.drop 58 header
+            unless (magic == x60LF) . checkError . atOffset $
+              "Bad magic " ++ show magic ++ " in header"
 
-                unless (metadata == BS.take 32 (BS.drop 16 header))
-                    . checkError . atOffset $ "Metadata has changed"
+            unless (metadata == BS.take 32 (BS.drop 16 header))
+              . checkError
+              . atOffset
+              $ "Metadata has changed"
 
-                let size = BS.take 10 $ BS.drop 48 header
-                objSize <- case reads (BS8.unpack size) of
-                    [(n, s)] | all isSpace s -> return n
-                    _ -> checkError (atOffset "Bad file size in header")
+            let size = BS.take 10 $ BS.drop 48 header
+            objSize <- case reads (BS8.unpack size) of
+              [(n, s)] | all isSpace s -> return n
+              _ -> checkError (atOffset "Bad file size in header")
 
-                let nextHeader = offset + toInteger headerSize +
-                        -- Odd objects are padded with an extra '\x0a'
-                        if odd objSize then objSize + 1 else objSize
-                hSeek h AbsoluteSeek nextHeader
-                checkHeader nextHeader
-
+            let nextHeader =
+                  offset
+                    + toInteger headerSize
+                    +
+                    -- Odd objects are padded with an extra '\x0a'
+                    if odd objSize then objSize + 1 else objSize
+            hSeek h AbsoluteSeek nextHeader
+            checkHeader nextHeader
           where
             atOffset msg = msg ++ " at offset " ++ show offset

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -1,192 +1,227 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | The test monad
-module Test.Cabal.Monad (
-    -- * High-level runners
-    setupAndCabalTest,
-    setupTest,
-    cabalTest,
-    cabalTest',
+module Test.Cabal.Monad
+  ( -- * High-level runners
+    setupAndCabalTest
+  , setupTest
+  , cabalTest
+  , cabalTest'
+
     -- * The monad
-    TestM,
-    runTestM,
+  , TestM
+  , runTestM
+
     -- * Helper functions
-    programPathM,
-    requireProgramM,
-    isAvailableProgram,
-    hackageRepoToolProgram,
-    gitProgram,
-    cabalProgram,
-    diffProgram,
-    python3Program,
-    requireSuccess,
-    initWorkDir,
-    recordLog,
+  , programPathM
+  , requireProgramM
+  , isAvailableProgram
+  , hackageRepoToolProgram
+  , gitProgram
+  , cabalProgram
+  , diffProgram
+  , python3Program
+  , requireSuccess
+  , initWorkDir
+  , recordLog
+
     -- * The test environment
-    TestEnv(..),
-    getTestEnv,
+  , TestEnv (..)
+  , getTestEnv
+
     -- * Recording mode
-    RecordMode(..),
-    testRecordMode,
+  , RecordMode (..)
+  , testRecordMode
+
     -- * Derived values from 'TestEnv'
-    testCurrentDir,
-    testWorkDir,
-    testPrefixDir,
-    testLibInstallDir,
-    testDistDir,
-    testSystemTmpDir,
-    testPackageDbDir,
-    testRepoDir,
-    testKeysDir,
-    testSourceCopyDir,
-    testCabalDir,
-    testStoreDir,
-    testUserCabalConfigFile,
-    testActualFile,
+  , testCurrentDir
+  , testWorkDir
+  , testPrefixDir
+  , testLibInstallDir
+  , testDistDir
+  , testSystemTmpDir
+  , testPackageDbDir
+  , testRepoDir
+  , testKeysDir
+  , testSourceCopyDir
+  , testCabalDir
+  , testStoreDir
+  , testUserCabalConfigFile
+  , testActualFile
+
     -- * Skipping tests
-    skip,
-    skipIO,
-    skipIf,
-    skipIfIO,
-    skipUnless,
-    skipUnlessIO,
+  , skip
+  , skipIO
+  , skipIf
+  , skipIfIO
+  , skipUnless
+  , skipUnlessIO
+
     -- * Known broken tests
-    expectBroken,
-    expectBrokenIf,
-    expectBrokenUnless,
+  , expectBroken
+  , expectBrokenIf
+  , expectBrokenUnless
+
     -- * Flaky tests
-    flaky,
-    flakyIf,
+  , flaky
+  , flakyIf
+
     -- * Arguments (TODO: move me)
-    CommonArgs(..),
-    renderCommonArgs,
-    commonArgParser,
+  , CommonArgs (..)
+  , renderCommonArgs
+  , commonArgParser
+
     -- * Version Constants
-    cabalVersionLibrary,
+  , cabalVersionLibrary
+  ) where
 
-) where
-
-import Test.Cabal.Script
-import Test.Cabal.Plan
 import Test.Cabal.OutputNormalizer
+import Test.Cabal.Plan
+import Test.Cabal.Script
 import Test.Cabal.TestCode
 
 import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Compiler
-    ( PackageDBStackCWD, PackageDBX(..), compilerFlavor
-    , Compiler, compilerVersion, showCompilerIdWithAbi )
-import Distribution.System
-import Distribution.Simple.Program.Db
-import Distribution.Simple.Program
+  ( Compiler
+  , PackageDBStackCWD
+  , PackageDBX (..)
+  , compilerFlavor
+  , compilerVersion
+  , showCompilerIdWithAbi
+  )
 import Distribution.Simple.Configure
-    ( configCompilerEx )
+  ( configCompilerEx
+  )
+import Distribution.Simple.Program
+import Distribution.Simple.Program.Db
 import qualified Distribution.Simple.Utils as U (cabalVersion)
+import Distribution.System
 import Distribution.Text
 
-import Test.Utils.TempTestDir (removeDirectoryRecursiveHack, withTestDir')
 import Distribution.Verbosity
 import Distribution.Version
+import Test.Utils.TempTestDir (removeDirectoryRecursiveHack, withTestDir')
 
+import Control.Applicative
 import Control.Concurrent.Async
-import Data.Monoid (mempty)
 import qualified Control.Exception as E
 import Control.Monad
-import Control.Monad.Trans.Reader
 import Control.Monad.IO.Class
+import Control.Monad.Trans.Reader
+import qualified Data.ByteString.Char8 as C
+import Data.List
 import Data.Maybe
-import Control.Applicative
+import Data.Monoid (mempty)
+import Distribution.Simple.Utils hiding (info)
+import GHC.Stack
+import Options.Applicative
 import System.Directory
 import System.Exit
 import System.FilePath
 import System.IO
 import System.IO.Error (isDoesNotExistError)
-import Distribution.Simple.Utils hiding (info)
 import System.Process hiding (env)
-import Options.Applicative
 import Test.Cabal.Run
-import qualified Data.ByteString.Char8 as C
-import Data.List
-import GHC.Stack
 
-data CommonArgs = CommonArgs {
-        argCabalInstallPath    :: Maybe FilePath,
-        argGhcPath             :: Maybe FilePath,
-        argHackageRepoToolPath :: Maybe FilePath,
-        argHaddockPath         :: Maybe FilePath,
-        argKeepTmpFiles        :: Bool,
-        argAccept              :: Bool,
-        argSkipSetupTests      :: Bool
-    }
+data CommonArgs = CommonArgs
+  { argCabalInstallPath :: Maybe FilePath
+  , argGhcPath :: Maybe FilePath
+  , argHackageRepoToolPath :: Maybe FilePath
+  , argHaddockPath :: Maybe FilePath
+  , argKeepTmpFiles :: Bool
+  , argAccept :: Bool
+  , argSkipSetupTests :: Bool
+  }
 
 commonArgParser :: Parser CommonArgs
-commonArgParser = CommonArgs
-    <$> optional (option str
-        ( help "Path to cabal-install executable to test. If omitted, tests involving cabal-install are skipped!"
-       <> long "with-cabal"
-       <> metavar "PATH"
-        ))
-    <*> optional (option str
-        ( help "GHC to ask Cabal to use via --with-ghc flag"
-       <> short 'w'
-       <> long "with-ghc"
-       <> metavar "PATH"
-        ))
-    <*> optional (option str
-        ( help "Path to hackage-repo-tool to use for repository manipulation"
-       <> long "with-hackage-repo-tool"
-       <> metavar "PATH"
-        ))
-    <*> optional (option str
-        ( help "Path to haddock to use for --with-haddock flag"
-       <> long "with-haddock"
-       <> metavar "PATH"
-        ))
+commonArgParser =
+  CommonArgs
+    <$> optional
+      ( option
+          str
+          ( help "Path to cabal-install executable to test. If omitted, tests involving cabal-install are skipped!"
+              <> long "with-cabal"
+              <> metavar "PATH"
+          )
+      )
+    <*> optional
+      ( option
+          str
+          ( help "GHC to ask Cabal to use via --with-ghc flag"
+              <> short 'w'
+              <> long "with-ghc"
+              <> metavar "PATH"
+          )
+      )
+    <*> optional
+      ( option
+          str
+          ( help "Path to hackage-repo-tool to use for repository manipulation"
+              <> long "with-hackage-repo-tool"
+              <> metavar "PATH"
+          )
+      )
+    <*> optional
+      ( option
+          str
+          ( help "Path to haddock to use for --with-haddock flag"
+              <> long "with-haddock"
+              <> metavar "PATH"
+          )
+      )
     <*> switch
-        ( long "keep-tmp-files"
-       <> help "Keep temporary files"
-        )
+      ( long "keep-tmp-files"
+          <> help "Keep temporary files"
+      )
     <*> switch
-        ( long "accept"
-       <> help "Accept output"
-        )
+      ( long "accept"
+          <> help "Accept output"
+      )
     <*> switch (long "skip-setup-tests" <> help "Skip setup tests")
 
 renderCommonArgs :: CommonArgs -> [String]
 renderCommonArgs args =
-    maybe [] (\x -> ["--with-cabal",             x]) (argCabalInstallPath    args) ++
-    maybe [] (\x -> ["--with-ghc",               x]) (argGhcPath             args) ++
-    maybe [] (\x -> ["--with-haddock",           x]) (argHaddockPath         args) ++
-    maybe [] (\x -> ["--with-hackage-repo-tool", x]) (argHackageRepoToolPath args) ++
-    (if argAccept args then ["--accept"] else []) ++
-    (if argKeepTmpFiles args then ["--keep-tmp-files"] else []) ++
-    (if argSkipSetupTests args then ["--skip-setup-tests"] else [])
+  maybe [] (\x -> ["--with-cabal", x]) (argCabalInstallPath args)
+    ++ maybe [] (\x -> ["--with-ghc", x]) (argGhcPath args)
+    ++ maybe [] (\x -> ["--with-haddock", x]) (argHaddockPath args)
+    ++ maybe [] (\x -> ["--with-hackage-repo-tool", x]) (argHackageRepoToolPath args)
+    ++ (if argAccept args then ["--accept"] else [])
+    ++ (if argKeepTmpFiles args then ["--keep-tmp-files"] else [])
+    ++ (if argSkipSetupTests args then ["--skip-setup-tests"] else [])
 
-data TestArgs = TestArgs {
-        testArgDistDir    :: FilePath,
-        testArgPackageDb  :: [FilePath],
-        testArgScriptPath :: FilePath,
-        testCommonArgs    :: CommonArgs
-    }
+data TestArgs = TestArgs
+  { testArgDistDir :: FilePath
+  , testArgPackageDb :: [FilePath]
+  , testArgScriptPath :: FilePath
+  , testCommonArgs :: CommonArgs
+  }
 
 testArgParser :: Parser TestArgs
-testArgParser = TestArgs
-    <$> option str
-        ( help "Build directory of cabal-testsuite"
-       <> long "builddir"
-       <> metavar "DIR")
-    <*> many (option str
-        ( help "Package DB which contains Cabal and Cabal-syntax"
-       <> long "extra-package-db"
-       <> metavar "DIR"))
-    <*> argument str ( metavar "FILE")
+testArgParser =
+  TestArgs
+    <$> option
+      str
+      ( help "Build directory of cabal-testsuite"
+          <> long "builddir"
+          <> metavar "DIR"
+      )
+    <*> many
+      ( option
+          str
+          ( help "Package DB which contains Cabal and Cabal-syntax"
+              <> long "extra-package-db"
+              <> metavar "DIR"
+          )
+      )
+    <*> argument str (metavar "FILE")
     <*> commonArgParser
 
 -- * skip tests
 
 skipIO :: String -> IO ()
 skipIO reason = do
-    putStrLn $ "SKIP (" <> reason <> ")"
-    E.throwIO (TestCodeSkip reason)
+  putStrLn $ "SKIP (" <> reason <> ")"
+  E.throwIO (TestCodeSkip reason)
 
 skip :: String -> TestM ()
 skip = liftIO . skipIO
@@ -207,16 +242,16 @@ skipUnless reason b = unless b (skip reason)
 
 expectBroken :: IssueID -> TestM a -> TestM a
 expectBroken ticket m = do
-    env <- getTestEnv
-    liftIO . withAsync (runReaderT m env) $ \a -> do
-        r <- waitCatch a
-        case r of
-            Left e  -> do
-                putStrLn $ "This test is known broken, see #" ++ show ticket ++ ":"
-                print e
-                throwExpectedBroken ticket
-            Right _ -> do
-                throwUnexpectedSuccess ticket
+  env <- getTestEnv
+  liftIO . withAsync (runReaderT m env) $ \a -> do
+    r <- waitCatch a
+    case r of
+      Left e -> do
+        putStrLn $ "This test is known broken, see #" ++ show ticket ++ ":"
+        print e
+        throwExpectedBroken ticket
+      Right _ -> do
+        throwUnexpectedSuccess ticket
 
 expectBrokenIf :: Bool -> IssueID -> TestM a -> TestM a
 expectBrokenIf True ticket m = expectBroken ticket m
@@ -227,29 +262,29 @@ expectBrokenUnless b = expectBrokenIf (not b)
 
 throwExpectedBroken :: IssueID -> IO a
 throwExpectedBroken ticket = do
-    putStrLn $ "EXPECTED FAIL (#" <> show ticket <> ")"
-    E.throwIO (TestCodeKnownFail ticket)
+  putStrLn $ "EXPECTED FAIL (#" <> show ticket <> ")"
+  E.throwIO (TestCodeKnownFail ticket)
 
 throwUnexpectedSuccess :: IssueID -> IO a
 throwUnexpectedSuccess ticket = do
-    putStrLn $ "UNEXPECTED OK (#" <> show ticket <> ")"
-    E.throwIO (TestCodeUnexpectedOk ticket)
+  putStrLn $ "UNEXPECTED OK (#" <> show ticket <> ")"
+  E.throwIO (TestCodeUnexpectedOk ticket)
 
 -- * Flaky tests
 
 flaky :: IssueID -> TestM a -> TestM a
 flaky ticket m = do
-    env <- getTestEnv
-    liftIO . withAsync (runReaderT m env) $ \a -> do
-        r <- waitCatch a
-        case r of
-            Left e  -> do
-                putStrLn $ "This test is known flaky, and it failed, see #" ++ show ticket ++ ":"
-                print e
-                throwFlakyFail ticket
-            Right _ -> do
-                putStrLn $ "This test is known flaky, but it passed, see #" ++ show ticket ++ ":"
-                throwFlakyPass ticket
+  env <- getTestEnv
+  liftIO . withAsync (runReaderT m env) $ \a -> do
+    r <- waitCatch a
+    case r of
+      Left e -> do
+        putStrLn $ "This test is known flaky, and it failed, see #" ++ show ticket ++ ":"
+        print e
+        throwFlakyFail ticket
+      Right _ -> do
+        putStrLn $ "This test is known flaky, but it passed, see #" ++ show ticket ++ ":"
+        throwFlakyPass ticket
 
 flakyIf :: Bool -> IssueID -> TestM a -> TestM a
 flakyIf True ticket m = flaky ticket m
@@ -257,40 +292,41 @@ flakyIf False _ m = m
 
 throwFlakyFail :: IssueID -> IO a
 throwFlakyFail ticket = do
-    putStrLn $ "FLAKY FAIL (#" <> show ticket <> ")"
-    E.throwIO (TestCodeFlakyFailed ticket)
+  putStrLn $ "FLAKY FAIL (#" <> show ticket <> ")"
+  E.throwIO (TestCodeFlakyFailed ticket)
 
 throwFlakyPass :: IssueID -> IO a
 throwFlakyPass ticket = do
-    putStrLn $ "FLAKY OK (#" <> show ticket <> ")"
-    E.throwIO (TestCodeFlakyPassed ticket)
+  putStrLn $ "FLAKY OK (#" <> show ticket <> ")"
+  E.throwIO (TestCodeFlakyPassed ticket)
 
 trySkip :: IO a -> IO (Either String a)
-trySkip m = fmap Right m `E.catch` \e -> case e of
+trySkip m =
+  fmap Right m `E.catch` \e -> case e of
     TestCodeSkip msg -> return (Left msg)
-    _                -> E.throwIO e
+    _ -> E.throwIO e
 
 setupAndCabalTest :: TestM () -> IO ()
 setupAndCabalTest m = do
-    r1 <- trySkip (setupTest m)
-    r2 <- trySkip (cabalTest' "cabal" m)
-    case (r1, r2) of
-        (Left msg1, Left msg2) -> E.throwIO (TestCodeSkip (msg1 ++ "; " ++ msg2))
-        _                      -> return ()
+  r1 <- trySkip (setupTest m)
+  r2 <- trySkip (cabalTest' "cabal" m)
+  case (r1, r2) of
+    (Left msg1, Left msg2) -> E.throwIO (TestCodeSkip (msg1 ++ "; " ++ msg2))
+    _ -> return ()
 
 setupTest :: TestM () -> IO ()
 setupTest m = runTestM "" $ do
-    env <- getTestEnv
-    skipIf "setup test" (testSkipSetupTests env)
-    m
+  env <- getTestEnv
+  skipIf "setup test" (testSkipSetupTests env)
+  m
 
 cabalTest :: TestM () -> IO ()
 cabalTest = cabalTest' ""
 
 cabalTest' :: String -> TestM () -> IO ()
 cabalTest' mode m = runTestM mode $ do
-    skipUnless "no cabal-install" =<< isAvailableProgram cabalProgram
-    withReaderT (\nenv -> nenv { testCabalInstallAsSetup = True }) m
+  skipUnless "no cabal-install" =<< isAvailableProgram cabalProgram
+  withReaderT (\nenv -> nenv{testCabalInstallAsSetup = True}) m
 
 type TestM = ReaderT TestEnv IO
 
@@ -301,10 +337,11 @@ hackageRepoToolProgram :: Program
 hackageRepoToolProgram = simpleProgram "hackage-repo-tool"
 
 cabalProgram :: Program
-cabalProgram = (simpleProgram "cabal") {
-        -- Do NOT search for executable named cabal, it's probably
-        -- not the one you were intending to test
-        programFindLocation = \_ _ -> return Nothing
+cabalProgram =
+  (simpleProgram "cabal")
+    { -- Do NOT search for executable named cabal, it's probably
+      -- not the one you were intending to test
+      programFindLocation = \_ _ -> return Nothing
     }
 
 diffProgram :: Program
@@ -316,197 +353,209 @@ python3Program = simpleProgram "python3"
 -- | Run a test in the test monad according to program's arguments.
 runTestM :: String -> TestM () -> IO ()
 runTestM mode m =
-    execParser (info testArgParser Data.Monoid.mempty) >>= \args ->
-    withTestDir' verbosity (defaultTempFileOptions { optKeepTempFiles = argKeepTmpFiles (testCommonArgs args) })
-                               "cabal-testsuite" $ \tmp_dir -> do
-    let dist_dir = testArgDistDir args
-        (script_dir0, script_filename) = splitFileName (testArgScriptPath args)
+  execParser (info testArgParser Data.Monoid.mempty) >>= \args ->
+    withTestDir'
+      verbosity
+      (defaultTempFileOptions{optKeepTempFiles = argKeepTmpFiles (testCommonArgs args)})
+      "cabal-testsuite"
+      $ \tmp_dir -> do
+        let dist_dir = testArgDistDir args
+            (script_dir0, script_filename) = splitFileName (testArgScriptPath args)
 
-        stripped = stripExtension ".test.hs" script_filename
-               <|> stripExtension ".multitest.hs" script_filename
-        script_base = fromMaybe (dropExtensions script_filename) stripped
+            stripped =
+              stripExtension ".test.hs" script_filename
+                <|> stripExtension ".multitest.hs" script_filename
+            script_base = fromMaybe (dropExtensions script_filename) stripped
 
-    -- Canonicalize this so that it is stable across working directory changes
-    script_dir <- canonicalizePath script_dir0
-    senv <- mkScriptEnv verbosity
-    -- Add test suite specific programs
-    let program_db0 =
-            addKnownPrograms
+        -- Canonicalize this so that it is stable across working directory changes
+        script_dir <- canonicalizePath script_dir0
+        senv <- mkScriptEnv verbosity
+        -- Add test suite specific programs
+        let program_db0 =
+              addKnownPrograms
                 ([gitProgram, hackageRepoToolProgram, cabalProgram, diffProgram, python3Program] ++ builtinPrograms)
                 (runnerProgramDb senv)
-    -- Reconfigure according to user flags
-    let cargs = testCommonArgs args
+        -- Reconfigure according to user flags
+        let cargs = testCommonArgs args
 
-    -- Reconfigure GHC
-    (comp, platform, program_db2) <- case argGhcPath cargs of
-        Nothing -> return (runnerCompiler senv, runnerPlatform senv, program_db0)
-        Just ghc_path -> do
+        -- Reconfigure GHC
+        (comp, platform, program_db2) <- case argGhcPath cargs of
+          Nothing -> return (runnerCompiler senv, runnerPlatform senv, program_db0)
+          Just ghc_path -> do
             -- All the things that get updated paths from
             -- configCompilerEx.  The point is to make sure
             -- we reconfigure these when we need them.
-            let program_db1 = unconfigureProgram "ghc"
-                            . unconfigureProgram "ghc-pkg"
-                            . unconfigureProgram "hsc2hs"
-                            . unconfigureProgram "haddock"
-                            . unconfigureProgram "hpc"
-                            . unconfigureProgram "runghc"
-                            . unconfigureProgram "gcc"
-                            . unconfigureProgram "ld"
-                            . unconfigureProgram "ar"
-                            . unconfigureProgram "strip"
-                            $ program_db0
+            let program_db1 =
+                  unconfigureProgram "ghc"
+                    . unconfigureProgram "ghc-pkg"
+                    . unconfigureProgram "hsc2hs"
+                    . unconfigureProgram "haddock"
+                    . unconfigureProgram "hpc"
+                    . unconfigureProgram "runghc"
+                    . unconfigureProgram "gcc"
+                    . unconfigureProgram "ld"
+                    . unconfigureProgram "ar"
+                    . unconfigureProgram "strip"
+                    $ program_db0
             -- TODO: this actually leaves a pile of things unconfigured.
             -- Optimal strategy for us is to lazily configure them, so
             -- we don't pay for things we don't need.  A bit difficult
             -- to do in the current design.
             configCompilerEx
-                (Just (compilerFlavor (runnerCompiler senv)))
-                (Just ghc_path)
-                Nothing
-                program_db1
-                verbosity
+              (Just (compilerFlavor (runnerCompiler senv)))
+              (Just ghc_path)
+              Nothing
+              program_db1
+              verbosity
 
-    (configuredGhcProg, _) <- requireProgram verbosity ghcProgram program_db2
+        (configuredGhcProg, _) <- requireProgram verbosity ghcProgram program_db2
 
-    program_db3 <-
-        reconfigurePrograms verbosity
-            ([("cabal", p)   | p <- maybeToList (argCabalInstallPath cargs)] ++
-             [("hackage-repo-tool", p)
-                             | p <- maybeToList (argHackageRepoToolPath cargs)] ++
-             [("haddock", p) | p <- maybeToList (argHaddockPath cargs)])
+        program_db3 <-
+          reconfigurePrograms
+            verbosity
+            ( [("cabal", p) | p <- maybeToList (argCabalInstallPath cargs)]
+                ++ [ ("hackage-repo-tool", p)
+                   | p <- maybeToList (argHackageRepoToolPath cargs)
+                   ]
+                ++ [("haddock", p) | p <- maybeToList (argHaddockPath cargs)]
+            )
             [] -- --prog-options not supported ATM
             program_db2
-    -- configCompilerEx only marks some programs as known, so to pick
-    -- them up we must configure them
-    program_db <- configureAllKnownPrograms verbosity program_db3
+        -- configCompilerEx only marks some programs as known, so to pick
+        -- them up we must configure them
+        program_db <- configureAllKnownPrograms verbosity program_db3
 
-    let db_stack = [GlobalPackageDB]
-        env = TestEnv {
-                    testSourceDir = script_dir,
-                    testTmpDir = tmp_dir,
-                    testSubName = script_base,
-                    testMode = mode,
-                    testProgramDb = program_db,
-                    testPlatform = platform,
-                    testCompiler = comp,
-                    testCompilerPath = programPath configuredGhcProg,
-                    testPackageDBStack = db_stack,
-                    testVerbosity = verbosity,
-                    testMtimeChangeDelay = Nothing,
-                    testScriptEnv = senv,
-                    testSetupPath = dist_dir </> "build" </> "setup" </> "setup",
-                    testPackageDbPath = case testArgPackageDb args of [] -> Nothing; xs -> Just xs,
-                    testSkipSetupTests =  argSkipSetupTests (testCommonArgs args),
-                    testHaveCabalShared = runnerWithSharedLib senv,
-                    testEnvironment =
-                        -- Use UTF-8 output on all platforms.
-                        [ ("LC_ALL", Just "en_US.UTF-8")
-                        -- Hermetic builds (knot-tied)
-                        , ("HOME", Just (testHomeDir env))
-                        -- Set CABAL_DIR in addition to HOME, since HOME has no
-                        -- effect on Windows.
-                        , ("CABAL_DIR", Just (testCabalDir env))
-                        , ("CABAL_CONFIG", Just (testUserCabalConfigFile env))
-                        -- Set `TMPDIR` so that temporary files aren't created in the global `TMPDIR`.
-                        , ("TMPDIR", Just (testSystemTmpDir env))
-                        -- Windows uses `TMP` for the `TMPDIR`.
-                        , ("TMP", Just (testSystemTmpDir env))
-                        ],
-                    testShouldFail = False,
-                    testRelativeCurrentDir = ".",
-                    testHavePackageDb = False,
-                    testHaveRepo = False,
-                    testCabalInstallAsSetup = False,
-                    testCabalProjectFile = Nothing,
-                    testPlan = Nothing,
-                    testRecordDefaultMode = DoNotRecord,
-                    testRecordUserMode = Nothing,
-                    testMaybeStoreDir = Nothing
+        let db_stack = [GlobalPackageDB]
+            env =
+              TestEnv
+                { testSourceDir = script_dir
+                , testTmpDir = tmp_dir
+                , testSubName = script_base
+                , testMode = mode
+                , testProgramDb = program_db
+                , testPlatform = platform
+                , testCompiler = comp
+                , testCompilerPath = programPath configuredGhcProg
+                , testPackageDBStack = db_stack
+                , testVerbosity = verbosity
+                , testMtimeChangeDelay = Nothing
+                , testScriptEnv = senv
+                , testSetupPath = dist_dir </> "build" </> "setup" </> "setup"
+                , testPackageDbPath = case testArgPackageDb args of [] -> Nothing; xs -> Just xs
+                , testSkipSetupTests = argSkipSetupTests (testCommonArgs args)
+                , testHaveCabalShared = runnerWithSharedLib senv
+                , testEnvironment =
+                    -- Use UTF-8 output on all platforms.
+                    [ ("LC_ALL", Just "en_US.UTF-8")
+                    , -- Hermetic builds (knot-tied)
+                      ("HOME", Just (testHomeDir env))
+                    , -- Set CABAL_DIR in addition to HOME, since HOME has no
+                      -- effect on Windows.
+                      ("CABAL_DIR", Just (testCabalDir env))
+                    , ("CABAL_CONFIG", Just (testUserCabalConfigFile env))
+                    , -- Set `TMPDIR` so that temporary files aren't created in the global `TMPDIR`.
+                      ("TMPDIR", Just (testSystemTmpDir env))
+                    , -- Windows uses `TMP` for the `TMPDIR`.
+                      ("TMP", Just (testSystemTmpDir env))
+                    ]
+                , testShouldFail = False
+                , testRelativeCurrentDir = "."
+                , testHavePackageDb = False
+                , testHaveRepo = False
+                , testCabalInstallAsSetup = False
+                , testCabalProjectFile = Nothing
+                , testPlan = Nothing
+                , testRecordDefaultMode = DoNotRecord
+                , testRecordUserMode = Nothing
+                , testMaybeStoreDir = Nothing
                 }
-    runReaderT cleanup env
-    join $ E.catch (runReaderT
-                (do
+        runReaderT cleanup env
+        join $
+          E.catch
+            ( runReaderT
+                ( do
                     withSourceCopy m
                     check_expect (argAccept (testCommonArgs args)) Nothing
                 )
                 env
-        )
-        (\(e :: TestCode) -> do
-            -- A test that resulted in unexpected success should check its output
-            -- because maybe it is the output the one that makes it fail!
-            case isTestCodeUnexpectedSuccess e of
-                Just t  -> runReaderT (check_expect (argAccept (testCommonArgs args)) (Just (t, False))) env
-                Nothing ->
+            )
+            ( \(e :: TestCode) -> do
+                -- A test that resulted in unexpected success should check its output
+                -- because maybe it is the output the one that makes it fail!
+                case isTestCodeUnexpectedSuccess e of
+                  Just t -> runReaderT (check_expect (argAccept (testCommonArgs args)) (Just (t, False))) env
+                  Nothing ->
                     -- A test that is reported flaky but passed might fail because of the output
                     case isTestCodeFlaky e of
-                        Flaky True t  -> runReaderT (check_expect (argAccept (testCommonArgs args)) (Just (t, True))) env
-                        _             -> E.throwIO e
-        )
-
+                      Flaky True t -> runReaderT (check_expect (argAccept (testCommonArgs args)) (Just (t, True))) env
+                      _ -> E.throwIO e
+            )
   where
     verbosity = normal -- TODO: configurable
-
     cleanup = do
-        env <- getTestEnv
-        onlyIfExists . removeDirectoryRecursiveHack verbosity $ testWorkDir env
-        -- NB: it's important to initialize this ourselves, as
-        -- the default configuration hardcodes Hackage, which we do
-        -- NOT want to assume for these tests (no test should
-        -- hit Hackage.)
-        liftIO $ createDirectoryIfMissing True (testCabalDir env)
-        ghc_path <- programPathM ghcProgram
-        liftIO $ writeFile (testUserCabalConfigFile env)
-               $ unlines [ "with-compiler: " ++ ghc_path ]
+      env <- getTestEnv
+      onlyIfExists . removeDirectoryRecursiveHack verbosity $ testWorkDir env
+      -- NB: it's important to initialize this ourselves, as
+      -- the default configuration hardcodes Hackage, which we do
+      -- NOT want to assume for these tests (no test should
+      -- hit Hackage.)
+      liftIO $ createDirectoryIfMissing True (testCabalDir env)
+      ghc_path <- programPathM ghcProgram
+      liftIO $
+        writeFile (testUserCabalConfigFile env) $
+          unlines ["with-compiler: " ++ ghc_path]
 
     check_expect accept was_expected_to_fail = do
-        env <- getTestEnv
-        actual_raw <- liftIO $ readFileOrEmpty (testActualFile env)
-        expect <- liftIO $ readFileOrEmpty (testExpectFile env)
-        norm_env <- mkNormalizerEnv
-        let actual = normalizeOutput norm_env actual_raw
-        case (was_expected_to_fail, words actual /= words expect) of
-         -- normal test, output doesn't match
-         (Nothing, True) -> do
-            -- First try whitespace insensitive diff
-            let actual_fp = testNormalizedActualFile env
-                expect_fp = testNormalizedExpectFile env
-            liftIO $ writeFile actual_fp actual
-            liftIO $ writeFile expect_fp expect
-            liftIO $ putStrLn "Actual output differs from expected:"
-            b <- diff ["-uw"] expect_fp actual_fp
-            unless b . void $ diff ["-u"] expect_fp actual_fp
-            if accept
-                then do liftIO $ putStrLn $ "Writing actual test output to " <> testExpectAcceptFile env
-                        liftIO $ writeFileNoCR (testExpectAcceptFile env) actual
-                        pure (pure ())
-                else pure (E.throwIO TestCodeFail)
-         -- normal test, output matches
-         (Nothing, False) -> pure (pure ())
-         -- expected fail, output matches
-         (Just (t, was_flaky), False) -> pure (E.throwIO $ if was_flaky then TestCodeFlakyPassed t else TestCodeUnexpectedOk t)
-         -- expected fail, output doesn't match
-         (Just (t, was_flaky), True) -> do
-            -- First try whitespace insensitive diff
-            let actual_fp = testNormalizedActualFile env
-                expect_fp = testNormalizedExpectFile env
-            liftIO $ writeFile actual_fp actual
-            liftIO $ writeFile expect_fp expect
-            liftIO $ putStrLn "Actual output differs from expected:"
-            b <- diff ["-uw"] expect_fp actual_fp
-            unless b . void $ diff ["-u"] expect_fp actual_fp
-            pure (E.throwIO $ if was_flaky then TestCodeFlakyFailed t else TestCodeKnownFail t)
+      env <- getTestEnv
+      actual_raw <- liftIO $ readFileOrEmpty (testActualFile env)
+      expect <- liftIO $ readFileOrEmpty (testExpectFile env)
+      norm_env <- mkNormalizerEnv
+      let actual = normalizeOutput norm_env actual_raw
+      case (was_expected_to_fail, words actual /= words expect) of
+        -- normal test, output doesn't match
+        (Nothing, True) -> do
+          -- First try whitespace insensitive diff
+          let actual_fp = testNormalizedActualFile env
+              expect_fp = testNormalizedExpectFile env
+          liftIO $ writeFile actual_fp actual
+          liftIO $ writeFile expect_fp expect
+          liftIO $ putStrLn "Actual output differs from expected:"
+          b <- diff ["-uw"] expect_fp actual_fp
+          unless b . void $ diff ["-u"] expect_fp actual_fp
+          if accept
+            then do
+              liftIO $ putStrLn $ "Writing actual test output to " <> testExpectAcceptFile env
+              liftIO $ writeFileNoCR (testExpectAcceptFile env) actual
+              pure (pure ())
+            else pure (E.throwIO TestCodeFail)
+        -- normal test, output matches
+        (Nothing, False) -> pure (pure ())
+        -- expected fail, output matches
+        (Just (t, was_flaky), False) -> pure (E.throwIO $ if was_flaky then TestCodeFlakyPassed t else TestCodeUnexpectedOk t)
+        -- expected fail, output doesn't match
+        (Just (t, was_flaky), True) -> do
+          -- First try whitespace insensitive diff
+          let actual_fp = testNormalizedActualFile env
+              expect_fp = testNormalizedExpectFile env
+          liftIO $ writeFile actual_fp actual
+          liftIO $ writeFile expect_fp expect
+          liftIO $ putStrLn "Actual output differs from expected:"
+          b <- diff ["-uw"] expect_fp actual_fp
+          unless b . void $ diff ["-u"] expect_fp actual_fp
+          pure (E.throwIO $ if was_flaky then TestCodeFlakyFailed t else TestCodeKnownFail t)
 
 readFileOrEmpty :: FilePath -> IO String
-readFileOrEmpty f = readFile f `E.catch` \e ->
-                                    if isDoesNotExistError e
-                                        then return ""
-                                        else E.throwIO e
+readFileOrEmpty f =
+  readFile f `E.catch` \e ->
+    if isDoesNotExistError e
+      then return ""
+      else E.throwIO e
 
 -- | Run an IO action, and suppress a "does not exist" error.
 onlyIfExists :: MonadIO m => IO () -> m ()
 onlyIfExists m =
-    liftIO $ E.catch m $ \(e :: IOError) ->
-        unless (isDoesNotExistError e) $ E.throwIO e
+  liftIO $ E.catch m $ \(e :: IOError) ->
+    unless (isDoesNotExistError e) $ E.throwIO e
 
 -- | Make a hermetic copy of the test directory.
 --
@@ -515,300 +564,330 @@ onlyIfExists m =
 -- hermetic copy.
 withSourceCopy :: TestM a -> TestM a
 withSourceCopy m = do
-    env <- getTestEnv
-    initWorkDir
-    let curdir  = testSourceDir env
-        dest = testSourceCopyDir env
-    fs <- getSourceFiles
-    when (null fs)
-      (error (unlines [ "withSourceCopy: No files to copy from " ++ curdir
-                      , "You need to \"git add\" any files before they are copied by the testsuite."]))
-    forM_ fs $ \f -> do
-        unless (isTestFile f) $ liftIO $ do
-            putStrLn ("Copying " ++ (curdir </> f) ++ " to " ++ (dest </> f))
-            createDirectoryIfMissing True (takeDirectory (dest </> f))
-            d <- liftIO $ doesDirectoryExist (curdir </> f)
-            if d
-              then
-                copyDirectoryRecursive normal (curdir </> f) (dest </> f)
-              else
-                copyFile (curdir </> f) (dest </> f)
-    m
-
+  env <- getTestEnv
+  initWorkDir
+  let curdir = testSourceDir env
+      dest = testSourceCopyDir env
+  fs <- getSourceFiles
+  when
+    (null fs)
+    ( error
+        ( unlines
+            [ "withSourceCopy: No files to copy from " ++ curdir
+            , "You need to \"git add\" any files before they are copied by the testsuite."
+            ]
+        )
+    )
+  forM_ fs $ \f -> do
+    unless (isTestFile f) $ liftIO $ do
+      putStrLn ("Copying " ++ (curdir </> f) ++ " to " ++ (dest </> f))
+      createDirectoryIfMissing True (takeDirectory (dest </> f))
+      d <- liftIO $ doesDirectoryExist (curdir </> f)
+      if d
+        then copyDirectoryRecursive normal (curdir </> f) (dest </> f)
+        else copyFile (curdir </> f) (dest </> f)
+  m
 
 -- NB: Keep this synchronized with partitionTests
 isTestFile :: FilePath -> Bool
 isTestFile f =
-    case takeExtensions f of
-        ".test.hs"      -> True
-        ".multitest.hs" -> True
-        _               -> False
-
+  case takeExtensions f of
+    ".test.hs" -> True
+    ".multitest.hs" -> True
+    _ -> False
 
 initWorkDir :: TestM ()
 initWorkDir = do
-    env <- getTestEnv
-    liftIO $ createDirectoryIfMissing True (testWorkDir env)
-    liftIO $ createDirectoryIfMissing True (testSystemTmpDir env)
-
-
+  env <- getTestEnv
+  liftIO $ createDirectoryIfMissing True (testWorkDir env)
+  liftIO $ createDirectoryIfMissing True (testSystemTmpDir env)
 
 getSourceFiles :: TestM [FilePath]
 getSourceFiles = do
-    env <- getTestEnv
-    configured_prog <- requireProgramM gitProgram
-    r <- liftIO $ run (testVerbosity env)
-                 (Just $ testSourceDir env)
-                 (testEnvironment env)
-                 (programPath configured_prog)
-                 ["ls-files", "--cached", "--modified"]
-                 Nothing
-    recordLog r
-    _ <- requireSuccess r
-    return (lines $ resultOutput r)
+  env <- getTestEnv
+  configured_prog <- requireProgramM gitProgram
+  r <-
+    liftIO $
+      run
+        (testVerbosity env)
+        (Just $ testSourceDir env)
+        (testEnvironment env)
+        (programPath configured_prog)
+        ["ls-files", "--cached", "--modified"]
+        Nothing
+  recordLog r
+  _ <- requireSuccess r
+  return (lines $ resultOutput r)
 
 recordLog :: Result -> TestM ()
 recordLog res = do
-    env <- getTestEnv
-    let mode = testRecordMode env
-    initWorkDir
-    liftIO $ C.appendFile (testWorkDir env </> "test.log")
-                         (C.pack $ "+ " ++ resultCommand res ++ "\n"
-                            ++ resultOutput res ++ "\n\n")
-    liftIO . C.appendFile (testActualFile env) . C.pack $
-        case mode of
-            RecordAll    -> unlines (lines (resultOutput res))
-            RecordMarked -> getMarkedOutput (resultOutput res)
-            DoNotRecord  -> ""
+  env <- getTestEnv
+  let mode = testRecordMode env
+  initWorkDir
+  liftIO $
+    C.appendFile
+      (testWorkDir env </> "test.log")
+      ( C.pack $
+          "+ "
+            ++ resultCommand res
+            ++ "\n"
+            ++ resultOutput res
+            ++ "\n\n"
+      )
+  liftIO . C.appendFile (testActualFile env) . C.pack $
+    case mode of
+      RecordAll -> unlines (lines (resultOutput res))
+      RecordMarked -> getMarkedOutput (resultOutput res)
+      DoNotRecord -> ""
 
 ------------------------------------------------------------------------
+
 -- * Subprocess run results
 
 requireSuccess :: Result -> TestM Result
-requireSuccess r@Result { resultCommand = cmd
-                        , resultExitCode = exitCode
-                        , resultOutput = output } = withFrozenCallStack $ do
+requireSuccess
+  r@Result
+    { resultCommand = cmd
+    , resultExitCode = exitCode
+    , resultOutput = output
+    } = withFrozenCallStack $ do
     env <- getTestEnv
     when (exitCode /= ExitSuccess && not (testShouldFail env)) $
-        assertFailure $ "Command " ++ cmd ++ " failed.\n" ++
-        "Output:\n" ++ output ++ "\n"
+      assertFailure $
+        "Command "
+          ++ cmd
+          ++ " failed.\n"
+          ++ "Output:\n"
+          ++ output
+          ++ "\n"
     when (exitCode == ExitSuccess && testShouldFail env) $
-        assertFailure $ "Command " ++ cmd ++ " succeeded.\n" ++
-        "Output:\n" ++ output ++ "\n"
+      assertFailure $
+        "Command "
+          ++ cmd
+          ++ " succeeded.\n"
+          ++ "Output:\n"
+          ++ output
+          ++ "\n"
     return r
 
 assertFailure :: String -> m ()
 assertFailure msg = withFrozenCallStack $ error msg
 
-
-
 -- | Runs 'diff' with some arguments on two files, outputting the
 -- diff to stderr, and returning true if the two files differ
 diff :: [String] -> FilePath -> FilePath -> TestM Bool
 diff args path1 path2 = do
-    diff_path <- programPathM diffProgram
-    (_,_,_,h) <- liftIO $
-        createProcess (proc diff_path (args ++ [path1, path2])) {
-                std_out = UseHandle stderr
-            }
-    r <- liftIO $ waitForProcess h
-    return (r /= ExitSuccess)
+  diff_path <- programPathM diffProgram
+  (_, _, _, h) <-
+    liftIO $
+      createProcess
+        (proc diff_path (args ++ [path1, path2]))
+          { std_out = UseHandle stderr
+          }
+  r <- liftIO $ waitForProcess h
+  return (r /= ExitSuccess)
 
 -- | Write a file with no CRs, always.
 writeFileNoCR :: FilePath -> String -> IO ()
 writeFileNoCR f s =
-    withFile f WriteMode $ \h -> do
-        hSetNewlineMode h noNewlineTranslation
-        hPutStr h s
+  withFile f WriteMode $ \h -> do
+    hSetNewlineMode h noNewlineTranslation
+    hPutStr h s
 
 mkNormalizerEnv :: TestM NormalizerEnv
 mkNormalizerEnv = do
-    env <- getTestEnv
-    ghc_pkg_program <- requireProgramM ghcPkgProgram
-    -- Arguably we should use Cabal's APIs but I am too lazy
-    -- to remember what it is
-    list_out <- liftIO $ readProcess (programPath ghc_pkg_program)
-                      ["list", "--global", "--simple-output"] ""
-    tmpDir <- liftIO $ getTemporaryDirectory
+  env <- getTestEnv
+  ghc_pkg_program <- requireProgramM ghcPkgProgram
+  -- Arguably we should use Cabal's APIs but I am too lazy
+  -- to remember what it is
+  list_out <-
+    liftIO $
+      readProcess
+        (programPath ghc_pkg_program)
+        ["list", "--global", "--simple-output"]
+        ""
+  tmpDir <- liftIO $ getTemporaryDirectory
 
-    canonicalizedTestTmpDir <- liftIO $ canonicalizePath (testTmpDir env)
-    canonicalizedGblDir <- liftIO $ canonicalizePath tmpDir
+  canonicalizedTestTmpDir <- liftIO $ canonicalizePath (testTmpDir env)
+  canonicalizedGblDir <- liftIO $ canonicalizePath tmpDir
 
-    -- 'cabal' is configured in the package-db, but doesn't specify how to find the program version
-    -- Thus we find the program location, if it exists, and query for the program version for
-    -- output normalisation.
-    cabalVersionM <- do
-        cabalProgM <- needProgramM "cabal"
-        case cabalProgM of
-            Nothing -> pure Nothing
-            Just cabalProg -> do
-                liftIO (findProgramVersion "--numeric-version" id (testVerbosity env) (programPath cabalProg))
+  -- 'cabal' is configured in the package-db, but doesn't specify how to find the program version
+  -- Thus we find the program location, if it exists, and query for the program version for
+  -- output normalisation.
+  cabalVersionM <- do
+    cabalProgM <- needProgramM "cabal"
+    case cabalProgM of
+      Nothing -> pure Nothing
+      Just cabalProg -> do
+        liftIO (findProgramVersion "--numeric-version" id (testVerbosity env) (programPath cabalProg))
 
-    return NormalizerEnv {
-        normalizerTmpDir
-            = (if buildOS == Windows
+  return
+    NormalizerEnv
+      { normalizerTmpDir =
+          ( if buildOS == Windows
               then joinDrive "\\" . dropDrive
-              else id)
-                $ addTrailingPathSeparator (testTmpDir env),
-        normalizerCanonicalTmpDir
-            = (if buildOS == Windows
+              else id
+          )
+            $ addTrailingPathSeparator (testTmpDir env)
+      , normalizerCanonicalTmpDir =
+          ( if buildOS == Windows
               then joinDrive "\\" . dropDrive
-              else id)
-                $ addTrailingPathSeparator canonicalizedTestTmpDir,
-        normalizerGblTmpDir
-            = (if buildOS == Windows
+              else id
+          )
+            $ addTrailingPathSeparator canonicalizedTestTmpDir
+      , normalizerGblTmpDir =
+          ( if buildOS == Windows
               then joinDrive "\\" . dropDrive
-              else id)
-                $ addTrailingPathSeparator tmpDir,
-        normalizerCanonicalGblTmpDir
-            = (if buildOS == Windows
+              else id
+          )
+            $ addTrailingPathSeparator tmpDir
+      , normalizerCanonicalGblTmpDir =
+          ( if buildOS == Windows
               then joinDrive "\\" . dropDrive
-              else id)
-                $ addTrailingPathSeparator canonicalizedGblDir,
-        normalizerGhcVersion
-            = compilerVersion (testCompiler env),
-        normalizerGhcPath
-            = testCompilerPath env,
-        normalizerKnownPackages
-            = mapMaybe simpleParse (words list_out),
-        normalizerPlatform
-            = testPlatform env,
-        normalizerCabalVersion
-            = cabalVersionLibrary,
-        normalizerCabalInstallVersion
-            = cabalVersionM
-    }
+              else id
+          )
+            $ addTrailingPathSeparator canonicalizedGblDir
+      , normalizerGhcVersion =
+          compilerVersion (testCompiler env)
+      , normalizerGhcPath =
+          testCompilerPath env
+      , normalizerKnownPackages =
+          mapMaybe simpleParse (words list_out)
+      , normalizerPlatform =
+          testPlatform env
+      , normalizerCabalVersion =
+          cabalVersionLibrary
+      , normalizerCabalInstallVersion =
+          cabalVersionM
+      }
 
 cabalVersionLibrary :: Version
 cabalVersionLibrary = U.cabalVersion
 
 requireProgramM :: Program -> TestM ConfiguredProgram
 requireProgramM program = do
-    env <- getTestEnv
-    (configured_program, _) <- liftIO $
-        requireProgram (testVerbosity env) program (testProgramDb env)
-    return configured_program
+  env <- getTestEnv
+  (configured_program, _) <-
+    liftIO $
+      requireProgram (testVerbosity env) program (testProgramDb env)
+  return configured_program
 
 needProgramM :: String -> TestM (Maybe ConfiguredProgram)
 needProgramM program = do
-    env <- getTestEnv
-    return $ lookupProgramByName program (testProgramDb env)
+  env <- getTestEnv
+  return $ lookupProgramByName program (testProgramDb env)
 
 programPathM :: Program -> TestM FilePath
 programPathM program = do
-    fmap programPath (requireProgramM program)
+  fmap programPath (requireProgramM program)
 
 isAvailableProgram :: Program -> TestM Bool
 isAvailableProgram program = do
-    env <- getTestEnv
-    case lookupProgram program (testProgramDb env) of
+  env <- getTestEnv
+  case lookupProgram program (testProgramDb env) of
+    Just _ -> return True
+    Nothing -> do
+      -- It might not have been configured. Try to configure.
+      progdb <- liftIO $ configureProgram (testVerbosity env) program (testProgramDb env)
+      case lookupProgram program progdb of
         Just _ -> return True
-        Nothing -> do
-            -- It might not have been configured. Try to configure.
-            progdb <- liftIO $ configureProgram (testVerbosity env) program (testProgramDb env)
-            case lookupProgram program progdb of
-                Just _  -> return True
-                Nothing -> return False
-
+        Nothing -> return False
 
 getMarkedOutput :: String -> String -- trailing newline
 getMarkedOutput out = unlines (go (lines out) False)
   where
     go [] _ = []
-    go (x:xs) True
-        | "-----END CABAL OUTPUT-----"   `isPrefixOf` x
-                    =     go xs False
-        | otherwise = x : go xs True
-    go (x:xs) False
-        -- NB: Windows has extra goo at the end
-        | "-----BEGIN CABAL OUTPUT-----" `isPrefixOf` x
-                    = go xs True
-        | otherwise = go xs False
-
+    go (x : xs) True
+      | "-----END CABAL OUTPUT-----" `isPrefixOf` x =
+          go xs False
+      | otherwise = x : go xs True
+    go (x : xs) False
+      -- NB: Windows has extra goo at the end
+      | "-----BEGIN CABAL OUTPUT-----" `isPrefixOf` x =
+          go xs True
+      | otherwise = go xs False
 
 data TestEnv = TestEnv
-    -- UNCHANGING:
+  -- UNCHANGING:
 
-    {
-    -- | Path to the test directory, as specified by path to test
-    -- script.
-      testSourceDir     :: FilePath
-    -- | Somewhere to stow temporary files needed by the test.
-    , testTmpDir        :: FilePath
+  { testSourceDir :: FilePath
+  -- ^ Path to the test directory, as specified by path to test
+  -- script.
+  , testTmpDir :: FilePath
+  -- ^ Somewhere to stow temporary files needed by the test.
+  , testSubName :: String
+  -- ^ Test sub-name, used to qualify dist/database directory to avoid
+  -- conflicts.
+  , testMode :: String
+  -- ^ Test mode, further qualifies multiple invocations of the
+  -- same test source code.
+  , testProgramDb :: ProgramDb
+  -- ^ Program database to use when we want ghc, ghc-pkg, etc.
+  , testCompiler :: Compiler
+  -- ^ Compiler we are running tests for
+  , testCompilerPath :: FilePath
+  , testPlatform :: Platform
+  -- ^ Platform we are running tests on
+  , testPackageDBStack :: PackageDBStackCWD
+  -- ^ Package database stack (actually this changes lol)
+  , testVerbosity :: Verbosity
+  -- ^ How verbose to be
+  , testMtimeChangeDelay :: Maybe Int
+  -- ^ How long we should 'threadDelay' to make sure the file timestamp is
+  -- updated correctly for recompilation tests.  Nothing if we haven't
+  -- calibrated yet.
+  , testScriptEnv :: ScriptEnv
+  -- ^ Script environment for runghc
+  , testSetupPath :: FilePath
+  -- ^ Setup script path
+  , testPackageDbPath :: Maybe [FilePath]
+  -- ^ Setup package-db path which contains Cabal and Cabal-syntax for cabal-install to
+  -- use when compiling custom setups, plus the store with possible dependencies of those setup packages.
+  , testSkipSetupTests :: Bool
+  -- ^ Skip Setup tests?
+  , testHaveCabalShared :: Bool
+  -- ^ Do we have shared libraries for the Cabal-under-tests?
+  -- This is used for example to determine whether we can build
+  -- detailed-0.9 tests dynamically, since they link against Cabal-under-test.
+  , -- CHANGING:
 
-    -- | Test sub-name, used to qualify dist/database directory to avoid
-    -- conflicts.
-    , testSubName       :: String
-    -- | Test mode, further qualifies multiple invocations of the
-    -- same test source code.
-    , testMode          :: String
-    -- | Program database to use when we want ghc, ghc-pkg, etc.
-    , testProgramDb     :: ProgramDb
-    -- | Compiler we are running tests for
-    , testCompiler      :: Compiler
-    , testCompilerPath  :: FilePath
-    -- | Platform we are running tests on
-    , testPlatform      :: Platform
-    -- | Package database stack (actually this changes lol)
-    , testPackageDBStack :: PackageDBStackCWD
-    -- | How verbose to be
-    , testVerbosity     :: Verbosity
-    -- | How long we should 'threadDelay' to make sure the file timestamp is
-    -- updated correctly for recompilation tests.  Nothing if we haven't
-    -- calibrated yet.
-    , testMtimeChangeDelay :: Maybe Int
-    -- | Script environment for runghc
-    , testScriptEnv :: ScriptEnv
-    -- | Setup script path
-    , testSetupPath :: FilePath
-    -- | Setup package-db path which contains Cabal and Cabal-syntax for cabal-install to
-    -- use when compiling custom setups, plus the store with possible dependencies of those setup packages.
-    , testPackageDbPath :: Maybe [FilePath]
-    -- | Skip Setup tests?
-    , testSkipSetupTests :: Bool
-    -- | Do we have shared libraries for the Cabal-under-tests?
-    -- This is used for example to determine whether we can build
-    -- detailed-0.9 tests dynamically, since they link against Cabal-under-test.
-    , testHaveCabalShared :: Bool
-
-    -- CHANGING:
-
-    -- | Environment override
-    , testEnvironment   :: [(String, Maybe String)]
-    -- | When true, we invert the meaning of command execution failure
-    , testShouldFail    :: Bool
-    -- | The current working directory, relative to 'testSourceDir'
-    , testRelativeCurrentDir :: FilePath
-    -- | Says if we've initialized the per-test package DB
-    , testHavePackageDb  :: Bool
-    -- | Says if we've setup a repository
-    , testHaveRepo :: Bool
-    -- | Says if we're testing cabal-install as setup
-    , testCabalInstallAsSetup :: Bool
-    -- | Says what cabal.project file to use (probed)
-    , testCabalProjectFile :: Maybe FilePath
-    -- | Cached record of the plan metadata from a new-build
-    -- invocation; controlled by 'withPlan'.
-    , testPlan :: Maybe Plan
-    -- | If user mode is not set, this is the record mode we default to.
-    , testRecordDefaultMode :: RecordMode
-    -- | User explicitly set record mode.  Not implemented ATM.
-    , testRecordUserMode :: Maybe RecordMode
-    -- | Path to the storedir used by the test, if not the default
-    , testMaybeStoreDir      :: Maybe FilePath
-    }
-    deriving Show
+    testEnvironment :: [(String, Maybe String)]
+  -- ^ Environment override
+  , testShouldFail :: Bool
+  -- ^ When true, we invert the meaning of command execution failure
+  , testRelativeCurrentDir :: FilePath
+  -- ^ The current working directory, relative to 'testSourceDir'
+  , testHavePackageDb :: Bool
+  -- ^ Says if we've initialized the per-test package DB
+  , testHaveRepo :: Bool
+  -- ^ Says if we've setup a repository
+  , testCabalInstallAsSetup :: Bool
+  -- ^ Says if we're testing cabal-install as setup
+  , testCabalProjectFile :: Maybe FilePath
+  -- ^ Says what cabal.project file to use (probed)
+  , testPlan :: Maybe Plan
+  -- ^ Cached record of the plan metadata from a new-build
+  -- invocation; controlled by 'withPlan'.
+  , testRecordDefaultMode :: RecordMode
+  -- ^ If user mode is not set, this is the record mode we default to.
+  , testRecordUserMode :: Maybe RecordMode
+  -- ^ User explicitly set record mode.  Not implemented ATM.
+  , testMaybeStoreDir :: Maybe FilePath
+  -- ^ Path to the storedir used by the test, if not the default
+  }
+  deriving (Show)
 
 testRecordMode :: TestEnv -> RecordMode
 testRecordMode env = fromMaybe (testRecordDefaultMode env) (testRecordUserMode env)
 
 data RecordMode = DoNotRecord | RecordMarked | RecordAll
-    deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 getTestEnv :: TestM TestEnv
 getTestEnv = ask
 
 ------------------------------------------------------------------------
+
 -- * Directories
 
 -- | The absolute path to the root of the package directory; it's
@@ -878,8 +957,8 @@ testCabalDir env = testHomeDir env </> ".cabal"
 
 testStoreDir :: TestEnv -> FilePath
 testStoreDir env = case testMaybeStoreDir env of
-                      Just dir -> dir
-                      Nothing -> testCabalDir env </> "store"
+  Just dir -> dir
+  Nothing -> testCabalDir env </> "store"
 
 -- | The user cabal config file
 testUserCabalConfigFile :: TestEnv -> FilePath

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -1,115 +1,134 @@
-module Test.Cabal.OutputNormalizer (
-    NormalizerEnv (..),
-    normalizeOutput,
-    ) where
+module Test.Cabal.OutputNormalizer
+  ( NormalizerEnv (..)
+  , normalizeOutput
+  ) where
 
 import Data.Monoid (Endo (..))
 
-import Distribution.Version
-import Distribution.Text
-import Distribution.Pretty
 import Distribution.Package
+import Distribution.Pretty
 import Distribution.System
+import Distribution.Text
+import Distribution.Version
 
+import Data.Array ((!))
 import Text.Regex.Base
 import Text.Regex.TDFA
-import Data.Array ((!))
 
 import qualified Data.Foldable as F
 
 normalizeOutput :: NormalizerEnv -> String -> String
 normalizeOutput nenv =
-    -- Normalize backslashes to forward slashes to normalize
-    -- file paths
-    backslashToSlash
+  -- Normalize backslashes to forward slashes to normalize
+  -- file paths
+  backslashToSlash
     -- Install path frequently has architecture specific elements, so
     -- nub it out
-  . resub "Installing (.+) in .+" "Installing \\1 in <PATH>"
+    . resub "Installing (.+) in .+" "Installing \\1 in <PATH>"
     -- Things that look like libraries
-  . resub "libHS[A-Za-z0-9.-]+\\.(so|dll|a|dynlib)" "<LIBRARY>"
+    . resub "libHS[A-Za-z0-9.-]+\\.(so|dll|a|dynlib)" "<LIBRARY>"
     -- look for PackageHash directories
-  . (if buildOS == Windows
-     then resub "\\\\(([A-Za-z0-9_]+)(-[A-Za-z0-9\\._]+)*)-[0-9a-f]{4,64}\\\\"
-                "\\\\<PACKAGE>-<HASH>\\\\"
-     else id)
-  . resub "/(([A-Za-z0-9_]+)(-[A-Za-z0-9\\._]+)*)-[0-9a-f]{4,64}/"
-          "/<PACKAGE>-<HASH>/"
+    . ( if buildOS == Windows
+          then
+            resub
+              "\\\\(([A-Za-z0-9_]+)(-[A-Za-z0-9\\._]+)*)-[0-9a-f]{4,64}\\\\"
+              "\\\\<PACKAGE>-<HASH>\\\\"
+          else id
+      )
+    . resub
+      "/(([A-Za-z0-9_]+)(-[A-Za-z0-9\\._]+)*)-[0-9a-f]{4,64}/"
+      "/<PACKAGE>-<HASH>/"
     -- This is dumb but I don't feel like pulling in another dep for
     -- string search-replace.  Make sure we do this before backslash
     -- normalization!
-  . resub (posixRegexEscape (normalizerGblTmpDir nenv) ++ "[a-z0-9\\.-]+") "<GBLTMPDIR>"
-  . resub (posixRegexEscape (normalizerCanonicalGblTmpDir nenv) ++ "[a-z0-9\\.-]+") "<GBLTMPDIR>"
+    . resub (posixRegexEscape (normalizerGblTmpDir nenv) ++ "[a-z0-9\\.-]+") "<GBLTMPDIR>"
+    . resub (posixRegexEscape (normalizerCanonicalGblTmpDir nenv) ++ "[a-z0-9\\.-]+") "<GBLTMPDIR>"
     -- Munge away .exe suffix on filenames (Windows)
-  . (if buildOS == Windows then resub "([A-Za-z0-9.-]+)\\.exe" "\\1" else id)
+    . (if buildOS == Windows then resub "([A-Za-z0-9.-]+)\\.exe" "\\1" else id)
     -- tmp/src-[0-9]+ is tmp\src-[0-9]+ in Windows
-  . (if buildOS == Windows then resub (posixRegexEscape "tmp\\src-" ++ "[0-9]+") "<TMPDIR>" else id)
-  . resub (posixRegexEscape "tmp/src-" ++ "[0-9]+") "<TMPDIR>"
-  . resub (posixRegexEscape (normalizerTmpDir nenv) ++ sameDir) "<ROOT>/"
-  . resub (posixRegexEscape (normalizerCanonicalTmpDir nenv) ++ sameDir) "<ROOT>/"
+    . (if buildOS == Windows then resub (posixRegexEscape "tmp\\src-" ++ "[0-9]+") "<TMPDIR>" else id)
+    . resub (posixRegexEscape "tmp/src-" ++ "[0-9]+") "<TMPDIR>"
+    . resub (posixRegexEscape (normalizerTmpDir nenv) ++ sameDir) "<ROOT>/"
+    . resub (posixRegexEscape (normalizerCanonicalTmpDir nenv) ++ sameDir) "<ROOT>/"
     -- Munge away C:\ prefix on filenames (Windows). We convert C:\ to \.
-  . (if buildOS == Windows then resub "([A-Z]):\\\\" "\\\\" else id)
-  . appEndo (F.fold (map (Endo . packageIdRegex) (normalizerKnownPackages nenv)))
+    . (if buildOS == Windows then resub "([A-Z]):\\\\" "\\\\" else id)
+    . appEndo (F.fold (map (Endo . packageIdRegex) (normalizerKnownPackages nenv)))
     -- Look for 0.1/installed-0d6uzW7Ubh1Fb4TB5oeQ3G
     -- These installed packages will vary depending on GHC version
     -- Apply this before packageIdRegex, otherwise this regex doesn't match.
-  . resub "[0-9]+(\\.[0-9]+)*/installed-[A-Za-z0-9.+]+"
-          "<VERSION>/installed-<HASH>"
+    . resub
+      "[0-9]+(\\.[0-9]+)*/installed-[A-Za-z0-9.+]+"
+      "<VERSION>/installed-<HASH>"
     -- incoming directories in the store
-  . (if buildOS == Windows then resub "\\\\incoming\\\\new-[0-9]+"
-                                      "\\\\incoming\\\\new-<RAND>"
-                           else id)
+    . ( if buildOS == Windows
+          then
+            resub
+              "\\\\incoming\\\\new-[0-9]+"
+              "\\\\incoming\\\\new-<RAND>"
+          else id
+      )
     -- incoming directories in the store
-  . resub "/incoming/new-[0-9]+"
-          "/incoming/new-<RAND>"
+    . resub
+      "/incoming/new-[0-9]+"
+      "/incoming/new-<RAND>"
     -- Normalize architecture
-  . resub (posixRegexEscape (display (normalizerPlatform nenv))) "<ARCH>"
+    . resub (posixRegexEscape (display (normalizerPlatform nenv))) "<ARCH>"
     -- Some GHC versions are chattier than others
-  . resub "^ignoring \\(possibly broken\\) abi-depends field for packages" ""
+    . resub "^ignoring \\(possibly broken\\) abi-depends field for packages" ""
     -- Normalize the current GHC version.  Apply this BEFORE packageIdRegex,
     -- which will pick up the install ghc library (which doesn't have the
     -- date glob).
-  . (if normalizerGhcVersion nenv /= nullVersion
-        then resub (posixRegexEscape (display (normalizerGhcVersion nenv))
-                        -- Also glob the date, for nightly GHC builds
-                        ++ "(\\.[0-9]+)?"
-                        -- Also glob the ABI hash, for GHCs which support it
-                        ++ "(-[a-z0-9]+)?")
-                   "<GHCVER>"
-        else id)
-  . normalizeBuildInfoJson
-  . maybe id normalizePathCmdOutput (normalizerCabalInstallVersion nenv)
-  -- hackage-security locks occur non-deterministically
-  . resub "(Released|Acquired|Waiting) .*hackage-security-lock\n" ""
-  . resub "installed: [0-9]+(\\.[0-9]+)*" "installed: <VERSION>"
+    . ( if normalizerGhcVersion nenv /= nullVersion
+          then
+            resub
+              ( posixRegexEscape (display (normalizerGhcVersion nenv))
+                  -- Also glob the date, for nightly GHC builds
+                  ++ "(\\.[0-9]+)?"
+                  -- Also glob the ABI hash, for GHCs which support it
+                  ++ "(-[a-z0-9]+)?"
+              )
+              "<GHCVER>"
+          else id
+      )
+    . normalizeBuildInfoJson
+    . maybe id normalizePathCmdOutput (normalizerCabalInstallVersion nenv)
+    -- hackage-security locks occur non-deterministically
+    . resub "(Released|Acquired|Waiting) .*hackage-security-lock\n" ""
+    . resub "installed: [0-9]+(\\.[0-9]+)*" "installed: <VERSION>"
   where
     sameDir = "(\\.((\\\\)+|\\/))*"
     packageIdRegex pid =
-        resub (posixRegexEscape (display pid) ++ "(-[A-Za-z0-9.-]+)?")
-              (prettyShow (packageName pid) ++ "-<VERSION>")
+      resub
+        (posixRegexEscape (display pid) ++ "(-[A-Za-z0-9.-]+)?")
+        (prettyShow (packageName pid) ++ "-<VERSION>")
 
     normalizePathCmdOutput cabalInstallVersion =
       -- clear the ghc path out of all supported output formats
-      resub ("compiler-path: " <> posixRegexEscape (normalizerGhcPath nenv))
-          "compiler-path: <GHCPATH>"
-      -- ghc compiler path is already covered by 'normalizeBuildInfoJson'
-      . resub ("{\"cabal-version\":\"" ++ posixRegexEscape (display cabalInstallVersion) ++ "\"")
+      resub
+        ("compiler-path: " <> posixRegexEscape (normalizerGhcPath nenv))
+        "compiler-path: <GHCPATH>"
+        -- ghc compiler path is already covered by 'normalizeBuildInfoJson'
+        . resub
+          ("{\"cabal-version\":\"" ++ posixRegexEscape (display cabalInstallVersion) ++ "\"")
           "{\"cabal-version\":\"<CABAL_INSTALL_VER>\""
-      -- Replace windows filepaths that contain `\\` in the json output.
-      -- since we need to escape each '\' ourselves, these 8 backslashes match on exactly 2 backslashes
-      -- in the test output.
-      -- As the json output is escaped, we need to re-escape the path.
-      . resub "\\\\\\\\" "\\"
+        -- Replace windows filepaths that contain `\\` in the json output.
+        -- since we need to escape each '\' ourselves, these 8 backslashes match on exactly 2 backslashes
+        -- in the test output.
+        -- As the json output is escaped, we need to re-escape the path.
+        . resub "\\\\\\\\" "\\"
 
     -- 'build-info.json' contains a plethora of host system specific information.
     --
     -- This must happen before the root-dir normalisation.
     normalizeBuildInfoJson =
-        -- Remove ghc path from show-build-info output
-        resub ("\"path\":\"" <> posixRegexEscape (normalizerGhcPath nenv) <> "\"")
-          "\"path\":\"<GHCPATH>\""
+      -- Remove ghc path from show-build-info output
+      resub
+        ("\"path\":\"" <> posixRegexEscape (normalizerGhcPath nenv) <> "\"")
+        "\"path\":\"<GHCPATH>\""
         -- Remove cabal version output from show-build-info output
-      . resub ("{\"cabal-lib-version\":\"" ++ posixRegexEscape (display (normalizerCabalVersion nenv)) ++ "\"")
-              "{\"cabal-lib-version\":\"<CABALVER>\""
+        . resub
+          ("{\"cabal-lib-version\":\"" ++ posixRegexEscape (display (normalizerCabalVersion nenv)) ++ "\"")
+          "{\"cabal-lib-version\":\"<CABALVER>\""
         -- Remove the package id for stuff such as:
         -- > "-package-id","base-4.14.0.0-<some-hash>"
         -- and replace it with:
@@ -121,32 +140,33 @@ normalizeOutput nenv =
         --
         -- This makes it impossible to have a stable package id, thus remove it completely.
         -- Check manually in your test-cases if the package-id needs to be verified.
-      . resub ("\"-package-id\",\"([^\"]*)\"")
-              "\"-package-id\",\"<PACKAGEDEP>\""
+        . resub
+          ("\"-package-id\",\"([^\"]*)\"")
+          "\"-package-id\",\"<PACKAGEDEP>\""
 
 data NormalizerEnv = NormalizerEnv
-    { normalizerTmpDir        :: FilePath
-    , normalizerCanonicalTmpDir :: FilePath
-    -- ^ May differ from 'normalizerTmpDir', especially e.g. on macos, where
-    -- `/var` is a symlink for `/private/var`.
-    , normalizerGblTmpDir     :: FilePath
-    -- ^ The global temp directory: @/tmp@ on Linux, @/var/folders/...@ on macos
-    -- and @\\msys64\\tmp@ on Windows.
-    --
-    -- Note that on windows the actual path would be @C:\\msys64\\tmp@ but we
-    -- drop the @C:@ prefix because this path appears sometimes
-    -- twice in the same path in some tests, and the second time it doesn't have a @C:@, so
-    -- the logic fails to catch it.
-    , normalizerCanonicalGblTmpDir :: FilePath
-    -- ^ The canonical version of 'normalizerGblTmpDir', might differ in the same
-    -- way as above on macos
-    , normalizerGhcVersion    :: Version
-    , normalizerGhcPath    :: FilePath
-    , normalizerKnownPackages :: [PackageId]
-    , normalizerPlatform      :: Platform
-    , normalizerCabalVersion  :: Version
-    , normalizerCabalInstallVersion :: Maybe Version
-    }
+  { normalizerTmpDir :: FilePath
+  , normalizerCanonicalTmpDir :: FilePath
+  -- ^ May differ from 'normalizerTmpDir', especially e.g. on macos, where
+  -- `/var` is a symlink for `/private/var`.
+  , normalizerGblTmpDir :: FilePath
+  -- ^ The global temp directory: @/tmp@ on Linux, @/var/folders/...@ on macos
+  -- and @\\msys64\\tmp@ on Windows.
+  --
+  -- Note that on windows the actual path would be @C:\\msys64\\tmp@ but we
+  -- drop the @C:@ prefix because this path appears sometimes
+  -- twice in the same path in some tests, and the second time it doesn't have a @C:@, so
+  -- the logic fails to catch it.
+  , normalizerCanonicalGblTmpDir :: FilePath
+  -- ^ The canonical version of 'normalizerGblTmpDir', might differ in the same
+  -- way as above on macos
+  , normalizerGhcVersion :: Version
+  , normalizerGhcPath :: FilePath
+  , normalizerKnownPackages :: [PackageId]
+  , normalizerPlatform :: Platform
+  , normalizerCabalVersion :: Version
+  , normalizerCabalInstallVersion :: Maybe Version
+  }
 
 posixSpecialChars :: [Char]
 posixSpecialChars = ".^$*+?()[{\\|"
@@ -163,35 +183,40 @@ backslashToSlash = map (\c -> if c == '\\' then '/' else c)
 resub :: String {- search -} -> String {- replace -} -> String {- input -} -> String
 resub _ _ "" = ""
 resub regexp repl inp =
-  let compile _i str [] = \ _m ->  (str ++)
+  let compile _i str [] = \_m -> (str ++)
       compile i str (("\\", (off, len)) : rest) =
         let i' = off + len
             pre = take (off - i) str
             str' = drop (i' - i) str
-        in if null str' then \ _m -> (pre ++) . ('\\' :)
-             else \ m -> (pre ++) . ('\\' :) . compile i' str' rest m
+         in if null str'
+              then \_m -> (pre ++) . ('\\' :)
+              else \m -> (pre ++) . ('\\' :) . compile i' str' rest m
       compile i str ((xstr, (off, len)) : rest) =
         let i' = off + len
             pre = take (off - i) str
             str' = drop (i' - i) str
             x = read xstr
-        in if null str' then \ m -> (pre++) . (fst (m ! x) ++)
-             else \ m -> (pre ++) . (fst (m ! x) ++) . compile i' str' rest m
+         in if null str'
+              then \m -> (pre ++) . (fst (m ! x) ++)
+              else \m -> (pre ++) . (fst (m ! x) ++) . compile i' str' rest m
       compiled :: MatchText String -> String -> String
-      compiled = compile 0 repl findrefs where
-        -- bre matches a backslash then capture either a backslash or some digits
-        bre = mkRegex "\\\\(\\\\|[0-9]+)"
-        findrefs = map (\m -> (fst (m ! 1), snd (m ! 0))) (matchAllText bre repl)
+      compiled = compile 0 repl findrefs
+        where
+          -- bre matches a backslash then capture either a backslash or some digits
+          bre = mkRegex "\\\\(\\\\|[0-9]+)"
+          findrefs = map (\m -> (fst (m ! 1), snd (m ! 0))) (matchAllText bre repl)
       go _i str [] = str
       go i str (m : ms) =
         let (_, (off, len)) = m ! 0
             i' = off + len
             pre = take (off - i) str
             str' = drop (i' - i) str
-        in if null str' then pre ++ compiled m ""
-             else pre ++ compiled m (go i' str' ms)
-  in go 0 inp (matchAllText (mkRegex regexp) inp)
+         in if null str'
+              then pre ++ compiled m ""
+              else pre ++ compiled m (go i' str' ms)
+   in go 0 inp (matchAllText (mkRegex regexp) inp)
 
 mkRegex :: String -> Regex
 mkRegex s = makeRegexOpts opt defaultExecOpt s
-  where opt = defaultCompOpt { newSyntax = True, multiline = True }
+  where
+    opt = defaultCompOpt{newSyntax = True, multiline = True}

--- a/cabal-testsuite/src/Test/Cabal/Plan.hs
+++ b/cabal-testsuite/src/Test/Cabal/Plan.hs
@@ -1,159 +1,188 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
--- | Utilities for understanding @plan.json@.
-module Test.Cabal.Plan (
-    Plan(..),
-    DistDirOrBinFile(..),
-    InstallItem(..),
-    ConfiguredGlobal(..),
-    Revision(..),
-    planDistDir,
-    buildInfoFile,
-) where
 
-import Distribution.Parsec (simpleParsec, eitherParsec)
+-- | Utilities for understanding @plan.json@.
+module Test.Cabal.Plan
+  ( Plan (..)
+  , DistDirOrBinFile (..)
+  , InstallItem (..)
+  , ConfiguredGlobal (..)
+  , Revision (..)
+  , planDistDir
+  , buildInfoFile
+  ) where
+
+import Control.Monad
+import Data.Aeson
+import Data.Aeson.Types
+import qualified Data.Text as Text
+import Distribution.Package
+import Distribution.Parsec (eitherParsec, simpleParsec)
 import Distribution.Pretty (prettyShow)
 import Distribution.Types.ComponentName
 import Distribution.Types.Version
-import Distribution.Package
-import qualified Data.Text as Text
-import Data.Aeson
-import Data.Aeson.Types
-import Control.Monad
 
 -- TODO: index this
-data Plan = Plan { planInstallPlan :: [InstallItem] }
-  deriving Show
+data Plan = Plan {planInstallPlan :: [InstallItem]}
+  deriving (Show)
 
 data InstallItem
-    = APreExisting
-    | AConfiguredGlobal ConfiguredGlobal
-    | AConfiguredInplace ConfiguredInplace
-  deriving Show
+  = APreExisting
+  | AConfiguredGlobal ConfiguredGlobal
+  | AConfiguredInplace ConfiguredInplace
+  deriving (Show)
 
 -- local or inplace package
 data ConfiguredInplace = ConfiguredInplace
-    { configuredInplaceDistDir       :: FilePath
-    , configuredInplaceBuildInfo     :: Maybe FilePath
-    , configuredInplacePackageName   :: PackageName
-    , configuredInplaceVersion       :: Version
-    , configuredInplaceRevision      :: Revision
-    , configuredInplaceComponentName :: Maybe ComponentName }
-  deriving Show
+  { configuredInplaceDistDir :: FilePath
+  , configuredInplaceBuildInfo :: Maybe FilePath
+  , configuredInplacePackageName :: PackageName
+  , configuredInplaceVersion :: Version
+  , configuredInplaceRevision :: Revision
+  , configuredInplaceComponentName :: Maybe ComponentName
+  }
+  deriving (Show)
 
 data ConfiguredGlobal = ConfiguredGlobal
-    { configuredGlobalBinFile       :: Maybe FilePath
-    , configuredGlobalPackageName   :: PackageName
-    , configuredGlobalVersion       :: Version
-    , configuredGlobalRevision      :: Revision
-    , configuredGlobalComponentName :: Maybe ComponentName }
-  deriving Show
+  { configuredGlobalBinFile :: Maybe FilePath
+  , configuredGlobalPackageName :: PackageName
+  , configuredGlobalVersion :: Version
+  , configuredGlobalRevision :: Revision
+  , configuredGlobalComponentName :: Maybe ComponentName
+  }
+  deriving (Show)
 
 newtype Revision = Revision Int
   deriving (Show, Eq, FromJSON)
 
 instance FromJSON Plan where
-    parseJSON (Object v) = fmap Plan (v .: "install-plan")
-    parseJSON invalid = typeMismatch "Plan" invalid
+  parseJSON (Object v) = fmap Plan (v .: "install-plan")
+  parseJSON invalid = typeMismatch "Plan" invalid
 
 instance FromJSON InstallItem where
-    parseJSON obj@(Object v) = do
-        t <- v .: "type"
-        case t :: String of
-            "pre-existing" -> return APreExisting
-            "configured"   -> do
-                s <- v .: "style"
-                case s :: String of
-                  "global"  -> AConfiguredGlobal `fmap` parseJSON obj
-                  "inplace" -> AConfiguredInplace `fmap` parseJSON obj
-                  "local"   -> AConfiguredInplace `fmap` parseJSON obj
-                  _         -> fail $ "unrecognized value of 'style' field: " ++ s
-            _              -> fail "unrecognized value of 'type' field"
-    parseJSON invalid = typeMismatch "InstallItem" invalid
+  parseJSON obj@(Object v) = do
+    t <- v .: "type"
+    case t :: String of
+      "pre-existing" -> return APreExisting
+      "configured" -> do
+        s <- v .: "style"
+        case s :: String of
+          "global" -> AConfiguredGlobal `fmap` parseJSON obj
+          "inplace" -> AConfiguredInplace `fmap` parseJSON obj
+          "local" -> AConfiguredInplace `fmap` parseJSON obj
+          _ -> fail $ "unrecognized value of 'style' field: " ++ s
+      _ -> fail "unrecognized value of 'type' field"
+  parseJSON invalid = typeMismatch "InstallItem" invalid
 
 instance FromJSON ConfiguredInplace where
-    parseJSON (Object v) = do
-        dist_dir <- v .: "dist-dir"
-        build_info <- v .:? "build-info"
-        pkg_name <- v .: "pkg-name"
-        pkg_version <- v .: "pkg-version"
-        pkg_revision <- v .: "pkg-revision"
-        component_name <- v .:? "component-name"
-        return (ConfiguredInplace dist_dir build_info pkg_name pkg_version pkg_revision component_name)
-    parseJSON invalid = typeMismatch "ConfiguredInplace" invalid
+  parseJSON (Object v) = do
+    dist_dir <- v .: "dist-dir"
+    build_info <- v .:? "build-info"
+    pkg_name <- v .: "pkg-name"
+    pkg_version <- v .: "pkg-version"
+    pkg_revision <- v .: "pkg-revision"
+    component_name <- v .:? "component-name"
+    return (ConfiguredInplace dist_dir build_info pkg_name pkg_version pkg_revision component_name)
+  parseJSON invalid = typeMismatch "ConfiguredInplace" invalid
 
 instance FromJSON ConfiguredGlobal where
-    parseJSON (Object v) = do
-        bin_file <- v .:? "bin-file"
-        pkg_name <- v .: "pkg-name"
-        pkg_version <- v .: "pkg-version"
-        pkg_revision <- v .: "pkg-revision"
-        component_name <- v .:? "component-name"
-        return (ConfiguredGlobal bin_file pkg_name pkg_version pkg_revision component_name)
-    parseJSON invalid = typeMismatch "ConfiguredGlobal" invalid
+  parseJSON (Object v) = do
+    bin_file <- v .:? "bin-file"
+    pkg_name <- v .: "pkg-name"
+    pkg_version <- v .: "pkg-version"
+    pkg_revision <- v .: "pkg-revision"
+    component_name <- v .:? "component-name"
+    return (ConfiguredGlobal bin_file pkg_name pkg_version pkg_revision component_name)
+  parseJSON invalid = typeMismatch "ConfiguredGlobal" invalid
 
 instance FromJSON PackageName where
-    parseJSON (String t) = return (mkPackageName (Text.unpack t))
-    parseJSON invalid = typeMismatch "PackageName" invalid
+  parseJSON (String t) = return (mkPackageName (Text.unpack t))
+  parseJSON invalid = typeMismatch "PackageName" invalid
 
 instance FromJSON Version where
-    parseJSON = withText "Version" $ either fail pure . eitherParsec . Text.unpack
+  parseJSON = withText "Version" $ either fail pure . eitherParsec . Text.unpack
 
 instance FromJSON ComponentName where
-    parseJSON (String t) =
-        case simpleParsec s of
-            Nothing -> fail ("could not parse component-name: " ++ s)
-            Just r  -> return r
-      where s = Text.unpack t
-    parseJSON invalid = typeMismatch "ComponentName" invalid
+  parseJSON (String t) =
+    case simpleParsec s of
+      Nothing -> fail ("could not parse component-name: " ++ s)
+      Just r -> return r
+    where
+      s = Text.unpack t
+  parseJSON invalid = typeMismatch "ComponentName" invalid
 
 data DistDirOrBinFile = DistDir FilePath | BinFile FilePath
 
 planDistDir :: Plan -> PackageName -> ComponentName -> DistDirOrBinFile
 planDistDir plan pkg_name cname =
-    case concatMap p (planInstallPlan plan) of
-        [x] -> x
-        []  -> error $ "planDistDir: component " ++ prettyShow cname
-                    ++ " of package " ++ prettyShow pkg_name ++ " either does not"
-                    ++ " exist in the install plan or does not have a dist-dir nor bin-file"
-        _   -> error $ "planDistDir: found multiple copies of component " ++ prettyShow cname
-                    ++ " of package " ++ prettyShow pkg_name ++ " in install plan"
+  case concatMap p (planInstallPlan plan) of
+    [x] -> x
+    [] ->
+      error $
+        "planDistDir: component "
+          ++ prettyShow cname
+          ++ " of package "
+          ++ prettyShow pkg_name
+          ++ " either does not"
+          ++ " exist in the install plan or does not have a dist-dir nor bin-file"
+    _ ->
+      error $
+        "planDistDir: found multiple copies of component "
+          ++ prettyShow cname
+          ++ " of package "
+          ++ prettyShow pkg_name
+          ++ " in install plan"
   where
-    p APreExisting      = []
+    p APreExisting = []
     p (AConfiguredGlobal conf) = do
-        guard (configuredGlobalPackageName conf == pkg_name)
-        guard $ case configuredGlobalComponentName conf of
-                    Nothing     -> True
-                    Just cname' -> cname == cname'
-        case configuredGlobalBinFile conf of
-            Nothing -> []
-            Just bin_file -> return $ BinFile bin_file
+      guard (configuredGlobalPackageName conf == pkg_name)
+      guard $ case configuredGlobalComponentName conf of
+        Nothing -> True
+        Just cname' -> cname == cname'
+      case configuredGlobalBinFile conf of
+        Nothing -> []
+        Just bin_file -> return $ BinFile bin_file
     p (AConfiguredInplace conf) = do
-        guard (configuredInplacePackageName conf == pkg_name)
-        guard $ case configuredInplaceComponentName conf of
-                    Nothing     -> True
-                    Just cname' -> cname == cname'
-        return $ DistDir $ configuredInplaceDistDir conf
+      guard (configuredInplacePackageName conf == pkg_name)
+      guard $ case configuredInplaceComponentName conf of
+        Nothing -> True
+        Just cname' -> cname == cname'
+      return $ DistDir $ configuredInplaceDistDir conf
 
 buildInfoFile :: Plan -> PackageName -> ComponentName -> FilePath
 buildInfoFile plan pkg_name cname =
-    case concatMap p (planInstallPlan plan) of
-        [Just x] -> x
-        [Nothing] -> error $ "buildInfoFile: component " ++ prettyShow cname
-                    ++ " of package " ++ prettyShow pkg_name ++ " does not"
-                    ++ " have a build info-file"
-        []  -> error $ "buildInfoFile: component " ++ prettyShow cname
-                    ++ " of package " ++ prettyShow pkg_name ++ " either does not"
-                    ++ " exist in the install plan or build info-file"
-        _   -> error $ "buildInfoFile: found multiple copies of component " ++ prettyShow cname
-                    ++ " of package " ++ prettyShow pkg_name ++ " in install plan"
+  case concatMap p (planInstallPlan plan) of
+    [Just x] -> x
+    [Nothing] ->
+      error $
+        "buildInfoFile: component "
+          ++ prettyShow cname
+          ++ " of package "
+          ++ prettyShow pkg_name
+          ++ " does not"
+          ++ " have a build info-file"
+    [] ->
+      error $
+        "buildInfoFile: component "
+          ++ prettyShow cname
+          ++ " of package "
+          ++ prettyShow pkg_name
+          ++ " either does not"
+          ++ " exist in the install plan or build info-file"
+    _ ->
+      error $
+        "buildInfoFile: found multiple copies of component "
+          ++ prettyShow cname
+          ++ " of package "
+          ++ prettyShow pkg_name
+          ++ " in install plan"
   where
-    p APreExisting      = []
+    p APreExisting = []
     p (AConfiguredGlobal _) = []
     p (AConfiguredInplace conf) = do
-        guard (configuredInplacePackageName conf == pkg_name)
-        guard $ case configuredInplaceComponentName conf of
-                    Nothing     -> True
-                    Just cname' -> cname == cname'
-        return $ configuredInplaceBuildInfo conf
+      guard (configuredInplacePackageName conf == pkg_name)
+      guard $ case configuredInplaceComponentName conf of
+        Nothing -> True
+        Just cname' -> cname == cname'
+      return $ configuredInplaceBuildInfo conf

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -8,86 +8,89 @@
 
 -- | Generally useful definitions that we expect most test scripts
 -- to use.
-module Test.Cabal.Prelude (
-    module Test.Cabal.Prelude,
-    module Test.Cabal.Monad,
-    module Test.Cabal.NeedleHaystack,
-    module Test.Cabal.Run,
-    module System.FilePath,
-    module Distribution.Utils.Path,
-    module Control.Monad,
-    module Control.Monad.IO.Class,
-    module Distribution.Version,
-    module Distribution.Simple.Program,
-) where
+module Test.Cabal.Prelude
+  ( module Test.Cabal.Prelude
+  , module Test.Cabal.Monad
+  , module Test.Cabal.NeedleHaystack
+  , module Test.Cabal.Run
+  , module System.FilePath
+  , module Distribution.Utils.Path
+  , module Control.Monad
+  , module Control.Monad.IO.Class
+  , module Distribution.Version
+  , module Distribution.Simple.Program
+  ) where
 
-import Test.Cabal.NeedleHaystack
-import Test.Cabal.Script
-import Test.Cabal.Run
 import Test.Cabal.Monad
+import Test.Cabal.NeedleHaystack
 import Test.Cabal.Plan
+import Test.Cabal.Run
+import Test.Cabal.Script
 import Test.Cabal.TestCode
 
 import Distribution.Compat.Time (calibrateMtimeChangeDelay)
-import Distribution.Simple.Compiler (PackageDBStackCWD, PackageDBCWD, PackageDBX(..))
-import Distribution.Simple.PackageDescription (readGenericPackageDescription)
-import Distribution.Simple.Program.Types
-import Distribution.Simple.Program.Db
-import Distribution.Simple.Program
-import Distribution.System (OS(Windows,Linux,OSX), Arch(JavaScript), buildOS, buildArch)
-import Distribution.Simple.Configure
-    ( getPersistBuildConfig )
-import Distribution.Simple.Utils
-    ( withFileContents, tryFindPackageDesc )
-import Distribution.Version
 import Distribution.Package
-import Distribution.Parsec (eitherParsec, simpleParsec)
-import Distribution.Types.UnqualComponentName
-import Distribution.Types.LocalBuildInfo
 import Distribution.PackageDescription
-import Test.Utils.TempTestDir (withTestDir)
-import Distribution.Verbosity (normal)
+import Distribution.Parsec (eitherParsec, simpleParsec)
+import Distribution.Simple.Compiler (PackageDBCWD, PackageDBStackCWD, PackageDBX (..))
+import Distribution.Simple.Configure
+  ( getPersistBuildConfig
+  )
+import Distribution.Simple.PackageDescription (readGenericPackageDescription)
+import Distribution.Simple.Program
+import Distribution.Simple.Utils
+  ( tryFindPackageDesc
+  , withFileContents
+  )
+import Distribution.System (Arch (JavaScript), OS (Linux, OSX, Windows), buildArch, buildOS)
+import Distribution.Types.LocalBuildInfo
 import Distribution.Utils.Path
-  ( makeSymbolicPath, relativeSymbolicPath, interpretSymbolicPathCWD )
+  ( interpretSymbolicPathCWD
+  , makeSymbolicPath
+  , relativeSymbolicPath
+  )
+import Distribution.Verbosity (normal)
+import Distribution.Version
+import Test.Utils.TempTestDir (withTestDir)
 
 import Distribution.Compat.Stack
 
 import Text.Regex.TDFA ((=~))
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync)
-import qualified Data.Aeson as JSON
-import qualified Data.ByteString.Lazy as BSL
-import Control.Monad (unless, when, void, forM_, foldM, liftM2, liftM4)
-import Control.Monad.Catch ( bracket_ )
-import Control.Monad.Trans.Reader (asks, withReaderT, runReaderT)
+import Control.Monad (foldM, forM_, liftM2, liftM4, unless, void, when)
+import Control.Monad.Catch (bracket_)
 import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Reader (asks, runReaderT, withReaderT)
+import Control.Retry (exponentialBackoff, limitRetriesByCumulativeDelay)
 import qualified Crypto.Hash.SHA256 as SHA256
+import qualified Data.Aeson as JSON
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as C
-import Data.List (isInfixOf, stripPrefix, isPrefixOf, intercalate)
-import Data.Maybe (isJust, mapMaybe, fromMaybe)
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Char as Char
+import Data.List (intercalate, isInfixOf, isPrefixOf, stripPrefix)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Network.Wait (waitTcpVerbose)
+import System.Directory
+import System.Environment
 import System.Exit (ExitCode (..))
 import System.FilePath
-import Control.Concurrent (threadDelay)
-import qualified Data.Char as Char
-import System.Directory
-import Control.Retry (exponentialBackoff, limitRetriesByCumulativeDelay)
-import Network.Wait (waitTcpVerbose)
-import System.Environment
-import qualified System.FilePath.Glob as Glob (globDir1, compile)
-import qualified System.OsRelease as OSR
-import System.Process
-import System.IO
+import qualified System.FilePath.Glob as Glob (compile, globDir1)
 import qualified System.FilePath.Posix as Posix
 import qualified System.FilePath.Windows as Windows
+import System.IO
+import qualified System.OsRelease as OSR
+import System.Process
 
 #ifndef mingw32_HOST_OS
 import System.Posix.Resource
 #endif
 
 ------------------------------------------------------------------------
--- * Utilities
 
+-- * Utilities
 
 runM :: FilePath -> [String] -> Maybe String -> TestM Result
 runM path args input = do
@@ -96,48 +99,53 @@ runM path args input = do
 
 runM' :: Maybe FilePath -> FilePath -> [String] -> Maybe String -> TestM Result
 runM' run_dir path args input = do
-    env <- getTestEnv
-    r <- liftIO $ run (testVerbosity env)
-                 run_dir
-                 (testEnvironment env)
-                 path
-                 args
-                 input
-    recordLog r
-    requireSuccess r
+  env <- getTestEnv
+  r <-
+    liftIO $
+      run
+        (testVerbosity env)
+        run_dir
+        (testEnvironment env)
+        path
+        args
+        input
+  recordLog r
+  requireSuccess r
 
-runProgramM  :: Program -> [String] -> Maybe String -> TestM Result
+runProgramM :: Program -> [String] -> Maybe String -> TestM Result
 runProgramM prog args input = do
   env <- getTestEnv
   runProgramM' (Just $ testCurrentDir env) prog args input
 
 runProgramM' :: Maybe FilePath -> Program -> [String] -> Maybe String -> TestM Result
 runProgramM' run_dir prog args input = do
-    configured_prog <- requireProgramM prog
-    -- TODO: Consider also using other information from
-    -- ConfiguredProgram, e.g., env and args
-    runM' run_dir (programPath configured_prog) args input
+  configured_prog <- requireProgramM prog
+  -- TODO: Consider also using other information from
+  -- ConfiguredProgram, e.g., env and args
+  runM' run_dir (programPath configured_prog) args input
 
 getLocalBuildInfoM :: TestM LocalBuildInfo
 getLocalBuildInfoM = do
-    env <- getTestEnv
-    liftIO $ getPersistBuildConfig Nothing (makeSymbolicPath $ testDistDir env)
+  env <- getTestEnv
+  liftIO $ getPersistBuildConfig Nothing (makeSymbolicPath $ testDistDir env)
 
 ------------------------------------------------------------------------
+
 -- * Changing parameters
 
 withDirectory :: FilePath -> TestM a -> TestM a
-withDirectory f = withReaderT
-    (\env -> env { testRelativeCurrentDir = testRelativeCurrentDir env </> f })
+withDirectory f =
+  withReaderT
+    (\env -> env{testRelativeCurrentDir = testRelativeCurrentDir env </> f})
 
 withStoreDir :: FilePath -> TestM a -> TestM a
 withStoreDir fp =
-  withReaderT (\env -> env { testMaybeStoreDir = Just fp })
+  withReaderT (\env -> env{testMaybeStoreDir = Just fp})
 
 -- We append to the environment list, as per 'getEffectiveEnvironment'
 -- which prefers the latest override.
 withEnv :: [(String, Maybe String)] -> TestM a -> TestM a
-withEnv e = withReaderT (\env -> env { testEnvironment = testEnvironment env ++ e })
+withEnv e = withReaderT (\env -> env{testEnvironment = testEnvironment env ++ e})
 
 -- | Prepend a directory to the PATH
 addToPath :: FilePath -> TestM a -> TestM a
@@ -148,12 +156,12 @@ addToPath exe_dir action = do
   let new_env = (("PATH", Just newpath) : (testEnvironment env))
   withEnv new_env action
 
-
 -- HACK please don't use me
 withEnvFilter :: (String -> Bool) -> TestM a -> TestM a
-withEnvFilter p = withReaderT (\env -> env { testEnvironment = filter (p . fst) (testEnvironment env) })
+withEnvFilter p = withReaderT (\env -> env{testEnvironment = filter (p . fst) (testEnvironment env)})
 
 ------------------------------------------------------------------------
+
 -- * Running Setup
 
 marked_verbose :: String
@@ -174,41 +182,44 @@ setup''
   -- ^ Arguments
   -> TestM Result
 setup'' prefix cmd args = do
-    env <- getTestEnv
-    let work_dir = if testRelativeCurrentDir env == "." then Nothing else Just (testRelativeCurrentDir env)
-    when ((cmd == "register" || cmd == "copy") && not (testHavePackageDb env)) $
-        error "Cannot register/copy without using 'withPackageDb'"
-    ghc_path     <- programPathM ghcProgram
-    haddock_path <- programPathM haddockProgram
-    let args' = case cmd of
-            "configure" ->
-                -- If the package database is empty, setting --global
-                -- here will make us error loudly if we try to install
-                -- into a bad place.
-                [ "--global"
-                -- NB: technically unnecessary with Cabal, but
-                -- definitely needed for Setup, which doesn't
-                -- respect cabal.config
-                , "--with-ghc", ghc_path
-                , "--with-haddock", haddock_path
-                -- This avoids generating hashes in our package IDs,
-                -- which helps the test suite's expect tests.
-                , "--enable-deterministic"
-                -- These flags make the test suite run faster
-                -- Can't do this unless we LD_LIBRARY_PATH correctly
-                -- , "--enable-executable-dynamic"
-                -- , "--disable-optimization"
-                -- Specify where we want our installed packages to go
-                , "--prefix=" ++ testPrefixDir env
-                ] ++ packageDBParams (testPackageDBStack env)
-                  ++ args
-            _ -> args
-    let rel_dist_dir = definitelyMakeRelative (testCurrentDir env) (testDistDir env)
-        work_dir_arg = case work_dir of
-                          Nothing -> []
-                          Just wd -> ["--working-dir", wd]
-        full_args = work_dir_arg ++ (cmd : [marked_verbose, "--distdir", rel_dist_dir] ++ args')
-    defaultRecordMode RecordMarked $ do
+  env <- getTestEnv
+  let work_dir = if testRelativeCurrentDir env == "." then Nothing else Just (testRelativeCurrentDir env)
+  when ((cmd == "register" || cmd == "copy") && not (testHavePackageDb env)) $
+    error "Cannot register/copy without using 'withPackageDb'"
+  ghc_path <- programPathM ghcProgram
+  haddock_path <- programPathM haddockProgram
+  let args' = case cmd of
+        "configure" ->
+          -- If the package database is empty, setting --global
+          -- here will make us error loudly if we try to install
+          -- into a bad place.
+          [ "--global"
+          , -- NB: technically unnecessary with Cabal, but
+            -- definitely needed for Setup, which doesn't
+            -- respect cabal.config
+            "--with-ghc"
+          , ghc_path
+          , "--with-haddock"
+          , haddock_path
+          , -- This avoids generating hashes in our package IDs,
+            -- which helps the test suite's expect tests.
+            "--enable-deterministic"
+          , -- These flags make the test suite run faster
+            -- Can't do this unless we LD_LIBRARY_PATH correctly
+            -- , "--enable-executable-dynamic"
+            -- , "--disable-optimization"
+            -- Specify where we want our installed packages to go
+            "--prefix=" ++ testPrefixDir env
+          ]
+            ++ packageDBParams (testPackageDBStack env)
+            ++ args
+        _ -> args
+  let rel_dist_dir = definitelyMakeRelative (testCurrentDir env) (testDistDir env)
+      work_dir_arg = case work_dir of
+        Nothing -> []
+        Just wd -> ["--working-dir", wd]
+      full_args = work_dir_arg ++ (cmd : [marked_verbose, "--distdir", rel_dist_dir] ++ args')
+  defaultRecordMode RecordMarked $ do
     recordHeader ["Setup", cmd]
 
     -- We test `cabal act-as-setup` when running cabal-tests.
@@ -219,84 +230,90 @@ setup'' prefix cmd args = do
     pdfile <- liftIO $ tryFindPackageDesc (testVerbosity env) (Just pkgDir)
     pdesc <- liftIO $ readGenericPackageDescription (testVerbosity env) (Just pkgDir) $ relativeSymbolicPath pdfile
     if testCabalInstallAsSetup env
-    then if buildType (packageDescription pdesc) == Simple
-         then runProgramM' (Just (testTmpDir env)) cabalProgram ("act-as-setup" : "--" : full_args) Nothing
-         else fail "Using act-as-setup for not 'build-type: Simple' package"
-    else do
+      then
         if buildType (packageDescription pdesc) == Simple
-            then runM' (Just $ testTmpDir env) (testSetupPath env) (full_args) Nothing
-            -- Run the Custom script!
-            else do
-              r <- liftIO $ runghc (testScriptEnv env)
-                                   (Just $ testTmpDir env)
-                                   (testEnvironment env)
-                                   (testRelativeCurrentDir env </> prefix </> "Setup.hs")
-                                   (full_args)
-              recordLog r
-              requireSuccess r
+          then runProgramM' (Just (testTmpDir env)) cabalProgram ("act-as-setup" : "--" : full_args) Nothing
+          else fail "Using act-as-setup for not 'build-type: Simple' package"
+      else do
+        if buildType (packageDescription pdesc) == Simple
+          then runM' (Just $ testTmpDir env) (testSetupPath env) (full_args) Nothing
+          else -- Run the Custom script!
+          do
+            r <-
+              liftIO $
+                runghc
+                  (testScriptEnv env)
+                  (Just $ testTmpDir env)
+                  (testEnvironment env)
+                  (testRelativeCurrentDir env </> prefix </> "Setup.hs")
+                  (full_args)
+            recordLog r
+            requireSuccess r
 
-    -- This code is very tempting (and in principle should be quick:
-    -- after all we are loading the built version of Cabal), but
-    -- actually it costs quite a bit in wallclock time (e.g. 54sec to
-    -- 68sec on AllowNewer, working with un-optimized Cabal.)
-    {-
-    r <- liftIO $ runghc (testScriptEnv env)
-                         (Just (testCurrentDir env))
-                         (testEnvironment env)
-                         "Setup.hs"
-                         (cmd : ["-v", "--distdir", testDistDir env] ++ args')
-    -- don't forget to check results...
-    -}
+-- This code is very tempting (and in principle should be quick:
+-- after all we are loading the built version of Cabal), but
+-- actually it costs quite a bit in wallclock time (e.g. 54sec to
+-- 68sec on AllowNewer, working with un-optimized Cabal.)
+{-
+r <- liftIO $ runghc (testScriptEnv env)
+                     (Just (testCurrentDir env))
+                     (testEnvironment env)
+                     "Setup.hs"
+                     (cmd : ["-v", "--distdir", testDistDir env] ++ args')
+-- don't forget to check results...
+-}
 
 definitelyMakeRelative :: FilePath -> FilePath -> FilePath
 definitelyMakeRelative base0 path0 =
-    let go [] path = joinPath path
-        go base [] = joinPath (replicate (length base) "..")
-        go (x:xs) (y:ys)
-            | x == y    = go xs ys
-            | otherwise = go (x:xs) [] </> go [] (y:ys)
-    -- NB: It's important to normalize, as otherwise if
-    -- we see "foo/./bar" we'll incorrectly conclude that we need
-    -- to go "../../.." to get out of it.
-    in go (splitPath (normalise base0)) (splitPath (normalise path0))
+  let go [] path = joinPath path
+      go base [] = joinPath (replicate (length base) "..")
+      go (x : xs) (y : ys)
+        | x == y = go xs ys
+        | otherwise = go (x : xs) [] </> go [] (y : ys)
+   in -- NB: It's important to normalize, as otherwise if
+      -- we see "foo/./bar" we'll incorrectly conclude that we need
+      -- to go "../../.." to get out of it.
+      go (splitPath (normalise base0)) (splitPath (normalise path0))
 
 -- | This abstracts the common pattern of configuring and then building.
 setup_build :: [String] -> TestM ()
 setup_build args = do
-    setup "configure" args
-    setup "build" []
-    return ()
+  setup "configure" args
+  setup "build" []
+  return ()
 
 -- | This abstracts the common pattern of "installing" a package.
 setup_install :: [String] -> TestM ()
 setup_install args = do
-    setup "configure" args
-    setup "build" []
-    setup "copy" []
-    setup "register" []
-    return ()
+  setup "configure" args
+  setup "build" []
+  setup "copy" []
+  setup "register" []
+  return ()
 
 -- | This abstracts the common pattern of "installing" a package,
 -- with haddock documentation.
 setup_install_with_docs :: [String] -> TestM ()
 setup_install_with_docs args = do
-    setup "configure" args
-    setup "build" []
-    setup "haddock" []
-    setup "copy" []
-    setup "register" []
-    return ()
+  setup "configure" args
+  setup "build" []
+  setup "haddock" []
+  setup "copy" []
+  setup "register" []
+  return ()
 
 packageDBParams :: PackageDBStackCWD -> [String]
-packageDBParams dbs = "--package-db=clear"
-                    : map (("--package-db=" ++) . convert) dbs
+packageDBParams dbs =
+  "--package-db=clear"
+    : map (("--package-db=" ++) . convert) dbs
   where
     convert :: PackageDBCWD -> String
-    convert  GlobalPackageDB         = "global"
-    convert  UserPackageDB           = "user"
+    convert GlobalPackageDB = "global"
+    convert UserPackageDB = "user"
     convert (SpecificPackageDB path) = path
 
 ------------------------------------------------------------------------
+
 -- * Running cabal
 
 -- cabal cmd args
@@ -318,57 +335,58 @@ cabalG' global_args cmd args = cabalGArgs global_args cmd args Nothing
 
 cabalGArgs :: [String] -> String -> [String] -> Maybe String -> TestM Result
 cabalGArgs global_args cmd args input = do
-    env <- getTestEnv
-    let extra_args
-          | cmd `elem`
-              [ "v1-update"
-              , "outdated"
-              , "user-config"
-              , "man"
-              , "v1-freeze"
-              , "check"
-              , "gen-bounds"
-              , "get", "unpack"
-              , "info"
-              , "init"
-              , "haddock-project"
-              ]
-          = [ ]
+  env <- getTestEnv
+  let extra_args
+        | cmd
+            `elem` [ "v1-update"
+                   , "outdated"
+                   , "user-config"
+                   , "man"
+                   , "v1-freeze"
+                   , "check"
+                   , "gen-bounds"
+                   , "get"
+                   , "unpack"
+                   , "info"
+                   , "init"
+                   , "haddock-project"
+                   ] =
+            []
+        -- new-build commands are affected by testCabalProjectFile
+        | cmd `elem` ["v2-sdist", "path"] =
+            ["--project-file=" ++ fp | Just fp <- [testCabalProjectFile env]]
+        | cmd == "v2-clean" || cmd == "clean" =
+            ["--builddir", testDistDir env]
+              ++ ["--project-file=" ++ fp | Just fp <- [testCabalProjectFile env]]
+        | "v2-" `isPrefixOf` cmd =
+            [ "--builddir"
+            , testDistDir env
+            , "-j1"
+            ]
+              ++ ["--project-file=" ++ fp | Just fp <- [testCabalProjectFile env]]
+              ++ ["--package-db=" ++ db | Just dbs <- [testPackageDbPath env], db <- dbs]
+        | "v1-" `isPrefixOf` cmd =
+            ["--builddir", testDistDir env]
+              ++ install_args
+        | otherwise =
+            ["--builddir", testDistDir env]
+              ++ ["--package-db=" ++ db | Just dbs <- [testPackageDbPath env], db <- dbs]
+              ++ install_args
 
-          -- new-build commands are affected by testCabalProjectFile
-          | cmd `elem` ["v2-sdist", "path"]
-          = [ "--project-file=" ++ fp | Just fp <- [testCabalProjectFile env] ]
+      install_args
+        | cmd == "v1-install" || cmd == "v1-build" = ["-j1"]
+        | otherwise = []
 
-          | cmd == "v2-clean" || cmd == "clean"
-          = [ "--builddir", testDistDir env ]
-            ++ [ "--project-file=" ++ fp | Just fp <- [testCabalProjectFile env] ]
+      global_args' =
+        ["--store-dir=" ++ storeDir | Just storeDir <- [testMaybeStoreDir env]]
+          ++ global_args
 
-          | "v2-" `isPrefixOf` cmd
-          = [ "--builddir", testDistDir env
-            , "-j1" ]
-            ++ [ "--project-file=" ++ fp | Just fp <- [testCabalProjectFile env] ]
-            ++ ["--package-db=" ++ db | Just dbs <- [testPackageDbPath env], db <- dbs]
-          | "v1-" `isPrefixOf` cmd
-          = [ "--builddir", testDistDir env ]
-            ++ install_args
-          | otherwise
-          = [ "--builddir", testDistDir env ]
-            ++ ["--package-db=" ++ db | Just dbs <- [testPackageDbPath env], db <- dbs]
-            ++ install_args
-
-        install_args
-          | cmd == "v1-install" || cmd == "v1-build" = [ "-j1" ]
-          | otherwise                                = []
-
-        global_args' =
-            [ "--store-dir=" ++ storeDir | Just storeDir <- [testMaybeStoreDir env] ]
-            ++ global_args
-
-        cabal_args = global_args'
-                  ++ [ cmd, marked_verbose ]
-                  ++ extra_args
-                  ++ args
-    defaultRecordMode RecordMarked $ do
+      cabal_args =
+        global_args'
+          ++ [cmd, marked_verbose]
+          ++ extra_args
+          ++ args
+  defaultRecordMode RecordMarked $ do
     recordHeader ["cabal", cmd]
     cabal_raw' cabal_args input
 
@@ -377,104 +395,124 @@ cabal_raw' cabal_args input = runProgramM cabalProgram cabal_args input
 
 withProjectFile :: FilePath -> TestM a -> TestM a
 withProjectFile fp m =
-    withReaderT (\env -> env { testCabalProjectFile = Just fp }) m
+  withReaderT (\env -> env{testCabalProjectFile = Just fp}) m
 
 -- | Assuming we've successfully configured a new-build project,
 -- read out the plan metadata so that we can use it to do other
 -- operations.
 withPlan :: TestM a -> TestM a
 withPlan m = do
-    env0 <- getTestEnv
-    let filepath = testDistDir env0 </> "cache" </> "plan.json"
-    mplan <- JSON.eitherDecode `fmap` liftIO (BSL.readFile filepath)
-    case mplan of
-        Left err   -> fail $ "withPlan: cannot decode plan " ++ err
-        Right plan -> withReaderT (\env -> env { testPlan = Just plan }) m
+  env0 <- getTestEnv
+  let filepath = testDistDir env0 </> "cache" </> "plan.json"
+  mplan <- JSON.eitherDecode `fmap` liftIO (BSL.readFile filepath)
+  case mplan of
+    Left err -> fail $ "withPlan: cannot decode plan " ++ err
+    Right plan -> withReaderT (\env -> env{testPlan = Just plan}) m
 
 -- | Run an executable from a package.  Requires 'withPlan' to have
 -- been run so that we can find the dist dir.
-runPlanExe :: String {- package name -} -> String {- component name -}
-           -> [String] -> TestM ()
+runPlanExe
+  :: String {- package name -}
+  -> String {- component name -}
+  -> [String]
+  -> TestM ()
 runPlanExe pkg_name cname args = void $ runPlanExe' pkg_name cname args
 
 -- | Run an executable from a package.  Requires 'withPlan' to have
 -- been run so that we can find the dist dir.  Also returns 'Result'.
-runPlanExe' :: String {- package name -} -> String {- component name -}
-            -> [String] -> TestM Result
+runPlanExe'
+  :: String {- package name -}
+  -> String {- component name -}
+  -> [String]
+  -> TestM Result
 runPlanExe' pkg_name cname args = do
-    exePath <- planExePath pkg_name cname
-    defaultRecordMode RecordAll $ do
+  exePath <- planExePath pkg_name cname
+  defaultRecordMode RecordAll $ do
     recordHeader [pkg_name, cname]
     runM exePath args Nothing
 
-planExePath :: String {- package name -} -> String {- component name -}
-            -> TestM FilePath
+planExePath
+  :: String {- package name -}
+  -> String {- component name -}
+  -> TestM FilePath
 planExePath pkg_name cname = do
-    Just plan <- testPlan `fmap` getTestEnv
-    let distDirOrBinFile = planDistDir plan (mkPackageName pkg_name)
-                               (CExeName (mkUnqualComponentName cname))
-        exePath = case distDirOrBinFile of
-          DistDir dist_dir -> dist_dir </> "build" </> cname </> cname
-          BinFile bin_file -> bin_file
-    return exePath
+  Just plan <- testPlan `fmap` getTestEnv
+  let distDirOrBinFile =
+        planDistDir
+          plan
+          (mkPackageName pkg_name)
+          (CExeName (mkUnqualComponentName cname))
+      exePath = case distDirOrBinFile of
+        DistDir dist_dir -> dist_dir </> "build" </> cname </> cname
+        BinFile bin_file -> bin_file
+  return exePath
 
 ------------------------------------------------------------------------
+
 -- * Running ghc-pkg
 
 withPackageDb :: TestM a -> TestM a
 withPackageDb m = do
-    env <- getTestEnv
-    let db_path = testPackageDbDir env
-    if testHavePackageDb env
-        then m
-        else withReaderT (\nenv ->
-                            nenv { testPackageDBStack
-                                    = testPackageDBStack env
-                                   ++ [SpecificPackageDB db_path]
-                                , testHavePackageDb = True
-                                } )
-               $ do ghcPkg "init" [db_path]
-                    m
+  env <- getTestEnv
+  let db_path = testPackageDbDir env
+  if testHavePackageDb env
+    then m
+    else withReaderT
+      ( \nenv ->
+          nenv
+            { testPackageDBStack =
+                testPackageDBStack env
+                  ++ [SpecificPackageDB db_path]
+            , testHavePackageDb = True
+            }
+      )
+      $ do
+        ghcPkg "init" [db_path]
+        m
 
 -- | Don't pass `--package-db` to cabal-install, so it won't find the specific version of
 -- `Cabal` which you have configured the testsuite to run with. You probably don't want to use
 -- this unless you are testing the `--package-db` flag itself.
 noCabalPackageDb :: TestM a -> TestM a
-noCabalPackageDb m = withReaderT (\nenv -> nenv { testPackageDbPath = Nothing }) m
+noCabalPackageDb m = withReaderT (\nenv -> nenv{testPackageDbPath = Nothing}) m
 
 ghcPkg :: String -> [String] -> TestM ()
 ghcPkg cmd args = void (ghcPkg' cmd args)
 
 ghcPkg' :: String -> [String] -> TestM Result
 ghcPkg' cmd args = do
-    env <- getTestEnv
-    unless (testHavePackageDb env) $
-        error "Must initialize package database using withPackageDb"
-    -- NB: testDBStack already has the local database
-    ghcConfProg <- requireProgramM ghcProgram
-    let db_stack = testPackageDBStack env
-        extraArgs = ghcPkgPackageDBParams
-                        (fromMaybe
-                            (error "ghc-pkg: cannot detect version")
-                            (programVersion ghcConfProg))
-                        db_stack
-    recordHeader ["ghc-pkg", cmd]
-    runProgramM ghcPkgProgram (cmd : extraArgs ++ args) Nothing
+  env <- getTestEnv
+  unless (testHavePackageDb env) $
+    error "Must initialize package database using withPackageDb"
+  -- NB: testDBStack already has the local database
+  ghcConfProg <- requireProgramM ghcProgram
+  let db_stack = testPackageDBStack env
+      extraArgs =
+        ghcPkgPackageDBParams
+          ( fromMaybe
+              (error "ghc-pkg: cannot detect version")
+              (programVersion ghcConfProg)
+          )
+          db_stack
+  recordHeader ["ghc-pkg", cmd]
+  runProgramM ghcPkgProgram (cmd : extraArgs ++ args) Nothing
 
 ghcPkgPackageDBParams :: Version -> PackageDBStackCWD -> [String]
-ghcPkgPackageDBParams version dbs = concatMap convert dbs where
+ghcPkgPackageDBParams version dbs = concatMap convert dbs
+  where
     convert :: PackageDBCWD -> [String]
     -- Ignoring global/user is dodgy but there's no way good
     -- way to give ghc-pkg the correct flags in this case.
-    convert  GlobalPackageDB         = []
-    convert  UserPackageDB           = []
+    convert GlobalPackageDB = []
+    convert UserPackageDB = []
     convert (SpecificPackageDB path)
-        | version >= mkVersion [7,6]
-        = ["--package-db=" ++ path]
-        | otherwise
-        = ["--package-conf=" ++ path]
+      | version >= mkVersion [7, 6] =
+          ["--package-db=" ++ path]
+      | otherwise =
+          ["--package-conf=" ++ path]
 
 ------------------------------------------------------------------------
+
 -- * Running other things
 
 -- | Run an executable that was produced by cabal.  The @exe_name@
@@ -484,8 +522,8 @@ runExe exe_name args = void (runExe' exe_name args)
 
 runExe' :: String -> [String] -> TestM Result
 runExe' exe_name args = do
-    env <- getTestEnv
-    defaultRecordMode RecordAll $ do
+  env <- getTestEnv
+  defaultRecordMode RecordAll $ do
     recordHeader [exe_name]
     runM (testDistDir env </> "build" </> exe_name </> exe_name) args Nothing
 
@@ -499,8 +537,8 @@ runInstalledExe exe_name args = void (runInstalledExe' exe_name args)
 -- stdout/stderr output.
 runInstalledExe' :: String -> [String] -> TestM Result
 runInstalledExe' exe_name args = do
-    env <- getTestEnv
-    defaultRecordMode RecordAll $ do
+  env <- getTestEnv
+  defaultRecordMode RecordAll $ do
     recordHeader [exe_name]
     runM (testPrefixDir env </> "bin" </> exe_name) args Nothing
 
@@ -509,6 +547,7 @@ shell :: String -> [String] -> TestM Result
 shell exe args = runM exe args Nothing
 
 ------------------------------------------------------------------------
+
 -- * Repository manipulation
 
 -- Workflows we support:
@@ -546,174 +585,188 @@ hackageRepoTool cmd args = void $ hackageRepoTool' cmd args
 
 hackageRepoTool' :: String -> [String] -> TestM Result
 hackageRepoTool' cmd args = do
-    recordHeader ["hackage-repo-tool", cmd]
-    runProgramM hackageRepoToolProgram (cmd : args) Nothing
+  recordHeader ["hackage-repo-tool", cmd]
+  runProgramM hackageRepoToolProgram (cmd : args) Nothing
 
 tar :: [String] -> TestM ()
 tar args = void $ tar' args
 
 tar' :: [String] -> TestM Result
 tar' args = do
-    recordHeader ["tar"]
-    runProgramM tarProgram args Nothing
+  recordHeader ["tar"]
+  runProgramM tarProgram args Nothing
 
 -- | Creates a tarball of a directory, such that if you
 -- archive the directory "/foo/bar/baz" to "mine.tgz", @tar tf@ reports
 -- @baz/file1@, @baz/file2@, etc.
 archiveTo :: FilePath -> FilePath -> TestM ()
 src `archiveTo` dst = do
-    -- TODO: Consider using the @tar@ library?
-    let (src_parent, src_dir) = splitFileName src
-    -- TODO: --format ustar, like createArchive?
-    -- --force-local is necessary for handling colons in Windows paths.
-    tar $ ["-czf", dst]
-       ++ ["-C", src_parent, src_dir]
+  -- TODO: Consider using the @tar@ library?
+  let (src_parent, src_dir) = splitFileName src
+  -- TODO: --format ustar, like createArchive?
+  -- --force-local is necessary for handling colons in Windows paths.
+  tar $
+    ["-czf", dst]
+      ++ ["-C", src_parent, src_dir]
 
 infixr 4 `archiveTo`
 
 -- | Like 'withRepo', but doesn't run @cabal update@.
 withRepoNoUpdate :: FilePath -> TestM a -> TestM a
 withRepoNoUpdate repo_dir m = do
-    env <- getTestEnv
+  env <- getTestEnv
 
-    -- 1. Initialize repo directory
-    let package_dir = testRepoDir env
-    liftIO $ createDirectoryIfMissing True package_dir
+  -- 1. Initialize repo directory
+  let package_dir = testRepoDir env
+  liftIO $ createDirectoryIfMissing True package_dir
 
-    -- 2. Create tarballs
-    pkgs <- liftIO $ getDirectoryContents (testCurrentDir env </> repo_dir)
-    forM_ pkgs $ \pkg -> do
-        let srcPath = testCurrentDir env </> repo_dir </> pkg
-        let destPath = package_dir </> pkg
-        isPreferredVersionsFile <- liftIO $
-            -- validate this is the "magic" 'preferred-versions' file
-            -- and perform a sanity-check whether this is actually a file
-            -- and not a package that happens to have the same name.
-            if pkg == "preferred-versions"
-                then doesFileExist srcPath
-                else return False
-        case pkg of
-            '.':_ -> return ()
-            _
-                | isPreferredVersionsFile ->
-                    liftIO $ copyFile srcPath destPath
-                | otherwise -> archiveTo
-                    srcPath
-                    (destPath <.> "tar.gz")
+  -- 2. Create tarballs
+  pkgs <- liftIO $ getDirectoryContents (testCurrentDir env </> repo_dir)
+  forM_ pkgs $ \pkg -> do
+    let srcPath = testCurrentDir env </> repo_dir </> pkg
+    let destPath = package_dir </> pkg
+    isPreferredVersionsFile <-
+      liftIO $
+        -- validate this is the "magic" 'preferred-versions' file
+        -- and perform a sanity-check whether this is actually a file
+        -- and not a package that happens to have the same name.
+        if pkg == "preferred-versions"
+          then doesFileExist srcPath
+          else return False
+    case pkg of
+      '.' : _ -> return ()
+      _
+        | isPreferredVersionsFile ->
+            liftIO $ copyFile srcPath destPath
+        | otherwise ->
+            archiveTo
+              srcPath
+              (destPath <.> "tar.gz")
 
-    -- 3. Wire it up in .cabal/config
-    -- TODO: libify this
-    let package_cache = testCabalDir env </> "packages"
-    liftIO $ appendFile (testUserCabalConfigFile env)
-           $ unlines [ "repository test-local-repo"
-                     , "  url: " ++ repoUri env
-                     , "remote-repo-cache: " ++ package_cache ]
-    liftIO $ print $ testUserCabalConfigFile env
-    liftIO $ print =<< readFile (testUserCabalConfigFile env)
+  -- 3. Wire it up in .cabal/config
+  -- TODO: libify this
+  let package_cache = testCabalDir env </> "packages"
+  liftIO $
+    appendFile (testUserCabalConfigFile env) $
+      unlines
+        [ "repository test-local-repo"
+        , "  url: " ++ repoUri env
+        , "remote-repo-cache: " ++ package_cache
+        ]
+  liftIO $ print $ testUserCabalConfigFile env
+  liftIO $ print =<< readFile (testUserCabalConfigFile env)
 
-    -- 4. Profit
-    withReaderT (\env' -> env' { testHaveRepo = True }) m
-    -- TODO: Arguably should undo everything when we're done...
+  -- 4. Profit
+  withReaderT (\env' -> env'{testHaveRepo = True}) m
   where
-    repoUri env ="file+noindex:" ++ (if isWindows
-                                        then map (\x -> if x == Windows.pathSeparator
-                                                        then Posix.pathSeparator
-                                                        else x
-                                                 )
-                                        else ("//" ++)) (testRepoDir env)
+    -- TODO: Arguably should undo everything when we're done...
+
+    repoUri env =
+      "file+noindex:"
+        ++ ( if isWindows
+              then
+                map
+                  ( \x ->
+                      if x == Windows.pathSeparator
+                        then Posix.pathSeparator
+                        else x
+                  )
+              else ("//" ++)
+           )
+          (testRepoDir env)
 
 -- | Given a directory (relative to the 'testCurrentDir') containing
 -- a series of directories representing packages, generate an
 -- external repository corresponding to all of these packages
 withRepo :: FilePath -> TestM a -> TestM a
 withRepo repo_dir m = do
-    withRepoNoUpdate repo_dir $ do
-        -- Update our local index
-        -- Note: this doesn't do anything for file+noindex repositories.
-        cabal "v2-update" ["-z"]
-        m
+  withRepoNoUpdate repo_dir $ do
+    -- Update our local index
+    -- Note: this doesn't do anything for file+noindex repositories.
+    cabal "v2-update" ["-z"]
+    m
 
 -- | Given a directory (relative to the 'testCurrentDir') containing
 -- a series of directories representing packages, generate an
 -- remote repository corresponding to all of these packages
 withRemoteRepo :: FilePath -> TestM a -> TestM a
 withRemoteRepo repoDir m = do
+  -- we rely on the presence of python3 for a simple http server
+  skipUnless "no python3" =<< isAvailableProgram python3Program
+  -- we rely on hackage-repo-tool to set up the secure repository
+  skipUnless "no hackage-repo-tool" =<< isAvailableProgram hackageRepoToolProgram
 
-    -- we rely on the presence of python3 for a simple http server
-    skipUnless "no python3" =<< isAvailableProgram python3Program
-    -- we rely on hackage-repo-tool to set up the secure repository
-    skipUnless "no hackage-repo-tool" =<< isAvailableProgram hackageRepoToolProgram
+  env <- getTestEnv
 
-    env <- getTestEnv
+  let workDir = testRepoDir env
 
-    let workDir = testRepoDir env
+  -- 1. Initialize repo and repo_keys directory
+  let keysDir = workDir </> "keys"
+  let packageDir = workDir </> "package"
 
-    -- 1. Initialize repo and repo_keys directory
-    let keysDir = workDir </> "keys"
-    let packageDir = workDir </> "package"
+  liftIO $ createDirectoryIfMissing True packageDir
+  liftIO $ createDirectoryIfMissing True keysDir
 
-    liftIO $ createDirectoryIfMissing True packageDir
-    liftIO $ createDirectoryIfMissing True keysDir
+  -- 2. Create tarballs
+  entries <- liftIO $ getDirectoryContents (testCurrentDir env </> repoDir)
+  forM_ entries $ \entry -> do
+    let srcPath = testCurrentDir env </> repoDir </> entry
+    let destPath = packageDir </> entry
+    isPreferredVersionsFile <-
+      liftIO $
+        -- validate this is the "magic" 'preferred-versions' file
+        -- and perform a sanity-check whether this is actually a file
+        -- and not a package that happens to have the same name.
+        if entry == "preferred-versions"
+          then doesFileExist srcPath
+          else return False
+    case entry of
+      '.' : _ -> return ()
+      _
+        | isPreferredVersionsFile ->
+            liftIO $ copyFile srcPath destPath
+        | otherwise ->
+            archiveTo srcPath (destPath <.> "tar.gz")
 
-    -- 2. Create tarballs
-    entries <- liftIO $ getDirectoryContents (testCurrentDir env </> repoDir)
-    forM_ entries $ \entry -> do
-        let srcPath = testCurrentDir env </> repoDir </> entry
-        let destPath = packageDir </> entry
-        isPreferredVersionsFile <- liftIO $
-            -- validate this is the "magic" 'preferred-versions' file
-            -- and perform a sanity-check whether this is actually a file
-            -- and not a package that happens to have the same name.
-            if entry == "preferred-versions"
-                then doesFileExist srcPath
-                else return False
-        case entry of
-            '.' : _ -> return ()
-            _
-                | isPreferredVersionsFile ->
-                      liftIO $ copyFile srcPath destPath
-                | otherwise ->
-                  archiveTo srcPath (destPath <.> "tar.gz")
+  -- 3. Create keys and bootstrap repository
+  hackageRepoTool "create-keys" $ ["--keys", keysDir]
+  hackageRepoTool "bootstrap" $ ["--keys", keysDir, "--repo", workDir]
 
-    -- 3. Create keys and bootstrap repository
-    hackageRepoTool "create-keys" $ ["--keys", keysDir ]
-    hackageRepoTool "bootstrap" $ ["--keys", keysDir, "--repo", workDir]
+  -- 4. Wire it up in .cabal/config
+  let package_cache = testCabalDir env </> "packages"
+  -- In the following we launch a python http server to serve the remote
+  -- repository. When the http server is ready we proceed with the tests.
+  -- NOTE 1: it's important that both the http server and cabal use the
+  -- same hostname ("localhost"), otherwise there could be a mismatch
+  -- (depending on the details of the host networking settings).
+  -- NOTE 2: here we use a fixed port (8000). This can cause problems in
+  -- case multiple tests are running concurrently or other another
+  -- process on the developer machine is using the same port.
+  liftIO $ do
+    appendFile (testUserCabalConfigFile env) $
+      unlines
+        [ "repository repository.localhost"
+        , "  url: http://localhost:8000/"
+        , "  secure: True"
+        , "  root-keys:"
+        , "  key-threshold: 0"
+        , "remote-repo-cache: " ++ package_cache
+        ]
+    putStrLn $ testUserCabalConfigFile env
+    putStrLn =<< readFile (testUserCabalConfigFile env)
 
-    -- 4. Wire it up in .cabal/config
-    let package_cache = testCabalDir env </> "packages"
-    -- In the following we launch a python http server to serve the remote
-    -- repository. When the http server is ready we proceed with the tests.
-    -- NOTE 1: it's important that both the http server and cabal use the
-    -- same hostname ("localhost"), otherwise there could be a mismatch
-    -- (depending on the details of the host networking settings).
-    -- NOTE 2: here we use a fixed port (8000). This can cause problems in
-    -- case multiple tests are running concurrently or other another
-    -- process on the developer machine is using the same port.
-    liftIO $ do
-        appendFile (testUserCabalConfigFile env) $
-            unlines [ "repository repository.localhost"
-                    , "  url: http://localhost:8000/"
-                    , "  secure: True"
-                    , "  root-keys:"
-                    , "  key-threshold: 0"
-                    , "remote-repo-cache: " ++ package_cache ]
-        putStrLn $ testUserCabalConfigFile env
-        putStrLn =<< readFile (testUserCabalConfigFile env)
-
-        withAsync
-          (flip runReaderT env $ python3 ["-m", "http.server", "-d", workDir, "--bind", "localhost", "8000"])
-          (\_ -> do
-            -- wait for the python webserver to come up with a exponential
-            -- backoff starting from 50ms, up to a maximum wait of 60s
-            _ <- waitTcpVerbose putStrLn (limitRetriesByCumulativeDelay 60000000 $ exponentialBackoff 50000) "localhost" "8000"
-            r <- runReaderT m (env { testHaveRepo = True })
-            -- Windows fails to kill the python server when the function above
-            -- is complete, so we kill it directly via CMD.
-            when (buildOS == Windows) $ void $ createProcess_ "kill python" $ System.Process.shell "taskkill /F /IM python3.exe"
-            pure r
-            )
-
-
+    withAsync
+      (flip runReaderT env $ python3 ["-m", "http.server", "-d", workDir, "--bind", "localhost", "8000"])
+      ( \_ -> do
+          -- wait for the python webserver to come up with a exponential
+          -- backoff starting from 50ms, up to a maximum wait of 60s
+          _ <- waitTcpVerbose putStrLn (limitRetriesByCumulativeDelay 60000000 $ exponentialBackoff 50000) "localhost" "8000"
+          r <- runReaderT m (env{testHaveRepo = True})
+          -- Windows fails to kill the python server when the function above
+          -- is complete, so we kill it directly via CMD.
+          when (buildOS == Windows) $ void $ createProcess_ "kill python" $ System.Process.shell "taskkill /F /IM python3.exe"
+          pure r
+      )
 
 -- | Record a header to help identify the output to the expect
 -- log.  Unlike the 'recordLog', we don't record all arguments;
@@ -722,23 +775,24 @@ withRemoteRepo repoDir m = do
 -- so we don't want to spew them to the log.)
 recordHeader :: [String] -> TestM ()
 recordHeader args = do
-    env <- getTestEnv
-    let mode = testRecordMode env
-        str_header = "# " ++ intercalate " " args ++ "\n"
-        rec_header = C.pack str_header
-    case mode of
-        DoNotRecord -> return ()
-        _ -> do
-            initWorkDir
-            liftIO $ putStr str_header
-            liftIO $ C.appendFile (testWorkDir env </> "test.log") rec_header
-            liftIO $ C.appendFile (testActualFile env) rec_header
-
+  env <- getTestEnv
+  let mode = testRecordMode env
+      str_header = "# " ++ intercalate " " args ++ "\n"
+      rec_header = C.pack str_header
+  case mode of
+    DoNotRecord -> return ()
+    _ -> do
+      initWorkDir
+      liftIO $ putStr str_header
+      liftIO $ C.appendFile (testWorkDir env </> "test.log") rec_header
+      liftIO $ C.appendFile (testActualFile env) rec_header
 
 ------------------------------------------------------------------------
+
 -- * Test helpers
 
 ------------------------------------------------------------------------
+
 -- * Subprocess run results
 assertFailure :: WithCallStack (String -> m a)
 assertFailure msg = withFrozenCallStack $ error msg
@@ -746,169 +800,234 @@ assertFailure msg = withFrozenCallStack $ error msg
 assertExitCode :: MonadIO m => WithCallStack (ExitCode -> Result -> m ())
 assertExitCode code result =
   when (code /= resultExitCode result) $
-    assertFailure $ "Expected exit code: "
-                 ++ show code
-                 ++ "\nActual: "
-                 ++ show (resultExitCode result)
+    assertFailure $
+      "Expected exit code: "
+        ++ show code
+        ++ "\nActual: "
+        ++ show (resultExitCode result)
 
 assertEqual :: (Eq a, Show a, MonadIO m) => WithCallStack (String -> a -> a -> m ())
 assertEqual s x y =
-    withFrozenCallStack $
-      when (x /= y) $
-        error (s ++ ":\nExpected: " ++ show x ++ "\nActual: " ++ show y)
+  withFrozenCallStack $
+    when (x /= y) $
+      error (s ++ ":\nExpected: " ++ show x ++ "\nActual: " ++ show y)
 
 assertNotEqual :: (Eq a, Show a, MonadIO m) => WithCallStack (String -> a -> a -> m ())
 assertNotEqual s x y =
-    withFrozenCallStack $
-      when (x == y) $
-        error (s ++ ":\nGot both: " ++ show x)
+  withFrozenCallStack $
+    when (x == y) $
+      error (s ++ ":\nGot both: " ++ show x)
 
 assertBool :: MonadIO m => WithCallStack (String -> Bool -> m ())
 assertBool s x =
-    withFrozenCallStack $
-      unless x $ error s
+  withFrozenCallStack $
+    unless x $
+      error s
 
 shouldExist :: MonadIO m => WithCallStack (FilePath -> m ())
 shouldExist path =
-    withFrozenCallStack $
-    liftIO $ doesFileExist path >>= assertBool (path ++ " should exist")
+  withFrozenCallStack $
+    liftIO $
+      doesFileExist path >>= assertBool (path ++ " should exist")
 
 shouldNotExist :: MonadIO m => WithCallStack (FilePath -> m ())
 shouldNotExist path =
-    withFrozenCallStack $
-    liftIO $ doesFileExist path >>= assertBool (path ++ " should exist") . not
+  withFrozenCallStack $
+    liftIO $
+      doesFileExist path >>= assertBool (path ++ " should exist") . not
 
 shouldDirectoryExist :: MonadIO m => WithCallStack (FilePath -> m ())
 shouldDirectoryExist path =
-    withFrozenCallStack $
-    liftIO $ doesDirectoryExist path >>= assertBool (path ++ " should exist")
+  withFrozenCallStack $
+    liftIO $
+      doesDirectoryExist path >>= assertBool (path ++ " should exist")
 
 shouldDirectoryNotExist :: MonadIO m => WithCallStack (FilePath -> m ())
 shouldDirectoryNotExist path =
-    withFrozenCallStack $
-    liftIO $ doesDirectoryExist path >>= assertBool (path ++ " should not exist") . not
+  withFrozenCallStack $
+    liftIO $
+      doesDirectoryExist path >>= assertBool (path ++ " should not exist") . not
 
 assertRegex :: MonadIO m => String -> String -> Result -> m ()
 assertRegex msg regex r =
-    withFrozenCallStack $
+  withFrozenCallStack $
     let out = resultOutput r
-    in assertBool (msg ++ ",\nactual output:\n" ++ out)
-       (out =~ regex)
+     in assertBool
+          (msg ++ ",\nactual output:\n" ++ out)
+          (out =~ regex)
 
 fails :: TestM a -> TestM a
-fails = withReaderT (\env -> env { testShouldFail = not (testShouldFail env) })
+fails = withReaderT (\env -> env{testShouldFail = not (testShouldFail env)})
 
 defaultRecordMode :: RecordMode -> TestM a -> TestM a
-defaultRecordMode mode = withReaderT (\env -> env {
-    testRecordDefaultMode = mode
-    })
+defaultRecordMode mode =
+  withReaderT
+    ( \env ->
+        env
+          { testRecordDefaultMode = mode
+          }
+    )
 
 recordMode :: RecordMode -> TestM a -> TestM a
-recordMode mode = withReaderT (\env -> env {
-    testRecordUserMode = Just mode
-    })
+recordMode mode =
+  withReaderT
+    ( \env ->
+        env
+          { testRecordUserMode = Just mode
+          }
+    )
 
 -- See Note [Multiline Needles]
 assertOutputContains :: MonadIO m => WithCallStack (String -> Result -> m ())
-assertOutputContains = assertOn isInfixOf needleHaystack
-    {txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}}
+assertOutputContains =
+  assertOn
+    isInfixOf
+    needleHaystack
+      { txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}
+      }
 
 assertOutputDoesNotContain :: MonadIO m => WithCallStack (String -> Result -> m ())
-assertOutputDoesNotContain = assertOn isInfixOf needleHaystack
-    { expectNeedleInHaystack = False
-    , txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}
-    }
+assertOutputDoesNotContain =
+  assertOn
+    isInfixOf
+    needleHaystack
+      { expectNeedleInHaystack = False
+      , txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}
+      }
 
 -- See Note [Multiline Needles]
 assertOn :: MonadIO m => WithCallStack (NeedleHaystackCompare -> NeedleHaystack -> String -> Result -> m ())
-assertOn isIn NeedleHaystack{..} (txFwd txNeedle -> needle) (txFwd txHaystack. resultOutput -> output) =
-    withFrozenCallStack $
+assertOn isIn NeedleHaystack{..} (txFwd txNeedle -> needle) (txFwd txHaystack . resultOutput -> output) =
+  withFrozenCallStack $
     if expectNeedleInHaystack
-        then unless (needle `isIn` output)
-            $ assertFailure $ "expected:\n" ++ (txBwd txNeedle needle) ++
-            if displayHaystack
+      then
+        unless (needle `isIn` output) $
+          assertFailure $
+            "expected:\n"
+              ++ (txBwd txNeedle needle)
+              ++ if displayHaystack
                 then "\nin output:\n" ++ (txBwd txHaystack output)
                 else ""
-        else when (needle `isInfixOf` output)
-            $ assertFailure $ "unexpected:\n" ++ (txBwd txNeedle needle) ++
-            if displayHaystack
+      else
+        when (needle `isInfixOf` output) $
+          assertFailure $
+            "unexpected:\n"
+              ++ (txBwd txNeedle needle)
+              ++ if displayHaystack
                 then "\nin output:\n" ++ (txBwd txHaystack output)
                 else ""
 
 assertOutputMatches :: MonadIO m => WithCallStack (String -> Result -> m ())
-assertOutputMatches = assertOn (flip (=~)) needleHaystack
-    { txNeedle = TxFwdBwd{txBwd = ("regex match with '" ++) . (++ "'"), txFwd = id}
-    , txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}
-    }
+assertOutputMatches =
+  assertOn
+    (flip (=~))
+    needleHaystack
+      { txNeedle = TxFwdBwd{txBwd = ("regex match with '" ++) . (++ "'"), txFwd = id}
+      , txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}
+      }
 
 assertOutputDoesNotMatch :: MonadIO m => WithCallStack (String -> Result -> m ())
-assertOutputDoesNotMatch = assertOn (flip (=~)) needleHaystack
-    { expectNeedleInHaystack = False
-    , txNeedle = TxFwdBwd{txBwd = ("regex match with '" ++) . (++ "'"), txFwd = id}
-    , txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}
-    }
+assertOutputDoesNotMatch =
+  assertOn
+    (flip (=~))
+    needleHaystack
+      { expectNeedleInHaystack = False
+      , txNeedle = TxFwdBwd{txBwd = ("regex match with '" ++) . (++ "'"), txFwd = id}
+      , txHaystack = TxFwdBwd{txBwd = delimitLines, txFwd = encodeLf}
+      }
 
 assertFindInFile :: MonadIO m => WithCallStack (String -> FilePath -> m ())
 assertFindInFile needle path =
-    withFrozenCallStack $
-    liftIO $ withFileContents path
-                 (\contents ->
-                  unless (needle `isInfixOf` contents)
-                         (assertFailure ("expected: " ++ needle ++ "\n" ++
-                                         " in file: " ++ path)))
+  withFrozenCallStack $
+    liftIO $
+      withFileContents
+        path
+        ( \contents ->
+            unless
+              (needle `isInfixOf` contents)
+              ( assertFailure
+                  ( "expected: "
+                      ++ needle
+                      ++ "\n"
+                      ++ " in file: "
+                      ++ path
+                  )
+              )
+        )
 
 assertFileDoesContain :: MonadIO m => WithCallStack (FilePath -> String -> m ())
 assertFileDoesContain path needle =
-    withFrozenCallStack $
-    liftIO $ withFileContents path
-                 (\contents ->
-                  unless (needle `isInfixOf` contents)
-                         (assertFailure ("expected: " ++ needle ++ "\n" ++
-                                         " in file: " ++ path)))
+  withFrozenCallStack $
+    liftIO $
+      withFileContents
+        path
+        ( \contents ->
+            unless
+              (needle `isInfixOf` contents)
+              ( assertFailure
+                  ( "expected: "
+                      ++ needle
+                      ++ "\n"
+                      ++ " in file: "
+                      ++ path
+                  )
+              )
+        )
 
 assertFileDoesNotContain :: MonadIO m => WithCallStack (FilePath -> String -> m ())
 assertFileDoesNotContain path needle =
-    withFrozenCallStack $
-    liftIO $ withFileContents path
-                 (\contents ->
-                  when (needle `isInfixOf` contents)
-                       (assertFailure ("expected: " ++ needle ++ "\n" ++
-                                       " in file: " ++ path)))
+  withFrozenCallStack $
+    liftIO $
+      withFileContents
+        path
+        ( \contents ->
+            when
+              (needle `isInfixOf` contents)
+              ( assertFailure
+                  ( "expected: "
+                      ++ needle
+                      ++ "\n"
+                      ++ " in file: "
+                      ++ path
+                  )
+              )
+        )
 
 -- | Assert that at least one of the given paths contains the given search string.
 assertAnyFileContains :: MonadIO m => WithCallStack ([FilePath] -> String -> m ())
 assertAnyFileContains paths needle = do
-    let findOne found path =
-            if found
-               then pure found
-               else withFileContents path $ \contents ->
-                   pure $! needle `isInfixOf` contents
-    foundNeedle <- liftIO $ foldM findOne False paths
-    withFrozenCallStack $
-      unless foundNeedle $
-        assertFailure $
-          "expected: " <>
-          needle <>
-          "\nin one of:\n" <>
-          unlines (map ("* " <>) paths)
+  let findOne found path =
+        if found
+          then pure found
+          else withFileContents path $ \contents ->
+            pure $! needle `isInfixOf` contents
+  foundNeedle <- liftIO $ foldM findOne False paths
+  withFrozenCallStack $
+    unless foundNeedle $
+      assertFailure $
+        "expected: "
+          <> needle
+          <> "\nin one of:\n"
+          <> unlines (map ("* " <>) paths)
 
 -- | Assert that none of the given paths contains the given search string.
 assertNoFileContains :: MonadIO m => WithCallStack ([FilePath] -> String -> m ())
 assertNoFileContains paths needle =
-    liftIO $
-      forM_ paths $
-        \path ->
-          assertFileDoesNotContain path needle
+  liftIO $
+    forM_ paths $
+      \path ->
+        assertFileDoesNotContain path needle
 
 -- | The directory where script build artifacts are expected to be cached
 getScriptCacheDirectory :: FilePath -> TestM FilePath
 getScriptCacheDirectory script = do
-    cabalDir <- testCabalDir `fmap` getTestEnv
-    hashinput <- liftIO $ canonicalizePath script
-    let hash = C.unpack . Base16.encode . C.take 26 . SHA256.hash . C.pack $ hashinput
-    return $ cabalDir </> "script-builds" </> hash
+  cabalDir <- testCabalDir `fmap` getTestEnv
+  hashinput <- liftIO $ canonicalizePath script
+  let hash = C.unpack . Base16.encode . C.take 26 . SHA256.hash . C.pack $ hashinput
+  return $ cabalDir </> "script-builds" </> hash
 
 ------------------------------------------------------------------------
+
 -- * Globs
 
 -- | Match a glob from a root directory and return the results.
@@ -961,18 +1080,25 @@ assertGlobDoesNotMatchTestDir rootSelector glob = do
   assertGlobDoesNotMatch root glob
 
 ------------------------------------------------------------------------
+
 -- * Skipping tests
 
 testCompilerWithArgs :: [String] -> TestM Bool
 testCompilerWithArgs args = do
-    env <- getTestEnv
-    ghc_path <- programPathM ghcProgram
-    let prof_test_hs = testWorkDir env </> "Prof.hs"
-    liftIO $ writeFile prof_test_hs "module Prof where"
-    r <- liftIO $ run (testVerbosity env) (Just $ testCurrentDir env)
-                      (testEnvironment env) ghc_path (["-c", prof_test_hs] ++ args)
-                      Nothing
-    return (resultExitCode r == ExitSuccess)
+  env <- getTestEnv
+  ghc_path <- programPathM ghcProgram
+  let prof_test_hs = testWorkDir env </> "Prof.hs"
+  liftIO $ writeFile prof_test_hs "module Prof where"
+  r <-
+    liftIO $
+      run
+        (testVerbosity env)
+        (Just $ testCurrentDir env)
+        (testEnvironment env)
+        ghc_path
+        (["-c", prof_test_hs] ++ args)
+        Nothing
+  return (resultExitCode r == ExitSuccess)
 
 hasProfiledLibraries, hasProfiledSharedLibraries, hasSharedLibraries :: TestM Bool
 hasProfiledLibraries = testCompilerWithArgs ["-prof"]
@@ -995,11 +1121,10 @@ hasCabalShared = do
   env <- getTestEnv
   return (testHaveCabalShared env)
 
-
-anyCabalVersion :: WithCallStack ( String -> TestM Bool )
+anyCabalVersion :: WithCallStack (String -> TestM Bool)
 anyCabalVersion = isCabalVersion any
 
-allCabalVersion :: WithCallStack ( String -> TestM Bool )
+allCabalVersion :: WithCallStack (String -> TestM Bool)
 allCabalVersion = isCabalVersion all
 
 -- Used by cabal-install tests to determine which Cabal library versions are
@@ -1012,9 +1137,9 @@ isCabalVersion decide range = do
   cabal_pkgs <- ghcPkg_raw' $ ["--global", "list", "Cabal", "--simple"] ++ ["--package-db=" ++ db | Just dbs <- [testPackageDbPath env], db <- dbs]
   let pkg_versions :: [PackageIdentifier] = mapMaybe simpleParsec (words (resultOutput cabal_pkgs))
   vr <- case eitherParsec range of
-          Left err -> fail err
-          Right vr -> return vr
-  return $ decide (`withinRange` vr)  (map pkgVersion pkg_versions)
+    Left err -> fail err
+    Right vr -> return vr
+  return $ decide (`withinRange` vr) (map pkgVersion pkg_versions)
 
 -- | Skip a test unless any available Cabal library version matches the predicate.
 skipUnlessAnyCabalVersion :: String -> TestM ()
@@ -1034,15 +1159,17 @@ skipIfAllCabalVersion range = skipIf ("incompatible with Cabal " ++ range) =<< a
 
 isGhcVersion :: WithCallStack (String -> TestM Bool)
 isGhcVersion range = do
-    ghc_program <- requireProgramM ghcProgram
-    v <- case programVersion ghc_program of
-        Nothing -> error $ "isGhcVersion: no ghc version for "
-                        ++ show (programLocation ghc_program)
-        Just v -> return v
-    vr <- case eitherParsec range of
-        Left err -> fail err
-        Right vr -> return vr
-    return (v `withinRange` vr)
+  ghc_program <- requireProgramM ghcProgram
+  v <- case programVersion ghc_program of
+    Nothing ->
+      error $
+        "isGhcVersion: no ghc version for "
+          ++ show (programLocation ghc_program)
+    Just v -> return v
+  vr <- case eitherParsec range of
+    Left err -> fail err
+    Right vr -> return vr
+  return (v `withinRange` vr)
 
 skipUnlessGhcVersion :: String -> TestM ()
 skipUnlessGhcVersion range = skipUnless ("needs ghc " ++ range) =<< isGhcVersion range
@@ -1074,8 +1201,9 @@ isLinux = buildOS == Linux
 
 isJavaScript :: Bool
 isJavaScript = buildArch == JavaScript
-  -- should probably be `hostArch` but Cabal doesn't distinguish build platform
-  -- and host platform
+
+-- should probably be `hostArch` but Cabal doesn't distinguish build platform
+-- and host platform
 
 skipIfWindows :: String -> IO ()
 skipIfWindows why = skipIfIO ("Windows " <> why) isWindows
@@ -1084,9 +1212,9 @@ skipIfAlpine :: String -> IO ()
 skipIfAlpine why = do
   mres <- OSR.parseOsRelease
   let b = case mres of
-            Just (OSR.OsReleaseResult { OSR.osRelease = OSR.OsRelease { OSR.id = osId } })
-              | isLinux -> osId == "alpine"
-            _ -> False
+        Just (OSR.OsReleaseResult{OSR.osRelease = OSR.OsRelease{OSR.id = osId}})
+          | isLinux -> osId == "alpine"
+        _ -> False
   skipIfIO ("Alpine " <> why) b
 
 skipUnlessWindows :: IO ()
@@ -1109,34 +1237,34 @@ expectBrokenIfWindows ticket = expectBrokenIf isWindows ticket
 
 expectBrokenIfWindowsCI :: IssueID -> TestM a -> TestM a
 expectBrokenIfWindowsCI ticket m = do
-    ci <- liftIO isCI
-    expectBrokenIf (isWindows && ci) ticket m
+  ci <- liftIO isCI
+  expectBrokenIf (isWindows && ci) ticket m
 
 expectBrokenIfWindowsCIAndGhc :: String -> IssueID -> TestM a -> TestM a
 expectBrokenIfWindowsCIAndGhc range ticket m = do
-    ghcVer <- isGhcVersion range
-    ci <- liftIO isCI
-    expectBrokenIf (isWindows && ghcVer && ci) ticket m
+  ghcVer <- isGhcVersion range
+  ci <- liftIO isCI
+  expectBrokenIf (isWindows && ghcVer && ci) ticket m
 
 expectBrokenIfWindowsAndGhc :: String -> IssueID -> TestM a -> TestM a
 expectBrokenIfWindowsAndGhc range ticket m = do
-    ghcVer <- isGhcVersion range
-    expectBrokenIf (isWindows && ghcVer) ticket m
+  ghcVer <- isGhcVersion range
+  expectBrokenIf (isWindows && ghcVer) ticket m
 
 expectBrokenIfOSXAndGhc :: String -> IssueID -> TestM a -> TestM a
 expectBrokenIfOSXAndGhc range ticket m = do
-    ghcVer <- isGhcVersion range
-    expectBrokenIf (isOSX && ghcVer) ticket m
+  ghcVer <- isGhcVersion range
+  expectBrokenIf (isOSX && ghcVer) ticket m
 
 expectBrokenIfGhc :: String -> IssueID -> TestM a -> TestM a
 expectBrokenIfGhc range ticket m = do
-    ghcVer <- isGhcVersion range
-    expectBrokenIf ghcVer ticket m
+  ghcVer <- isGhcVersion range
+  expectBrokenIf ghcVer ticket m
 
 flakyIfCI :: IssueID -> TestM a -> TestM a
 flakyIfCI ticket m = do
-    ci <- liftIO isCI
-    flakyIf ci ticket m
+  ci <- liftIO isCI
+  flakyIf ci ticket m
 
 flakyIfWindows :: IssueID -> TestM a -> TestM a
 flakyIfWindows ticket m = flakyIf isWindows ticket m
@@ -1164,7 +1292,6 @@ getOpenFilesLimit = liftIO $ do
 -- rather lengthy build process), instead using the boot Cabal if
 -- possible.  But some GHCs don't have a recent enough boot Cabal!
 -- You'll want to exclude them in that case.
---
 hasNewBuildCompatBootCabal :: TestM Bool
 hasNewBuildCompatBootCabal = isGhcVersion ">= 7.9"
 
@@ -1175,81 +1302,80 @@ git cmd args = void $ git' cmd args
 
 git' :: String -> [String] -> TestM Result
 git' cmd args = do
-    recordHeader ["git", cmd]
-    runProgramM gitProgram (cmd : args) Nothing
+  recordHeader ["git", cmd]
+  runProgramM gitProgram (cmd : args) Nothing
 
 gcc :: [String] -> TestM ()
 gcc args = void $ gcc' args
 
 gcc' :: [String] -> TestM Result
 gcc' args = do
-    recordHeader ["gcc"]
-    runProgramM gccProgram args Nothing
+  recordHeader ["gcc"]
+  runProgramM gccProgram args Nothing
 
 ghc :: [String] -> TestM ()
 ghc args = void $ ghc' args
 
 ghc' :: [String] -> TestM Result
 ghc' args = do
-    recordHeader ["ghc"]
-    runProgramM ghcProgram args Nothing
+  recordHeader ["ghc"]
+  runProgramM ghcProgram args Nothing
 
 ghcPkg_raw' :: [String] -> TestM Result
 ghcPkg_raw' args = do
   recordHeader ["ghc-pkg"]
   runProgramM ghcPkgProgram args Nothing
 
-
 python3 :: [String] -> TestM ()
 python3 args = void $ python3' args
 
 python3' :: [String] -> TestM Result
 python3' args = do
-    recordHeader ["python3"]
-    runProgramM python3Program args Nothing
-
+  recordHeader ["python3"]
+  runProgramM python3Program args Nothing
 
 -- | Look up the 'InstalledPackageId' of a package name.
 getIPID :: String -> TestM String
 getIPID pn = do
-    r <- ghcPkg' "field" ["--global", pn, "id"]
-    -- Don't choke on warnings from ghc-pkg
-    case mapMaybe (stripPrefix "id: ") (lines (resultOutput r)) of
-        -- ~/.cabal/store may contain multiple versions of single package
-        -- we pick first one. It should work
-        (x:_) -> return (takeWhile (not . Char.isSpace) x)
-        _     -> error $ "could not determine id of " ++ pn
+  r <- ghcPkg' "field" ["--global", pn, "id"]
+  -- Don't choke on warnings from ghc-pkg
+  case mapMaybe (stripPrefix "id: ") (lines (resultOutput r)) of
+    -- ~/.cabal/store may contain multiple versions of single package
+    -- we pick first one. It should work
+    (x : _) -> return (takeWhile (not . Char.isSpace) x)
+    _ -> error $ "could not determine id of " ++ pn
 
 -- | Delay a sufficient period of time to permit file timestamp
 -- to be updated.
 delay :: TestM ()
 delay = do
-    env <- getTestEnv
-    is_old_ghc <- isGhcVersion "< 7.7"
-    -- For old versions of GHC, we only had second-level precision,
-    -- so we need to sleep a full second.  Newer versions use
-    -- millisecond level precision, so we only have to wait
-    -- the granularity of the underlying filesystem.
-    -- TODO: cite commit when GHC got better precision; this
-    -- version bound was empirically generated.
-    liftIO . threadDelay $
-        if is_old_ghc
-            then 1000000
-            else fromMaybe
-                    (error "Delay must be enclosed by withDelay")
-                    (testMtimeChangeDelay env)
+  env <- getTestEnv
+  is_old_ghc <- isGhcVersion "< 7.7"
+  -- For old versions of GHC, we only had second-level precision,
+  -- so we need to sleep a full second.  Newer versions use
+  -- millisecond level precision, so we only have to wait
+  -- the granularity of the underlying filesystem.
+  -- TODO: cite commit when GHC got better precision; this
+  -- version bound was empirically generated.
+  liftIO . threadDelay $
+    if is_old_ghc
+      then 1000000
+      else
+        fromMaybe
+          (error "Delay must be enclosed by withDelay")
+          (testMtimeChangeDelay env)
 
 -- | Calibrate file modification time delay, if not
 -- already determined.
 withDelay :: TestM a -> TestM a
 withDelay m = do
-    env <- getTestEnv
-    case testMtimeChangeDelay env of
-        Nothing -> do
-            -- Figure out how long we need to delay for recompilation tests
-            (_, mtimeChange) <- liftIO $ calibrateMtimeChangeDelay
-            withReaderT (\nenv -> nenv { testMtimeChangeDelay = Just mtimeChange }) m
-        Just _ -> m
+  env <- getTestEnv
+  case testMtimeChangeDelay env of
+    Nothing -> do
+      -- Figure out how long we need to delay for recompilation tests
+      (_, mtimeChange) <- liftIO $ calibrateMtimeChangeDelay
+      withReaderT (\nenv -> nenv{testMtimeChangeDelay = Just mtimeChange}) m
+    Just _ -> m
 
 -- | Create a symlink for the duration of the provided action. If the symlink
 -- already exists, it is deleted.
@@ -1260,18 +1386,20 @@ withSymlink oldpath newpath0 act = do
   let newpath = testCurrentDir env </> newpath0
   symlinkExists <- liftIO $ doesFileExist newpath
   when symlinkExists $ liftIO $ removeFile newpath
-  bracket_ (liftIO $ createFileLink oldpath newpath)
-           (liftIO $ pure ()) act
+  bracket_
+    (liftIO $ createFileLink oldpath newpath)
+    (liftIO $ pure ())
+    act
 
 writeSourceFile :: FilePath -> String -> TestM ()
 writeSourceFile fp s = do
-    cwd <- fmap testCurrentDir getTestEnv
-    liftIO $ writeFile (cwd </> fp) s
+  cwd <- fmap testCurrentDir getTestEnv
+  liftIO $ writeFile (cwd </> fp) s
 
 copySourceFileTo :: FilePath -> FilePath -> TestM ()
 copySourceFileTo src dest = do
-    cwd <- fmap testCurrentDir getTestEnv
-    liftIO $ copyFile (cwd </> src) (cwd </> dest)
+  cwd <- fmap testCurrentDir getTestEnv
+  liftIO $ copyFile (cwd </> src) (cwd </> dest)
 
 -- | Work around issue #4515 (store paths exceeding the Windows path length
 -- limit) by creating a temporary directory for the new-build store. This
@@ -1283,24 +1411,27 @@ withShorterPathForNewBuildStore test =
 
 -- | Find where a package locates in the store dir. This works only if there is exactly one 1 ghc version
 -- and exactly 1 directory for the given package in the store dir.
-findDependencyInStore :: String -- ^package name prefix
-                      -> TestM FilePath -- ^package dir
+findDependencyInStore
+  :: String
+  -- ^ package name prefix
+  -> TestM FilePath
+  -- ^ package dir
 findDependencyInStore pkgName = do
-    storeDir <- testStoreDir <$> getTestEnv
-    liftIO $ do
-      storeDirForGhcVersion:_ <- listDirectory storeDir
-      packageDirs <- listDirectory (storeDir </> storeDirForGhcVersion)
-      -- Ideally, we should call 'hashedInstalledPackageId' from 'Distribution.Client.PackageHash'.
-      -- But 'PackageHashInputs', especially 'PackageHashConfigInputs', is too hard to construct.
-      let pkgName' =
-              if buildOS == OSX
-              then filter (not . flip elem "aeiou") pkgName
-                  -- simulates the way 'hashedInstalledPackageId' uses to compress package name
-              else pkgName
-      let libDir = case filter (pkgName' `isPrefixOf`) packageDirs of
-                      [] -> error $ "Could not find " <> pkgName' <> " when searching for " <> pkgName' <> " in\n" <> show packageDirs
-                      (dir:_) -> dir
-      pure (storeDir </> storeDirForGhcVersion </> libDir)
+  storeDir <- testStoreDir <$> getTestEnv
+  liftIO $ do
+    storeDirForGhcVersion : _ <- listDirectory storeDir
+    packageDirs <- listDirectory (storeDir </> storeDirForGhcVersion)
+    -- Ideally, we should call 'hashedInstalledPackageId' from 'Distribution.Client.PackageHash'.
+    -- But 'PackageHashInputs', especially 'PackageHashConfigInputs', is too hard to construct.
+    let pkgName' =
+          if buildOS == OSX
+            then filter (not . flip elem "aeiou") pkgName
+            else -- simulates the way 'hashedInstalledPackageId' uses to compress package name
+              pkgName
+    let libDir = case filter (pkgName' `isPrefixOf`) packageDirs of
+          [] -> error $ "Could not find " <> pkgName' <> " when searching for " <> pkgName' <> " in\n" <> show packageDirs
+          (dir : _) -> dir
+    pure (storeDir </> storeDirForGhcVersion </> libDir)
 
 -- | It can be easier to paste expected output verbatim into a text file,
 -- especially if it is a multiline string, rather than encoding it as a multiline

--- a/cabal-testsuite/src/Test/Cabal/Run.hs
+++ b/cabal-testsuite/src/Test/Cabal/Run.hs
@@ -1,116 +1,132 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NondecreasingIndentation #-}
+
 -- | A module for running commands in a chatty way.
-module Test.Cabal.Run (
-    run,
-    runAction,
-    Result(..)
-) where
+module Test.Cabal.Run
+  ( run
+  , runAction
+  , Result (..)
+  ) where
 
 import Distribution.Simple.Program.Run
 import Distribution.Verbosity
 
 import Control.Concurrent.Async
-import System.Process
-import System.IO
-import System.Exit
 import System.Directory
+import System.Exit
 import System.FilePath
+import System.IO
+import System.Process
 
 -- | The result of invoking the command line.
 data Result = Result
-    { resultExitCode    :: ExitCode
-    , resultCommand     :: String
-    , resultOutput      :: String
-    } deriving Show
+  { resultExitCode :: ExitCode
+  , resultCommand :: String
+  , resultOutput :: String
+  }
+  deriving (Show)
 
 -- | Run a command, streaming its output to stdout, and return a 'Result'
 -- with this information.
-run :: Verbosity -> Maybe FilePath -> [(String, Maybe String)] -> FilePath -> [String]
-    -> Maybe String -> IO Result
+run
+  :: Verbosity
+  -> Maybe FilePath
+  -> [(String, Maybe String)]
+  -> FilePath
+  -> [String]
+  -> Maybe String
+  -> IO Result
 run verbosity mb_cwd env_overrides path0 args input =
-    runAction verbosity mb_cwd env_overrides path0 args input (\_ -> return ())
+  runAction verbosity mb_cwd env_overrides path0 args input (\_ -> return ())
 
-runAction :: Verbosity -> Maybe FilePath -> [(String, Maybe String)] -> FilePath -> [String]
-    -> Maybe String -> (ProcessHandle -> IO ()) -> IO Result
+runAction
+  :: Verbosity
+  -> Maybe FilePath
+  -> [(String, Maybe String)]
+  -> FilePath
+  -> [String]
+  -> Maybe String
+  -> (ProcessHandle -> IO ())
+  -> IO Result
 runAction _verbosity mb_cwd env_overrides path0 args input action = do
-    -- In our test runner, we allow a path to be relative to the
-    -- current directory using the same heuristic as shells:
-    -- 'foo' refers to an executable in the PATH, but './foo'
-    -- and 'foo/bar' refer to relative files.
-    --
-    -- Unfortunately, we cannot just pass these relative paths directly:
-    -- 'runProcess' resolves an executable path not with respect to the
-    -- current working directory, but the working directory that the
-    -- subprocess will execute in.  Thus, IF we have a relative
-    -- path which is not a bare executable name, we have to tack on
-    -- the CWD to make it resolve correctly
-    cwdir <- getCurrentDirectory
-    let path | length (splitPath path0) /= 1 && isRelative path0
-             = cwdir </> path0
-             | otherwise
-             = path0
+  -- In our test runner, we allow a path to be relative to the
+  -- current directory using the same heuristic as shells:
+  -- 'foo' refers to an executable in the PATH, but './foo'
+  -- and 'foo/bar' refer to relative files.
+  --
+  -- Unfortunately, we cannot just pass these relative paths directly:
+  -- 'runProcess' resolves an executable path not with respect to the
+  -- current working directory, but the working directory that the
+  -- subprocess will execute in.  Thus, IF we have a relative
+  -- path which is not a bare executable name, we have to tack on
+  -- the CWD to make it resolve correctly
+  cwdir <- getCurrentDirectory
+  let path
+        | length (splitPath path0) /= 1 && isRelative path0 =
+            cwdir </> path0
+        | otherwise =
+            path0
 
-    mb_env <- getEffectiveEnvironment env_overrides
-    putStrLn $ "+ " ++ showCommandForUser path args
-    (readh, writeh) <- createPipe
+  mb_env <- getEffectiveEnvironment env_overrides
+  putStrLn $ "+ " ++ showCommandForUser path args
+  (readh, writeh) <- createPipe
 
-    -- `System.Process.createPipe` calls (through many intermediaries)
-    -- `GHC.IO.Handle.FD.fdToHandle`, whose documentation says:
-    --
-    -- > Makes a binary Handle. This is for historical reasons; it should
-    -- > probably be a text Handle with the default encoding and newline
-    -- > translation instead.
-    --
-    -- The documentation for `System.IO.hSetBinaryMode` says:
-    --
-    -- > This has the same effect as calling `hSetEncoding` with `char8`, together
-    -- > with `hSetNewlineMode` with `noNewlineTranslation`.
-    --
-    -- But this is a lie, and Unicode written to or read from binary handles is
-    -- always encoded or decoded as Latin-1, which is always the wrong choice.
-    --
-    -- Therefore, we explicitly set the output to UTF-8 to keep it consistent
-    -- between platforms and correct on all modern computers.
-    --
-    -- See: https://gitlab.haskell.org/ghc/ghc/-/issues/25307
-    hSetEncoding readh utf8
-    hSetEncoding writeh utf8
+  -- `System.Process.createPipe` calls (through many intermediaries)
+  -- `GHC.IO.Handle.FD.fdToHandle`, whose documentation says:
+  --
+  -- > Makes a binary Handle. This is for historical reasons; it should
+  -- > probably be a text Handle with the default encoding and newline
+  -- > translation instead.
+  --
+  -- The documentation for `System.IO.hSetBinaryMode` says:
+  --
+  -- > This has the same effect as calling `hSetEncoding` with `char8`, together
+  -- > with `hSetNewlineMode` with `noNewlineTranslation`.
+  --
+  -- But this is a lie, and Unicode written to or read from binary handles is
+  -- always encoded or decoded as Latin-1, which is always the wrong choice.
+  --
+  -- Therefore, we explicitly set the output to UTF-8 to keep it consistent
+  -- between platforms and correct on all modern computers.
+  --
+  -- See: https://gitlab.haskell.org/ghc/ghc/-/issues/25307
+  hSetEncoding readh utf8
+  hSetEncoding writeh utf8
 
-    hSetBuffering readh LineBuffering
-    hSetBuffering writeh LineBuffering
-    let drain = do
-            r <- hGetContents readh
-            putStr r -- forces the output
-            hClose readh
-            return r
-    withAsync drain $ \sync -> do
-
-    let prc = (proc path args)
-          { cwd = mb_cwd
-          , env = mb_env
-          , std_in = case input of { Just _ -> CreatePipe; Nothing -> Inherit }
-          , std_out = UseHandle writeh
-          , std_err = UseHandle writeh
-          }
+  hSetBuffering readh LineBuffering
+  hSetBuffering writeh LineBuffering
+  let drain = do
+        r <- hGetContents readh
+        putStr r -- forces the output
+        hClose readh
+        return r
+  withAsync drain $ \sync -> do
+    let prc =
+          (proc path args)
+            { cwd = mb_cwd
+            , env = mb_env
+            , std_in = case input of Just _ -> CreatePipe; Nothing -> Inherit
+            , std_out = UseHandle writeh
+            , std_err = UseHandle writeh
+            }
 
     withCreateProcess prc $ \stdin_h _ _ procHandle -> do
+      case input of
+        Just x ->
+          case stdin_h of
+            Just h -> hPutStr h x >> hClose h
+            Nothing -> error "No stdin handle when input was specified!"
+        Nothing -> return ()
 
-    case input of
-      Just x ->
-        case stdin_h of
-          Just h -> hPutStr h x >> hClose h
-          Nothing -> error "No stdin handle when input was specified!"
-      Nothing -> return ()
+      action procHandle
 
-    action procHandle
+      -- wait for the program to terminate
+      exitcode <- waitForProcess procHandle
+      out <- wait sync
 
-    -- wait for the program to terminate
-    exitcode <- waitForProcess procHandle
-    out <- wait sync
-
-    return Result {
-            resultExitCode = exitcode,
-            resultCommand = showCommandForUser path args,
-            resultOutput = out
-        }
+      return
+        Result
+          { resultExitCode = exitcode
+          , resultCommand = showCommandForUser path args
+          , resultOutput = out
+          }

--- a/cabal-testsuite/src/Test/Cabal/Script.hs
+++ b/cabal-testsuite/src/Test/Cabal/Script.hs
@@ -4,45 +4,43 @@
 
 -- | Functionality for invoking Haskell scripts with the correct
 -- package database setup.
-module Test.Cabal.Script (
-    ScriptEnv(..),
-    mkScriptEnv,
-    runnerGhcArgs,
-    runnerCommand,
-    runghc,
-) where
+module Test.Cabal.Script
+  ( ScriptEnv (..)
+  , mkScriptEnv
+  , runnerGhcArgs
+  , runnerCommand
+  , runghc
+  ) where
 
 import Test.Cabal.Run
 import Test.Cabal.ScriptEnv0
 
 import Distribution.Backpack
+import Distribution.Simple.Compiler
+import Distribution.Simple.Program
+import Distribution.Simple.Program.Builtin
+import Distribution.Simple.Program.GHC
+import Distribution.Simple.Setup (pattern Flag)
+import Distribution.System
 import Distribution.Types.ModuleRenaming
 import Distribution.Utils.NubList
 import Distribution.Utils.Path
-import Distribution.Simple.Program.Db
-import Distribution.Simple.Program.Builtin
-import Distribution.Simple.Program.GHC
-import Distribution.Simple.Program
-import Distribution.Simple.Compiler
 import Distribution.Verbosity
-import Distribution.System
-import Distribution.Simple.Setup (pattern Flag)
 
 import qualified Data.Monoid as M
-
 
 -- | The runner environment, which contains all of the important
 -- parameters for invoking GHC.  Mostly subset of 'LocalBuildInfo'.
 data ScriptEnv = ScriptEnv
-        { runnerProgramDb       :: ProgramDb
-        , runnerPackageDbStack  :: PackageDBStackCWD
-        , runnerVerbosity       :: Verbosity
-        , runnerPlatform        :: Platform
-        , runnerCompiler        :: Compiler
-        , runnerPackages        :: [(OpenUnitId, ModuleRenaming)]
-        , runnerWithSharedLib   :: Bool
-        }
-    deriving Show
+  { runnerProgramDb :: ProgramDb
+  , runnerPackageDbStack :: PackageDBStackCWD
+  , runnerVerbosity :: Verbosity
+  , runnerPlatform :: Platform
+  , runnerCompiler :: Compiler
+  , runnerPackages :: [(OpenUnitId, ModuleRenaming)]
+  , runnerWithSharedLib :: Bool
+  }
+  deriving (Show)
 
 {-
 
@@ -59,34 +57,46 @@ canonicalizePackageDB x = return x
 -- the GHC that we want to use.
 mkScriptEnv :: Verbosity -> IO ScriptEnv
 mkScriptEnv verbosity =
-  return $ ScriptEnv
-    { runnerVerbosity       = verbosity
-    , runnerProgramDb       = lbiProgramDb
-    , runnerPackageDbStack  = lbiPackageDbStack
-    , runnerPlatform        = lbiPlatform
-    , runnerCompiler        = lbiCompiler
-    -- NB: the set of packages available to test.hs scripts will COINCIDE
-    -- with the dependencies on the cabal-testsuite library
-    , runnerPackages        = lbiPackages
-    , runnerWithSharedLib   = lbiWithSharedLib
-    }
+  return $
+    ScriptEnv
+      { runnerVerbosity = verbosity
+      , runnerProgramDb = lbiProgramDb
+      , runnerPackageDbStack = lbiPackageDbStack
+      , runnerPlatform = lbiPlatform
+      , runnerCompiler = lbiCompiler
+      , -- NB: the set of packages available to test.hs scripts will COINCIDE
+        -- with the dependencies on the cabal-testsuite library
+        runnerPackages = lbiPackages
+      , runnerWithSharedLib = lbiWithSharedLib
+      }
 
 -- | Run a script with 'runghc', under the 'ScriptEnv'.
-runghc :: ScriptEnv -> Maybe FilePath -> [(String, Maybe String)]
-       -> FilePath -> [String] -> IO Result
+runghc
+  :: ScriptEnv
+  -> Maybe FilePath
+  -> [(String, Maybe String)]
+  -> FilePath
+  -> [String]
+  -> IO Result
 runghc senv mb_cwd env_overrides script_path args = do
-    (real_path, real_args) <- runnerCommand senv mb_cwd env_overrides script_path args
-    run (runnerVerbosity senv) mb_cwd env_overrides real_path real_args Nothing
+  (real_path, real_args) <- runnerCommand senv mb_cwd env_overrides script_path args
+  run (runnerVerbosity senv) mb_cwd env_overrides real_path real_args Nothing
 
 -- | Compute the command line which should be used to run a Haskell
 -- script with 'runghc'.
-runnerCommand :: ScriptEnv -> Maybe FilePath -> [(String, Maybe String)]
-              -> FilePath -> [String] -> IO (FilePath, [String])
+runnerCommand
+  :: ScriptEnv
+  -> Maybe FilePath
+  -> [(String, Maybe String)]
+  -> FilePath
+  -> [String]
+  -> IO (FilePath, [String])
 runnerCommand senv mb_cwd _env_overrides script_path args = do
-    (prog, _) <- requireProgram verbosity runghcProgram (runnerProgramDb senv)
-    return $
-      (programPath prog,
-        runghc_args ++ ["--"] ++ map ("--ghc-arg="++) ghc_args ++ [script_path] ++ args)
+  (prog, _) <- requireProgram verbosity runghcProgram (runnerProgramDb senv)
+  return $
+    ( programPath prog
+    , runghc_args ++ ["--"] ++ map ("--ghc-arg=" ++) ghc_args ++ [script_path] ++ args
+    )
   where
     verbosity = runnerVerbosity senv
     runghc_args = []
@@ -97,18 +107,20 @@ runnerGhcArgs :: ScriptEnv -> Maybe FilePath -> [String]
 runnerGhcArgs senv mb_cwd =
   renderGhcOptions (runnerCompiler senv) (runnerPlatform senv) ghc_options
   where
-    ghc_options = M.mempty { ghcOptPackageDBs = fmap (fmap makeSymbolicPath) (runnerPackageDbStack senv)
-                           , ghcOptPackages   = toNubListR (runnerPackages senv)
-                           , ghcOptHideAllPackages = Flag True
-                           -- Avoid picking stray module files that look
-                           -- like our imports...
-                           , ghcOptSourcePathClear = Flag True
-                           -- ... yet retain the current directory as an included
-                           -- directory, e.g. so that we can compile a Setup.hs
-                           -- script which imports a locally defined module.
-                           -- See the PackageTests/SetupDep test.
-                           , ghcOptSourcePath = toNubListR $
-                              case mb_cwd of
-                                Nothing -> []
-                                Just {} -> [sameDirectory]
-                            }
+    ghc_options =
+      M.mempty
+        { ghcOptPackageDBs = fmap (fmap makeSymbolicPath) (runnerPackageDbStack senv)
+        , ghcOptPackages = toNubListR (runnerPackages senv)
+        , ghcOptHideAllPackages = Flag True
+        , -- Avoid picking stray module files that look
+          -- like our imports...
+          ghcOptSourcePathClear = Flag True
+        , -- ... yet retain the current directory as an included
+          -- directory, e.g. so that we can compile a Setup.hs
+          -- script which imports a locally defined module.
+          -- See the PackageTests/SetupDep test.
+          ghcOptSourcePath = toNubListR $
+            case mb_cwd of
+              Nothing -> []
+              Just{} -> [sameDirectory]
+        }

--- a/cabal-testsuite/src/Test/Cabal/TestCode.hs
+++ b/cabal-testsuite/src/Test/Cabal/TestCode.hs
@@ -3,16 +3,16 @@
 
 -- | Exception type like 'ExitCode' but with more information
 -- than just integer.
-module Test.Cabal.TestCode (
-    -- * TestCode
-    TestCode (..),
-    FlakyStatus (..),
-    IssueID (..),
-    displayTestCode,
-    isTestCodeSkip,
-    isTestCodeFlaky,
-    isTestCodeUnexpectedSuccess,
-) where
+module Test.Cabal.TestCode
+  ( -- * TestCode
+    TestCode (..)
+  , FlakyStatus (..)
+  , IssueID (..)
+  , displayTestCode
+  , isTestCodeSkip
+  , isTestCodeFlaky
+  , isTestCodeUnexpectedSuccess
+  ) where
 
 import Control.Exception (Exception (..))
 
@@ -21,31 +21,30 @@ import Control.Exception (Exception (..))
 -------------------------------------------------------------------------------
 
 data TestCode
-    = TestCodeOk
-    | TestCodeSkip String
-    | TestCodeKnownFail IssueID
-    | TestCodeUnexpectedOk IssueID
-    | TestCodeFail
-    | TestCodeFlakyFailed IssueID
-    | TestCodeFlakyPassed IssueID
+  = TestCodeOk
+  | TestCodeSkip String
+  | TestCodeKnownFail IssueID
+  | TestCodeUnexpectedOk IssueID
+  | TestCodeFail
+  | TestCodeFlakyFailed IssueID
+  | TestCodeFlakyPassed IssueID
   deriving (Eq, Show, Read)
 
-instance Exception TestCode
-  where
-    displayException = displayTestCode
+instance Exception TestCode where
+  displayException = displayTestCode
 
 displayTestCode :: TestCode -> String
-displayTestCode TestCodeOk               = "OK"
-displayTestCode (TestCodeSkip msg)       = "SKIP " ++ msg
-displayTestCode (TestCodeKnownFail t)    = "OK (known failure, see #" <> show t <> ")"
+displayTestCode TestCodeOk = "OK"
+displayTestCode (TestCodeSkip msg) = "SKIP " ++ msg
+displayTestCode (TestCodeKnownFail t) = "OK (known failure, see #" <> show t <> ")"
 displayTestCode (TestCodeUnexpectedOk t) = "FAIL (unexpected success, see #" <> show t <> ")"
-displayTestCode TestCodeFail             = "FAIL"
-displayTestCode (TestCodeFlakyFailed t)  = "FLAKY (FAIL, see #" <> show t <> ")"
-displayTestCode (TestCodeFlakyPassed t)  = "FLAKY (OK, see #" <> show t <> ")"
+displayTestCode TestCodeFail = "FAIL"
+displayTestCode (TestCodeFlakyFailed t) = "FLAKY (FAIL, see #" <> show t <> ")"
+displayTestCode (TestCodeFlakyPassed t) = "FLAKY (OK, see #" <> show t <> ")"
 
 isTestCodeSkip :: TestCode -> Bool
 isTestCodeSkip (TestCodeSkip _) = True
-isTestCodeSkip _                = False
+isTestCodeSkip _ = False
 
 type TestPassed = Bool
 
@@ -59,8 +58,8 @@ data FlakyStatus
 isTestCodeFlaky :: TestCode -> FlakyStatus
 isTestCodeFlaky (TestCodeFlakyPassed t) = Flaky True t
 isTestCodeFlaky (TestCodeFlakyFailed t) = Flaky False t
-isTestCodeFlaky _                       = NotFlaky
+isTestCodeFlaky _ = NotFlaky
 
 isTestCodeUnexpectedSuccess :: TestCode -> Maybe IssueID
 isTestCodeUnexpectedSuccess (TestCodeUnexpectedOk t) = Just t
-isTestCodeUnexpectedSuccess _                        = Nothing
+isTestCodeUnexpectedSuccess _ = Nothing

--- a/cabal-testsuite/src/Test/Cabal/Workdir.hs
+++ b/cabal-testsuite/src/Test/Cabal/Workdir.hs
@@ -3,19 +3,19 @@
 -- | Functions for interrogating the current working directory
 module Test.Cabal.Workdir where
 
-import Distribution.Simple.Setup
 import Distribution.Simple.Configure
+import Distribution.Simple.Setup
 import Distribution.Utils.Path
-  ( FileOrDir(..)
+  ( Dist
+  , FileOrDir (..)
   , Pkg
-  , Dist
   , SymbolicPath
-  , makeSymbolicPath
   , getSymbolicPath
+  , makeSymbolicPath
   )
 
 import System.Directory
-import System.Environment ( getExecutablePath )
+import System.Environment (getExecutablePath)
 import System.FilePath
 
 -- | Guess what the dist directory of a running executable is,
@@ -24,10 +24,10 @@ import System.FilePath
 -- if the executable has been installed somewhere else.
 guessDistDir :: IO (SymbolicPath Pkg (Dir Dist))
 guessDistDir = do
-    exe_path <- canonicalizePath =<< getExecutablePath
-    let dist0 = dropFileName exe_path </> ".." </> ".."
-    b <- doesFileExist (dist0 </> "setup-config")
-    if b
+  exe_path <- canonicalizePath =<< getExecutablePath
+  let dist0 = dropFileName exe_path </> ".." </> ".."
+  b <- doesFileExist (dist0 </> "setup-config")
+  if b
     then do
       cwd <- getCurrentDirectory
       dist1 <- canonicalizePath dist0


### PR DESCRIPTION
See #8936. Include `cabal-testsuite/src` for fourmolu formatting.

I was looking at `cabal-testsuite/PackageTests/MultiRepl/CustomSetupKeepTempFiles/cabal.test.hs`. It uses `cabalWithStdin` that has no documentation. It took me a while to see what was going on with this function.

https://github.com/haskell/cabal/blob/8e8a8395f7d8623f73dd7df28acfd019d252ebdc/cabal-testsuite/src/Test/Cabal/Prelude.hs#L310-L311

Before adding some haddocks to this function, I checked to see if this file was formatted by fourmolu and it is not.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
