### PR TITLE
Make Distribution.Compat.Environment.setEnv reuse System.Environment.Blank.setEnv

### DIFF
--- a/Cabal/src/Distribution/Compat/Environment.hs
+++ b/Cabal/src/Distribution/Compat/Environment.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
 {-# OPTIONS_HADDOCK hide #-}
 
 module Distribution.Compat.Environment (getEnvironment, lookupEnv, setEnv, unsetEnv)
@@ -9,22 +6,10 @@ where
 
 import Distribution.Compat.Prelude
 import Prelude ()
-import qualified Prelude
 
 import System.Environment (lookupEnv, unsetEnv)
 import qualified System.Environment as System
-
-import Distribution.Compat.Stack
-
-#ifdef mingw32_HOST_OS
-import Foreign.C
-import GHC.Windows
-#else
-import Foreign.C.Types
-import Foreign.C.String
-import Foreign.C.Error (throwErrnoIfMinus1_)
-import System.Posix.Internals ( withFilePath )
-#endif /* mingw32_HOST_OS */
+import qualified System.Environment.Blank as Blank (setEnv)
 
 getEnvironment :: IO [(String, String)]
 #ifdef mingw32_HOST_OS
@@ -40,40 +25,5 @@ getEnvironment = System.getEnvironment
 #endif
 
 -- | @setEnv name value@ sets the specified environment variable to @value@.
---
--- Throws `Control.Exception.IOException` if either @name@ or @value@ is the
--- empty string or contains an equals sign.
 setEnv :: String -> String -> IO ()
-setEnv key value_ = setEnv_ key value
-  where
-    -- NOTE: Anything that follows NUL is ignored on both POSIX and Windows. We
-    -- still strip it manually so that the null check above succeeds if a value
-    -- starts with NUL.
-    value = takeWhile (/= '\NUL') value_
-
-setEnv_ :: String -> String -> IO ()
-
-#ifdef mingw32_HOST_OS
-
-setEnv_ key value = withCWString key $ \k -> withCWString value $ \v -> do
-  success <- c_SetEnvironmentVariable k v
-  unless success (throwGetLastError "setEnv")
- where
-  _ = callStack -- TODO: attach CallStack to exception
-
-{- FOURMOLU_DISABLE -}
-foreign import capi unsafe "windows.h SetEnvironmentVariableW"
-  c_SetEnvironmentVariable :: LPTSTR -> LPTSTR -> Prelude.IO Bool
-#else
-setEnv_ key value = do
-  withFilePath key $ \ keyP ->
-    withFilePath value $ \ valueP ->
-      throwErrnoIfMinus1_ "setenv" $
-        c_setenv keyP valueP (fromIntegral (fromEnum True))
- where
-  _ = callStack -- TODO: attach CallStack to exception
-
-foreign import capi unsafe "setenv"
-   c_setenv :: CString -> CString -> CInt -> Prelude.IO CInt
-#endif /* mingw32_HOST_OS */
-{- FOURMOLU_ENABLE -}
+setEnv key value = Blank.setEnv key value True


### PR DESCRIPTION
`Distribution.Compat.Environment.setEnv` was originally introduced in c70913b6e953d649cbf9e58cd7ae73df6056eb69 (PR #1122, year 2012), because it was not yet in `base` at that time. But now `setEnv` is available for all supported versions of `base`.

More precisely, nowadays there are two `setEnv` in `base`: in `System.Environment` and in `System.Environment.Blank`. The difference is in their behaviour on empty values: the former acts as `unsetEnv` and the latter just assigns an empty string. Although I doubt it matters for Cabal purposes, since 56b7eb7acedb8ddd01a31c89ca342ffffedc302b our implementation matches `System.Environment.Blank.setEnv`.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
