### PR TITLE
Make sure that cabal-install honours --with-ghc-pkg option

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -280,25 +280,6 @@ compilerProgramDb
   -- ^ user-specified @ghc-pkg@ path (optional)
   -> IO ProgramDb
 compilerProgramDb verbosity comp progdb1 hcPkgPath = do
-  let
-    ghcProg = fromJust $ lookupProgram ghcProgram progdb1
-    ghcVersion = compilerVersion comp
-
-  -- This is slightly tricky, we have to configure ghc first, then we use the
-  -- location of ghc to help find ghc-pkg in the case that the user did not
-  -- specify the location of ghc-pkg directly:
-  (ghcPkgProg, ghcPkgVersion, progdb2) <-
-    requireProgramVersion
-      verbosity
-      ghcPkgProgram
-        { programFindLocation = guessGhcPkgFromGhcPath ghcProg
-        }
-      anyVersion
-      (userMaybeSpecifyPath "ghc-pkg" hcPkgPath progdb1)
-
-  when (ghcVersion /= ghcPkgVersion) $
-    dieWithException verbosity $
-      VersionMismatchGHC (programPath ghcProg) ghcVersion (programPath ghcPkgProg) ghcPkgVersion
   -- Likewise we try to find the matching hsc2hs and haddock programs.
   let hsc2hsProgram' =
         hsc2hsProgram
@@ -316,20 +297,49 @@ compilerProgramDb verbosity comp progdb1 hcPkgPath = do
         runghcProgram
           { programFindLocation = guessRunghcFromGhcPath ghcProg
           }
-      progdb3 =
-        addKnownProgram haddockProgram' $
-          addKnownProgram hsc2hsProgram' $
-            addKnownProgram hpcProgram' $
-              addKnownProgram runghcProgram' progdb2
+      ghcPkgProgram' =
+        ghcPkgProgram
+          { programFindLocation = guessGhcPkgFromGhcPath ghcProg
+          }
+      progdb2 =
+        -- The knownPrograms are populated before userMaybeSpecifyPath
+        -- in the case that ProgramDb has been restored from a cache and is empty
+        -- See #11373 for where this went wrong before
+        userMaybeSpecifyPath "ghc-pkg" hcPkgPath $
+          addKnownProgram haddockProgram' $
+            addKnownProgram hsc2hsProgram' $
+              addKnownProgram hpcProgram' $
+                addKnownProgram runghcProgram' $
+                  addKnownProgram
+                    ghcPkgProgram'
+                    progdb1
+
+      ghcProg = fromJust $ lookupProgram ghcProgram progdb1
+      ghcVersion = compilerVersion comp
 
       -- configure gcc, ld, ar etc... based on the paths stored
       -- in the GHC settings file
-      progdb4 =
+      progdb3 =
         Internal.configureToolchain
           (ghcVersionImplInfo ghcVersion)
           ghcProg
           (compilerProperties comp)
-          progdb3
+          progdb2
+
+  -- This is slightly tricky, we have to configure ghc first, then we use the
+  -- location of ghc to help find ghc-pkg in the case that the user did not
+  -- specify the location of ghc-pkg directly:
+  (ghcPkgProg, ghcPkgVersion, progdb4) <-
+    requireProgramVersion
+      verbosity
+      ghcPkgProgram'
+      anyVersion
+      progdb3
+
+  when (ghcVersion /= ghcPkgVersion) $
+    dieWithException verbosity $
+      VersionMismatchGHC (programPath ghcProg) ghcVersion (programPath ghcPkgProg) ghcPkgVersion
+
   return progdb4
 
 -- | Given something like /usr/local/bin/ghc-6.6.1(.exe) we try and find

--- a/cabal-testsuite/PackageTests/WithGhcPkg/app/Main.hs
+++ b/cabal-testsuite/PackageTests/WithGhcPkg/app/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "with-ghc-pkg test"

--- a/cabal-testsuite/PackageTests/WithGhcPkg/cabal.out
+++ b/cabal-testsuite/PackageTests/WithGhcPkg/cabal.out
@@ -1,0 +1,13 @@
+# cabal v2-build
+Warning: cannot determine version of <ROOT>/fake-ghc-pkg-bin/ghc-pkg :
+""
+Error: [Cabal-1008]
+The program 'ghc-pkg' is required but the version of <ROOT>/fake-ghc-pkg-bin/ghc-pkg could not be determined.
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - with-ghc-pkg-0.1.0.0 (exe:with-ghc-pkg) (first run)
+Configuring executable 'with-ghc-pkg' for with-ghc-pkg-0.1.0.0...
+Preprocessing executable 'with-ghc-pkg' for with-ghc-pkg-0.1.0.0...
+Building executable 'with-ghc-pkg' for with-ghc-pkg-0.1.0.0...

--- a/cabal-testsuite/PackageTests/WithGhcPkg/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/WithGhcPkg/cabal.test.hs
@@ -1,0 +1,31 @@
+import Test.Cabal.Prelude
+import System.FilePath ((</>))
+import System.Directory (createDirectoryIfMissing, getPermissions, setPermissions, Permissions(..))
+
+main :: IO ()
+main = do
+    skipIfWindows "relies on a POSIX shell script"
+    cabalTest $ do
+        env <- getTestEnv
+        let fakeDir = testTmpDir env </> "fake-ghc-pkg-bin"
+        liftIO $ createDirectoryIfMissing True fakeDir
+        let fakeGhcPkg = fakeDir </> "ghc-pkg"
+            fakeGhc    = fakeDir </> "ghc"
+        realGhcPkg <- programPathM ghcPkgProgram
+        realGhc    <- programPathM ghcProgram
+
+        liftIO $ do
+            writeFile fakeGhcPkg "#!/bin/sh\n\necho \"fake ghc-pkg\" >&2\nexit 1\n"
+            perms <- getPermissions fakeGhcPkg
+            setPermissions fakeGhcPkg perms { executable = True }
+            writeFile fakeGhc $ "#!/bin/sh\nexec \"" ++ realGhc ++ "\" \"$@\"\n"
+            ghcPerms <- getPermissions fakeGhc
+            setPermissions fakeGhc ghcPerms { executable = True }
+
+        -- Passing -w makes GHC look for ghc-pkg in the fake directory alongside the ghc wrapper.
+        -- The wrapper fails.
+        fails $ cabal "v2-build" ["-w", fakeGhc, "all"]
+
+        -- Adding --with-hc-pkg must override that lookup and use the real
+        -- tool even though the configured compiler still lives in fakeDir.
+        cabal "v2-build" ["-w", fakeGhc, "--with-hc-pkg", realGhcPkg, "all"]

--- a/cabal-testsuite/PackageTests/WithGhcPkg/with-ghc-pkg.cabal
+++ b/cabal-testsuite/PackageTests/WithGhcPkg/with-ghc-pkg.cabal
@@ -1,0 +1,10 @@
+cabal-version:      3.0
+name:               with-ghc-pkg
+version:            0.1.0.0
+build-type:         Simple
+
+executable with-ghc-pkg
+  main-is:          Main.hs
+  hs-source-dirs:   app
+  build-depends:    base >=4.13 && <5
+  default-language: Haskell2010

--- a/changelog.d/with-ghc-pkg.md
+++ b/changelog.d/with-ghc-pkg.md
@@ -1,0 +1,9 @@
+---
+synopsis: Honour `--with-ghc-pkg` when supplied by the user
+packages: [cabal-install]
+prs: [11450]
+issues: [11373]
+---
+
+`cabal-install` now properly honours when a user supplies `--with-ghc-pkg`.
+


### PR DESCRIPTION
The cause of this bug was when ProgramDb is serialised (by caching), the `UnconfiguredPrograms` are discarded. `cabal-install` resolves this by adding back the relevant `UnconfiguredPrograms` in `compilerProgramDb`.

The cause of the bug was the order programs were added back. I have clarified the logic of the function now to:

1. Add back all unconfigured programs, and handle an explicit ghc-pkg path.
2. Then configure ghc-pkg and check it's the right version.

This makes sure that the user-supplied path is honoured in both situations.

Fixes #11373

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
