### PR TITLE
Default package name and all targets for REPL

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | cabal-install CLI command: repl
@@ -63,6 +64,7 @@ import Distribution.Client.ProjectPlanning.Types
 import Distribution.Client.ScriptUtils
   ( AcceptNoTargets (..)
   , TargetContext (..)
+  , TargetsAction
   , fakeProjectSourcePackage
   , lSrcpkgDescription
   , updateContextAndWriteProjectFile
@@ -113,6 +115,7 @@ import Distribution.Simple.Setup
 import Distribution.Simple.Utils
   ( debugNoWrap
   , dieWithException
+  , notice
   , withTempDirectoryEx
   , wrapText
   )
@@ -274,6 +277,16 @@ multiReplDecision ctx compiler flags =
     -- a repl specific option.
     (fromFlagOrDefault False (projectConfigMultiRepl ctx <> replUseMulti flags))
 
+-- | A function that resolves targets within a project context. The input target
+-- selectors may be empty with a project in which case a default target is
+-- chosen. The input target selectors must be empty with a global context that
+-- will construct a fake package target. For a script context, the input target
+-- selectors must contain only one element.
+type TargetResolver = ProjectBaseContext -> [TargetSelector] -> IO ResolvedTargets
+
+-- | Targets resolved from target strings with context and multi-repl flag.
+type ResolvedTargets = ((ProjectBaseContext, Bool), [TargetSelector])
+
 -- | The @repl@ command is very much like @build@. It brings the install plan
 -- up to date, selects that part of the plan needed by the given or implicit
 -- repl target and then executes the plan.
@@ -285,75 +298,115 @@ multiReplDecision ctx compiler flags =
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 replAction :: NixStyleFlags ReplFlags -> [String] -> GlobalFlags -> IO ()
-replAction flags@NixStyleFlags{extraFlags = replFlags@ReplFlags{..}, configFlags} targetStrings globalFlags = do
-  withCtx verbosity targetStrings $ \targetCtx ctx userTargetSelectors -> do
+replAction flags targetStrings globalFlags =
+  withCtx flags targetStrings globalFlags $ \targetCtx ctx selectors -> do
     when (buildSettingOnlyDeps (buildSettings ctx)) $
-      dieWithException verbosity ReplCommandDoesn'tSupport
-    let projectRoot = distProjectRootDirectory $ distDirLayout ctx
-        distDir = distDirectory $ distDirLayout ctx
+      dieWithException (cfgVerbosity normal flags) ReplCommandDoesn'tSupport
+    let resolveTarget = case targetCtx of
+          ProjectContext -> resolveProjectTarget
+          GlobalContext -> resolveGlobalTarget
+          ScriptContext path exe -> resolveScriptTarget path exe
+    resolvedTargets <- resolveTarget flags targetStrings ctx selectors
+    targetedRepl flags targetCtx ctx resolvedTargets
 
-    -- After the user selectors have been resolved, and it's decided what context
-    -- we're in, implement repl-specific behaviour.
-    (baseCtx, targetSelectors) <- case targetCtx of
-      -- If in the project context, and no selectors are provided
-      -- then produce an error.
-      ProjectContext -> do
-        let projectFile = projectConfigProjectFile . projectConfigShared $ projectConfig ctx
-        let pkgs = projectPackages $ projectConfig ctx
-        case userTargetSelectors of
-          [] ->
-            dieWithException verbosity $
-              RenderReplTargetProblem [render (reportProjectNoTarget projectFile pkgs)]
-          _ -> return (ctx, userTargetSelectors)
-      -- In the global context, construct a fake package which can be used to start
-      -- a repl with extra arguments if `-b` is given.
-      GlobalContext -> do
-        unless (null userTargetSelectors) $
-          dieWithException verbosity $
-            ReplTakesNoArguments targetStrings
-        let
-          sourcePackage =
-            fakeProjectSourcePackage projectRoot
-              & ( (lSrcpkgDescription . L.condLibrary)
-                    ?~ (CondNode library [baseDep] [])
-                )
-          library = emptyLibrary{libBuildInfo = lBuildInfo}
-          lBuildInfo =
-            emptyBuildInfo
-              { targetBuildDepends = [baseDep] ++ envPackages replEnvFlags
-              , defaultLanguage = Just Haskell2010
-              }
-          baseDep = Dependency "base" anyVersion mainLibSet
+resolveProjectTarget :: NixStyleFlags ReplFlags -> [String] -> TargetResolver
+resolveProjectTarget flags@NixStyleFlags{extraFlags = ReplFlags{..}} targetStrings ctx userTargetSelectors = do
+  case userTargetSelectors of
+    [] -> do
+      -- If in the project context with no selectors then for a target we:
+      -- 1. pick the only package in the project
+      -- 2. pick 'all' if multiple packages and multi-repl is enabled
+      --
+      -- We could have picked 'all' even for a single package project with
+      -- multi-repl but that is not as specific.
+      let projectFile = projectConfigProjectFile . projectConfigShared $ projectConfig ctx
+      let pkgs = projectPackages $ projectConfig ctx
+      case pkgs of
+        [pkg] | pkg `notElem` targetStrings -> do
+          retargetNotice ("package '" ++ pkg ++ "'")
+          return (ctxMulti, [TargetPackageNamed (mkPackageName pkg) Nothing])
+        _ ->
+          if isMulti && not (null pkgs)
+            then do
+              retargetNotice "'all'"
+              return (ctxMulti, [TargetAllPackages Nothing])
+            else
+              dieWithException verbosity $
+                RenderReplTargetProblem [render (reportProjectNoTarget projectFile pkgs)]
+    _ -> return (ctxMulti, userTargetSelectors)
+  where
+    verbosity = cfgVerbosity normal flags
+    ctxMulti@(_, isMulti) = (ctx, isMultiReplEnabled replUseMulti ctx)
+    retargetNotice newTarget =
+      notice verbosity $
+        "No target specified, using " ++ newTarget ++ " as the target for the REPL."
 
-        -- Write the fake package
-        updatedCtx <- updateContextAndWriteProjectFile' ctx sourcePackage
-        -- Specify the selector for this package
-        let fakeSelector = TargetPackage TargetExplicitNamed [fakePackageId] Nothing
-        return (updatedCtx, [fakeSelector])
+resolveGlobalTarget :: NixStyleFlags ReplFlags -> [String] -> TargetResolver
+resolveGlobalTarget flags@NixStyleFlags{extraFlags = ReplFlags{..}} targetStrings ctx userTargetSelectors = do
+  let projectRoot = distProjectRootDirectory $ distDirLayout ctx
 
-      -- For the script context, no special behaviour.
-      ScriptContext scriptPath scriptExecutable -> do
-        unless (length targetStrings == 1) $
-          dieWithException verbosity $
-            ReplTakesSingleArgument targetStrings
-        existsScriptPath <- doesFileExist scriptPath
-        unless existsScriptPath $
-          dieWithException verbosity $
-            ReplTakesSingleArgument targetStrings
+  -- In the global context, construct a fake package which can be used to start
+  -- a repl with extra arguments if `-b` is given.
+  do
+    unless (null userTargetSelectors) $
+      dieWithException (cfgVerbosity normal flags) $
+        ReplTakesNoArguments targetStrings
+    let
+      sourcePackage =
+        fakeProjectSourcePackage projectRoot
+          & ( (lSrcpkgDescription . L.condLibrary)
+                ?~ (CondNode library [baseDep] [])
+            )
+      library = emptyLibrary{libBuildInfo = lBuildInfo}
+      lBuildInfo =
+        emptyBuildInfo
+          { targetBuildDepends = [baseDep] ++ envPackages replEnvFlags
+          , defaultLanguage = Just Haskell2010
+          }
+      baseDep = Dependency "base" anyVersion mainLibSet
 
-        updatedCtx <- updateContextAndWriteProjectFile ctx scriptPath scriptExecutable
-        return (updatedCtx, userTargetSelectors)
+    -- Write the fake package
+    updatedCtx <- updateContextAndWriteProjectFile' ctx sourcePackage
+    -- Specify the selector for this package
+    let fakeSelector = TargetPackage TargetExplicitNamed [fakePackageId] Nothing
+    return ((updatedCtx, isMultiReplEnabled replUseMulti updatedCtx), [fakeSelector])
 
-    -- If multi-repl is used, we need a Cabal recent enough to handle it.
-    -- We need to do this before solving, but the compiler version is only known
-    -- after solving (phaseConfigureCompiler), so instead of using
-    -- multiReplDecision we just check the flag.
-    let multiReplEnabled =
-          fromFlagOrDefault False $
-            projectConfigMultiRepl (projectConfigShared $ projectConfig baseCtx)
-              <> replUseMulti
+resolveScriptTarget :: FilePath -> L.Executable -> NixStyleFlags ReplFlags -> [String] -> TargetResolver
+resolveScriptTarget scriptPath scriptExecutable flags@NixStyleFlags{extraFlags = ReplFlags{..}} targetStrings ctx userTargetSelectors = do
+  -- For the script context, no special behaviour.
+  do
+    unless (length targetStrings == 1) $
+      dieWithException verbosity $
+        ReplTakesSingleArgument targetStrings
+    existsScriptPath <- doesFileExist scriptPath
+    unless existsScriptPath $
+      dieWithException verbosity $
+        ReplTakesSingleArgument targetStrings
 
-        withReplEnabled =
+    updatedCtx <- updateContextAndWriteProjectFile ctx scriptPath scriptExecutable
+    return ((updatedCtx, isMultiReplEnabled replUseMulti updatedCtx), userTargetSelectors)
+  where
+    verbosity = cfgVerbosity normal flags
+
+-- If multi-repl is used, we need a Cabal recent enough to handle it.  We need
+-- to do this before solving, but the compiler version is only known after
+-- solving (phaseConfigureCompiler), so instead of using multiReplDecision we
+-- just check the flag.
+isMultiReplEnabled :: Flag Bool -> ProjectBaseContext -> Bool
+isMultiReplEnabled replUseMulti ctx =
+  fromFlagOrDefault False $
+    projectConfigMultiRepl (projectConfigShared $ projectConfig ctx)
+      <> replUseMulti
+
+-- | Bring up a REPL with the targets.  With resolved user selectors and
+-- context, adjust the REPL behaviour for the target.
+targetedRepl :: NixStyleFlags ReplFlags -> TargetsAction ResolvedTargets ()
+targetedRepl
+  flags@NixStyleFlags{extraFlags = replFlags@ReplFlags{..}, configFlags}
+  targetCtx
+  ctx
+  ((baseCtx, multiReplEnabled), targetSelectors) = do
+    let withReplEnabled =
           isJust $ flagToMaybe $ replWithRepl configureReplOptions
 
         addConstraintWhen cond constraint base_ctx =
@@ -413,10 +466,15 @@ replAction flags@NixStyleFlags{extraFlags = replFlags@ReplFlags{..}, configFlags
 
         let
           elaboratedPlan' =
-            pruneInstallPlanToTargets
-              TargetActionRepl
-              targets
-              elaboratedPlan
+            -- Guard against pruning with empty targets and failing an assertion
+            -- within pruneInstallPlanToTargets.
+            if null targets
+              then elaboratedPlan
+              else
+                pruneInstallPlanToTargets
+                  TargetActionRepl
+                  targets
+                  elaboratedPlan
           includeTransitive = fromFlagOrDefault True (envIncludeTransitive replEnvFlags)
 
         pkgsBuildStatus <-
@@ -535,20 +593,30 @@ replAction flags@NixStyleFlags{extraFlags = replFlags@ReplFlags{..}, configFlags
 
         buildOutcomes <- runProjectBuildPhase verbosity baseCtx'' buildCtx'
         runProjectPostBuildPhase verbosity baseCtx'' buildCtx' buildOutcomes
-  where
-    combine_search_paths paths =
-      foldl' go Map.empty paths
-      where
-        go m ("PATH", Just s) = foldl' (\m' f -> Map.insertWith (+) f 1 m') m (splitSearchPath s)
-        go m _ = m
+    where
+      projectRoot = distProjectRootDirectory $ distDirLayout ctx
+      distDir = distDirectory $ distDirLayout ctx
 
-    withCtx ctxVerbosity strings =
-      withContextAndSelectors ctxVerbosity AcceptNoTargets (Just LibKind) flags strings globalFlags ReplCommand
+      combine_search_paths paths =
+        foldl' go Map.empty paths
+        where
+          go m ("PATH", Just s) = foldl' (\m' f -> Map.insertWith (+) f 1 m') m (splitSearchPath s)
+          go m _ = m
 
-    verbosity = cfgVerbosity normal flags
-    tempFileOptions = commonSetupTempFileOptions $ configCommonFlags configFlags
+      verbosity = cfgVerbosity normal flags
+      tempFileOptions = commonSetupTempFileOptions $ configCommonFlags configFlags
+      validatedTargets' = validatedTargets verbosity replFlags
 
-    validatedTargets' = validatedTargets verbosity replFlags
+withCtx :: NixStyleFlags a -> [String] -> GlobalFlags -> TargetsAction [TargetSelector] b -> IO b
+withCtx flags targetStrings globalFlags =
+  withContextAndSelectors
+    (cfgVerbosity normal flags)
+    (if null targetStrings then AcceptNoTargets else RejectNoTargets)
+    (Just LibKind)
+    flags
+    targetStrings
+    globalFlags
+    ReplCommand
 
 -- | Create a constraint which requires a later version of Cabal.
 -- This is used for commands which require a specific feature from the Cabal library

--- a/cabal-install/src/Distribution/Client/ScriptUtils.hs
+++ b/cabal-install/src/Distribution/Client/ScriptUtils.hs
@@ -12,6 +12,7 @@ module Distribution.Client.ScriptUtils
   , withContextAndSelectors
   , AcceptNoTargets (..)
   , TargetContext (..)
+  , TargetsAction
   , updateContextAndWriteProjectFile
   , updateContextAndWriteProjectFile'
   , fakeProjectSourcePackage
@@ -269,6 +270,9 @@ data TargetContext
     ScriptContext FilePath Executable
   deriving (Eq, Show)
 
+-- | An action working with selected targets within a context.
+type TargetsAction targets a = TargetContext -> ProjectBaseContext -> targets -> IO a
+
 -- | Determine whether the targets represent regular targets or a script
 -- and return the proper context and target selectors.
 -- Die with an error message if selectors are valid as neither regular targets or as a script.
@@ -289,8 +293,7 @@ withContextAndSelectors
   -- ^ Global flags.
   -> CurrentCommand
   -- ^ Current Command (usually for error reporting).
-  -> (TargetContext -> ProjectBaseContext -> [TargetSelector] -> IO b)
-  -- ^ The body of your command action.
+  -> TargetsAction [TargetSelector] b
   -> IO b
 withContextAndSelectors verbosity noTargets kind flags@NixStyleFlags{..} targetStrings globalFlags cmd act =
   withTemporaryTempDirectory $ \mkTmpDir -> do

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.alt-multiple-repl-options.out
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.alt-multiple-repl-options.out
@@ -1,5 +1,9 @@
 # cabal clean
 # cabal v2-repl
-Error: [Cabal-7076]
-Please pick a single [package:][ctype:]component (or all) as target for the REPL command. The packages in 'alt.project' from which to select a component target are:
- - alt
+No target specified, using package 'alt' as the target for the REPL.
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - alt-0.1 (interactive) (lib) (first run)
+Configuring library for alt-0.1...
+Preprocessing library for alt-0.1...

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.alt-single-repl-options.out
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.alt-single-repl-options.out
@@ -1,5 +1,9 @@
 # cabal clean
 # cabal v2-repl
-Error: [Cabal-7076]
-Please pick a single [package:][ctype:]component (or all) as target for the REPL command. The packages in 'alt.project' from which to select a component target are:
- - alt
+No target specified, using package 'alt' as the target for the REPL.
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - alt-0.1 (interactive) (lib) (first run)
+Configuring library for alt-0.1...
+Preprocessing library for alt-0.1...

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
@@ -12,8 +12,8 @@ main = do
 
   cabalTest' "alt-single-repl-options" $ do
     cabal' "clean" []
-    -- We can't 'cabal repl' without a target when the project has a single package.
-    void $ fails $ cabalWithStdin "v2-repl" (altProject singleOpts) ":set"
+    -- We can 'cabal repl' without a target when the project has a single package.
+    void $ cabalWithStdin "v2-repl" (altProject singleOpts) ":set"
 
   cabalTest' "multiple-repl-options" $ do
     cabal' "clean" []
@@ -24,8 +24,8 @@ main = do
 
   cabalTest' "alt-multiple-repl-options" $ do
     cabal' "clean" []
-    -- We can't 'cabal repl' without a target when the project has a single package.
-    void $ fails $ cabalWithStdin "v2-repl" (altProject multiOpts) ":set"
+    -- We can 'cabal repl' without a target when the project has a single package.
+    void $ cabalWithStdin "v2-repl" (altProject multiOpts) ":set"
 
   cabalTest' "single-repl-options-multiple-flags" $ do
     cabal' "clean" []

--- a/cabal-testsuite/PackageTests/ReplProjectNoneTarget/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplProjectNoneTarget/cabal.test.hs
@@ -7,13 +7,13 @@ main = cabalTest . recordMode RecordMarked $ do
   -- refers to the fake package.
   log "checking repl command with no project and --ignore-project"
   ignored <- cabalWithStdin "repl" ["--ignore-project"] ""
-  assertOutputContains "fake-package-0 (interactive) (lib) (first run)" ignored
+  assertOutputContains "fake-package-0 (interactive) (lib)" ignored
 
   -- The following output is not what we want but is the current behaviour that
   -- refers to the fake package.
   log "checking repl command with no project and no project options"
   noOptions <- cabalWithStdin "repl" [] ""
-  assertOutputContains "fake-package-0 (interactive) (lib) (configuration changed)" noOptions
+  assertOutputContains "fake-package-0 (interactive) (lib)" noOptions
 
   log "checking repl command with a missing project"
   missing <- fails $ cabalWithStdin "repl" [ "--project-file=missing.project" ] ""

--- a/cabal-testsuite/PackageTests/ReplProjectTargetOnePkg/cabal.out
+++ b/cabal-testsuite/PackageTests/ReplProjectTargetOnePkg/cabal.out
@@ -8,19 +8,23 @@ Configuring library for fake-package-0...
 Warning: No exposed modules
 # checking repl command with a 'cabal.project' and no project options
 # cabal repl
-Error: [Cabal-7076]
-Please pick a single [package:][ctype:]component (or all) as target for the REPL command. The packages from which to select a component in 'cabal.project', the implicit default as if `--project-file=cabal.project` was added as a command option, are:
- - pkg-one
-# checking repl command with a single package in 'cabal.project'
-# cabal repl
-Error: [Cabal-7076]
-Please pick a single [package:][ctype:]component (or all) as target for the REPL command. The packages in 'cabal.project' from which to select a component target are:
- - pkg-one
-# checking repl command with the 'all' target
-# cabal repl
+No target specified, using package 'pkg-one' as the target for the REPL.
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - pkg-one-0.1 (interactive) (first run)
 Configuring pkg-one-0.1...
+Preprocessing library for pkg-one-0.1...
+# checking repl command with a single package in 'cabal.project'
+# cabal repl
+No target specified, using package 'pkg-one' as the target for the REPL.
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - pkg-one-0.1 (interactive) (first run)
+Preprocessing library for pkg-one-0.1...
+# checking repl command with the 'all' target
+# cabal repl
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - pkg-one-0.1 (interactive) (first run)
 Preprocessing library for pkg-one-0.1...

--- a/cabal-testsuite/PackageTests/ReplProjectTargetOnePkg/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplProjectTargetOnePkg/cabal.test.hs
@@ -10,14 +10,14 @@ main = cabalTest . recordMode RecordMarked $ do
   assertOutputContains "fake-package-0 (interactive) (lib) (first run)" ignored
 
   log "checking repl command with a 'cabal.project' and no project options"
-  defaultProject <- fails $ cabalWithStdin "repl" [] ""
---  assertOutputContains "the following will be built" defaultProject
---  assertOutputContains "pkg-one-0.1" defaultProject
+  defaultProject <- cabalWithStdin "repl" [] ""
+  assertOutputContains "the following will be built" defaultProject
+  assertOutputContains "pkg-one-0.1" defaultProject
 
   log "checking repl command with a single package in 'cabal.project'"
-  defaultProject <- fails $ cabalWithStdin "repl" [ "--project-file=cabal.project" ] ""
---  assertOutputContains "the following will be built" defaultProject
---  assertOutputContains "pkg-one-0.1" defaultProject
+  defaultProject <- cabalWithStdin "repl" [ "--project-file=cabal.project" ] ""
+  assertOutputContains "the following will be built" defaultProject
+  assertOutputContains "pkg-one-0.1" defaultProject
 
   log "checking repl command with the 'all' target"
   allTarget <- cabalWithStdin "repl" ["all"] ""

--- a/cabal-testsuite/PackageTests/ReplProjectTargetTwoPkgs/cabal.out
+++ b/cabal-testsuite/PackageTests/ReplProjectTargetTwoPkgs/cabal.out
@@ -33,8 +33,21 @@ There are no packages in 'empty.project'. Please add a package to the project an
 # cabal repl
 # checking repl command with a missing 'missing.project'
 # cabal repl
-# checking repl command with the 'all' target
+# checking multi-repl command with the 'all' target
 # cabal repl
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - pkg-one-0.1 (interactive) (first run)
+ - pkg-two-0.1 (interactive) (first run)
+Configuring pkg-one-0.1...
+Preprocessing library for pkg-one-0.1...
+Configuring pkg-two-0.1...
+Preprocessing library for pkg-two-0.1...
+# checking multi-repl command with no target, should default to the 'all' target
+# cabal clean
+# cabal repl
+No target specified, using 'all' as the target for the REPL.
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:

--- a/cabal-testsuite/PackageTests/ReplProjectTargetTwoPkgs/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplProjectTargetTwoPkgs/cabal.test.hs
@@ -43,10 +43,17 @@ main = cabalTest . recordMode RecordMarked $ do
   -- before we reach the skip.
   skipUnlessGhcVersion ">= 9.4.1"
 
-  log "checking repl command with the 'all' target"
-  allTarget <- cabalWithStdin "repl" ["all", "--enable-multi-repl"] ""
+  log "checking multi-repl command with the 'all' target"
+  allTargetExplicit <- cabalWithStdin "repl" ["all", "--enable-multi-repl"] ""
 
   readFileVerbatim "all-repl.txt"
-    >>= flip (assertOn isInfixOf multilineNeedleHaystack) allTarget . normalizePathSeparators
+    >>= flip (assertOn isInfixOf multilineNeedleHaystack) allTargetExplicit . normalizePathSeparators
+
+  log "checking multi-repl command with no target, should default to the 'all' target"
+  cabal "clean" []
+  allTargetImplicit <- cabalWithStdin "repl" ["--enable-multi-repl"] ""
+
+  readFileVerbatim "all-repl.txt"
+    >>= flip (assertOn isInfixOf multilineNeedleHaystack) allTargetImplicit . normalizePathSeparators
 
   return ()

--- a/changelog.d/11452.md
+++ b/changelog.d/11452.md
@@ -1,0 +1,11 @@
+---
+synopsis: "Default project target for the REPL command"
+packages: [cabal-install]
+prs: 11452
+issues: 11451
+---
+
+The REPL for a project always requires an explicit target except in two cases:
+
+1. The package name is the default implicit target in a single package project.
+2. `all` is the default implicit target with `--enable-multi-repl`.


### PR DESCRIPTION
Fixes #11451. A follow on from #10684 that I closed because its changelog entry was already committed with #11237. This is the behaviour change of #10684 that was not included with #11237.

Uses existing tests. Some of these no longer fail if no target is supplied.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
