### PR TITLE
Remove old warnings section in generated cabal files

### DIFF
--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-no-comments.golden
@@ -54,7 +54,6 @@ test-suite y-test
     import:           extensions
     import:           ghc-options
     import:           rts-options
-    import:           warnings
     default-language: Haskell2010
     -- other-modules:
     -- other-extensions:

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-with-comments.golden
@@ -130,9 +130,6 @@ test-suite y-test
     -- Common RTS options
     import:           rts-options
 
-    -- Import common warning flags.
-    import:           warnings
-
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-no-comments.golden
@@ -40,7 +40,6 @@ test-suite y-test
     import:           extensions
     import:           ghc-options
     import:           rts-options
-    import:           warnings
     default-language: Haskell2010
     -- other-modules:
     -- other-extensions:

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-with-comments.golden
@@ -100,9 +100,6 @@ test-suite y-test
     -- Common RTS options
     import:           rts-options
 
-    -- Import common warning flags.
-    import:           warnings
-
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-no-comments.golden
@@ -30,7 +30,6 @@ test-suite y-test
     import:           extensions
     import:           ghc-options
     import:           rts-options
-    import:           warnings
     default-language: Haskell2010
     -- other-modules:
     -- other-extensions:

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-with-comments.golden
@@ -75,9 +75,6 @@ test-suite y-test
     -- Common RTS options
     import:           rts-options
 
-    -- Import common warning flags.
-    import:           warnings
-
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/test/standalone-test-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/standalone-test-no-comments.golden
@@ -2,7 +2,6 @@ test-suite y-test
     import:           extensions
     import:           ghc-options
     import:           rts-options
-    import:           warnings
     default-language: Haskell2010
     -- other-modules:
     -- other-extensions:

--- a/cabal-install/tests/fixtures/init/golden/test/standalone-test-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/standalone-test-with-comments.golden
@@ -8,9 +8,6 @@ test-suite y-test
     -- Common RTS options
     import:           rts-options
 
-    -- Import common warning flags.
-    import:           warnings
-
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/test/test-build-tools-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-build-tools-with-comments.golden
@@ -8,9 +8,6 @@ test-suite y-test
     -- Common RTS options
     import:             rts-options
 
-    -- Import common warning flags.
-    import:             warnings
-
     -- Base language which the package is written in.
     default-language:   Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/test/test-minimal-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-minimal-no-comments.golden
@@ -2,7 +2,6 @@ test-suite y-test
     import:           extensions
     import:           ghc-options
     import:           rts-options
-    import:           warnings
     default-language: Haskell2010
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test

--- a/cabal-install/tests/fixtures/init/golden/test/test-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-no-comments.golden
@@ -2,7 +2,6 @@ test-suite y-test
     import:           extensions
     import:           ghc-options
     import:           rts-options
-    import:           warnings
     default-language: Haskell2010
     -- other-modules:
     -- other-extensions:

--- a/cabal-install/tests/fixtures/init/golden/test/test-simple-minimal-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-simple-minimal-with-comments.golden
@@ -2,7 +2,6 @@ test-suite y-test
     import:           extensions
     import:           ghc-options
     import:           rts-options
-    import:           warnings
     default-language: Haskell2010
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test

--- a/cabal-install/tests/fixtures/init/golden/test/test-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-with-comments.golden
@@ -8,9 +8,6 @@ test-suite y-test
     -- Common RTS options
     import:           rts-options
 
-    -- Import common warning flags.
-    import:           warnings
-
     -- Base language which the package is written in.
     default-language: Haskell2010
 


### PR DESCRIPTION
This is a follow-up to #11261

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)