### PR TITLE
Replace OS name with image version in cache keys

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -32,13 +32,18 @@ jobs:
           rm -rf ~/.config/cabal
           rm -rf ~/.cache/cabal
 
+      # runner.os isn't sufficient for binary compatible caches
+      - name: Get runner OS/version for cache keys
+        id: get-osver
+        run: echo "osver=$ImageOS" >> "$GITHUB_OUTPUT"
+
       - uses: actions/cache@v5
         name: Cache the downloads
         id: bootstrap-cache
         with:
           path: "/home/runner/work/cabal/cabal/_build"
-          key: bootstrap-${{ runner.os }}-${{ matrix.ghc }}-20221115-${{ github.sha }}
-          restore-keys: bootstrap-${{ runner.os }}-${{ matrix.ghc }}-20221115-
+          key: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-20221115-${{ github.sha }}
+          restore-keys: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-20221115-
 
       - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -44,13 +44,16 @@ jobs:
       - uses: actions/checkout@v6
       - name: Generate build plan for correct cache key
         run: ${{ env.cabal_build }} --dry-run
+      - name: Get runner OS/version for cache keys
+        id: get-osver
+        run: echo "osver=$ImageOS" >> "$GITHUB_OUTPUT"
       - name: Restore cached dependencies
         uses: actions/cache/restore@v5
         id: cache
         with:
           path: ~/.local/state/cabal
-          key: linux-store-meta-${{ hashfiles('dist-newstyle-meta/cache/plan.json') }}
-          restore-keys: linux-store-meta-
+          key: ${{ steps.get-osver.outputs.osver }}-store-meta-${{ hashfiles('dist-newstyle-meta/cache/plan.json') }}
+          restore-keys: ${{ steps.get-osver.outputs.osver }}-store-meta-
       - name: Build tools
         run: ${{ env.cabal_build }}
       - name: Regenerate files
@@ -90,13 +93,16 @@ jobs:
       - name: Use date as cache key
         run: |
           echo "DATE=$(date +'%Y-%m-%d')" >> "${GITHUB_ENV}"
+      - name: Get runner OS/version for cache keys
+        id: get-osver
+        run: echo "osver=$ImageOS" >> "$GITHUB_OUTPUT"
       - name: Restore cached dependencies
         uses: actions/cache/restore@v5
         id: cache
         with:
           path: ~/.local/state/cabal
-          key: linux-store-doctest-${{ env.DATE }}
-          restore-keys: linux-store-doctest
+          key: ${{ steps.get-osver.outputs.osver }}-store-doctest-${{ env.DATE }}
+          restore-keys: ${{ steps.get-osver.outputs.osver }}-store-doctest
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v6
@@ -132,13 +138,16 @@ jobs:
       - uses: actions/checkout@v6
       - name: Generate build plan for correct cache key
         run: ${{ env.cabal_build }} --dry-run
+      - name: Get runner OS/version for cache keys
+        id: get-osver
+        run: echo "osver=$ImageOS" >> "$GITHUB_OUTPUT"
       - name: Restore cached dependencies
         uses: actions/cache/restore@v5
         id: cache
         with:
           path: ~/.local/state/cabal
-          key: linux-store-buildinfo-doc-diff-${{ hashfiles('dist-newstyle/cache/plan.json') }}
-          restore-keys: linux-store-buildinfo-doc-diff
+          key: ${{ steps.get-osver.outputs.osver }}-store-buildinfo-doc-diff-${{ hashfiles('dist-newstyle/cache/plan.json') }}
+          restore-keys: ${{ steps.get-osver.outputs.osver }}-store-buildinfo-doc-diff
       - name: Build buildinfo-reference-generator
         run: ${{ env.cabal_build }}
       - name: Are buildinfo docs up to date?

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -133,6 +133,11 @@ jobs:
           cabal-version: 3.12.1.0 # see https://github.com/haskell/cabal/pull/10251
           ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.9.yaml
 
+      # runner.os isn't sufficient for binary compatible caches
+      - name: Get runner OS/version for cache keys
+        id: get-osver
+        run: echo "osver=$ImageOS" >> "$GITHUB_OUTPUT"
+
       #  See the following link for a breakdown of the following step
       #  https://github.com/haskell/actions/issues/7#issuecomment-745697160
       - uses: actions/cache@v5
@@ -141,8 +146,8 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-*
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          key: ${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-${{ github.sha }}
+          restore-keys: ${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-
 
       - name: "Work around git problem https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586 (cabal PR #8546)"
         # alternatively, use 'continue-on-error: true'
@@ -294,6 +299,11 @@ jobs:
           ghc --version
           "ghc-${{ matrix.extra-ghc }}" --version
 
+      # runner.os isn't sufficient for binary compatible caches
+      - name: Get runner OS/version for cache keys
+        id: get-osver
+        run: echo "osver=$ImageOS" >> "$GITHUB_OUTPUT"
+
       # As we are reusing the cached build dir from the previous step
       # the generated artifacts are available here,
       # including the cabal executable and the test suite
@@ -302,8 +312,8 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-*
-          key: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-
+          key: ${{ steps.get-osver.outputs.osver }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
+          restore-keys: ${{ steps.get-osver.outputs.osver }}-${{ env.GHC_FOR_RELEASE }}-
 
       - name: Validate build
         id: build
@@ -356,8 +366,8 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-*
-          key: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-
+          key: ${{ steps.get-osver.outputs.osver }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
+          restore-keys: ${{ steps.get-osver.outputs.osver }}-${{ env.GHC_FOR_RELEASE }}-
 
       - name: Enable statically linked executables
         run: |


### PR DESCRIPTION
Use cache keys that capture the OS version in sufficient detail to ensure that e.g. OS libraries don't mismatch between caches. This will prevent bad caches from being used when e.g. `ubuntu-latest` is updated.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
