### PR TITLE
Reject unconstrained dependency = `none|all|eq`

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -54,6 +54,7 @@ import Distribution.Types.UnqualComponentName
     ( unUnqualComponentName )
 
 import Text.PrettyPrint ( nest, render )
+import Distribution.Solver.Types.Settings (OnlyConstrained(..))
 
 -- A data type to hold log information from the modular solver.
 data Message =
@@ -309,7 +310,7 @@ showFR _ (PackageRequiresMissingComponent qpn comp) = " (requires " ++ showExpos
 showFR _ (PackageRequiresPrivateComponent qpn comp) = " (requires " ++ showExposedComponent comp ++ " from " ++ showQPN qpn ++ ", but the component is private)"
 showFR _ (PackageRequiresUnbuildableComponent qpn comp) = " (requires " ++ showExposedComponent comp ++ " from " ++ showQPN qpn ++ ", but the component is not buildable in the current environment)"
 showFR _ CannotReinstall                  = " (avoiding to reinstall a package with same version but new dependencies)"
-showFR _ NotExplicit                      = " (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)"
+showFR _ (NotExplicit oc)                 = showNotExplicit oc
 showFR _ Shadowed                         = " (shadowed by another installed package with same version)"
 showFR _ (Broken u)                       = " (package is broken, missing dependency " ++ prettyShow u ++ ")"
 showFR _ UnknownPackage                   = " (unknown package)"
@@ -331,6 +332,11 @@ showFR _ (UnsupportedSpecVer ver)         = " (unsupported spec-version " ++ pre
 showFR _ (MalformedFlagChoice qfn)        = " (INTERNAL ERROR: MALFORMED FLAG CHOICE: " ++ showQFN qfn ++ ")"
 showFR _ (MalformedStanzaChoice qsn)      = " (INTERNAL ERROR: MALFORMED STANZA CHOICE: " ++ showQSN qsn ++ ")"
 showFR _ EmptyGoalChoice                  = " (INTERNAL ERROR: EMPTY GOAL CHOICE)"
+
+showNotExplicit :: OnlyConstrained -> String
+showNotExplicit oc = if oc == OnlyConstrainedNone
+  then " (INTERNAL ERROR: NOT EXPLICIT when reject-unconstrained-dependencies=" ++ prettyShow oc ++ " was set)"
+  else " (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=" ++ prettyShow oc ++ " was set)"
 
 showExposedComponent :: ExposedComponent -> String
 showExposedComponent (ExposedLib LMainLibName)       = "library"

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
@@ -42,6 +42,7 @@ import Distribution.Solver.Modular.Tree
 import Distribution.Solver.Modular.Version
 import qualified Distribution.Solver.Modular.ConflictSet as CS
 import qualified Distribution.Solver.Modular.WeightedPSQ as W
+import Distribution.Solver.Types.Settings (OnlyConstrained(..))
 
 -- | Update the weights of children under 'PChoice' nodes. 'addWeights' takes a
 -- list of weight-calculating functions in order to avoid sorting the package
@@ -350,13 +351,13 @@ avoidReinstalls p = go
     go x          = x
 
 -- | Require all packages to be mentioned in a constraint or as a goal.
-onlyConstrained :: (PN -> Bool) -> EndoTreeTrav d QGoalReason
-onlyConstrained p = go
+onlyConstrained :: OnlyConstrained -> (PN -> Bool) -> EndoTreeTrav d QGoalReason
+onlyConstrained oc p = go
   where
     go (PChoiceF v@(Q _ pn) _ gr _) | not (p pn)
       = FailF
         (varToConflictSet (P v) `CS.union` goalReasonToConflictSetWithConflict v gr)
-        NotExplicit
+        (NotExplicit oc)
     go x
       = x
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -20,12 +20,12 @@ import Distribution.Verbosity
 
 import Distribution.Compiler (CompilerInfo)
 
+import Distribution.Version
 import Distribution.Solver.Types.PackagePath
 import Distribution.Solver.Types.PackagePreferences
 import Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.PackageConstraint (PackageConstraint(..), PackageProperty(..))
-import Distribution.Types.VersionRange (normaliseVersionRange, projectVersionRange, VersionRangeF(ThisVersionF))
 import Distribution.Solver.Types.Settings
 import Distribution.Solver.Types.Variable
 
@@ -170,9 +170,10 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
 -- | Keep version ranges that normalise to equality version constraints (== v).
 filterThisVersion :: M.Map PN [LabeledPackageConstraint] -> M.Map PN [LabeledPackageConstraint]
 filterThisVersion = M.filter (not . null) . M.map (filter isThisVersion) where
+  normalise = fromVersionIntervals . toVersionIntervals
   isThisVersion lpc
     | LabeledPackageConstraint (PackageConstraint _ (PackagePropertyVersion vr)) _ <- lpc
-    , ThisVersionF _ <- projectVersionRange $ normaliseVersionRange vr = True
+    , ThisVersionF _ <- projectVersionRange $ normalise vr = True
     | otherwise = False
 
 -- | Dump solver tree to a file (in debugging mode)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -22,6 +22,8 @@ import Distribution.Solver.Types.PackagePath
 import Distribution.Solver.Types.PackagePreferences
 import Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
 import Distribution.Solver.Types.LabeledPackageConstraint
+import Distribution.Solver.Types.PackageConstraint (PackageConstraint(..), PackageProperty(..))
+import Distribution.Types.VersionRange (normaliseVersionRange, projectVersionRange, VersionRangeF(ThisVersionF))
 import Distribution.Solver.Types.Settings
 import Distribution.Solver.Types.Variable
 
@@ -139,16 +141,13 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                        validateTree cinfo idx pkgConfigDB
     prunePhase       = (if asBool (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
                        (case onlyConstrained sc of
-                          OnlyConstrainedAll ->
-                            P.onlyConstrained pkgIsExplicit
-                          OnlyConstrainedNone ->
-                            id)
+                          OnlyConstrainedEq -> P.onlyConstrained (`S.member` allExplicitEq)
+                          OnlyConstrainedAll -> P.onlyConstrained (`S.member` allExplicit)
+                          OnlyConstrainedNone -> id)
     buildPhase       = buildTree idx (independentGoals sc) (S.toList userGoals)
 
+    allExplicitEq = M.keysSet (filterThisVersion userConstraints) `S.union` userGoals
     allExplicit = M.keysSet userConstraints `S.union` userGoals
-
-    pkgIsExplicit :: PN -> Bool
-    pkgIsExplicit pn = S.member pn allExplicit
 
     -- When --reorder-goals is set, we use preferReallyEasyGoalChoices, which
     -- prefers (keeps) goals only if the have 0 or 1 enabled choice.
@@ -165,6 +164,14 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
     goalChoiceHeuristics
       | asBool (reorderGoals sc) = P.preferReallyEasyGoalChoices
       | otherwise                = id {- P.firstGoal -}
+
+-- | Keep version ranges that normalise to equality version constraints (== v).
+filterThisVersion :: M.Map PN [LabeledPackageConstraint] -> M.Map PN [LabeledPackageConstraint]
+filterThisVersion = M.filter (not . null) . M.map (filter isThisVersion) where
+  isThisVersion lpc
+    | LabeledPackageConstraint (PackageConstraint _ (PackagePropertyVersion vr)) _ <- lpc
+    , ThisVersionF _ <- projectVersionRange $ normaliseVersionRange vr = True
+    | otherwise = False
 
 -- | Dump solver tree to a file (in debugging mode)
 --

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 #ifdef DEBUG_TRACETREE
 {-# OPTIONS_GHC -Wno-orphans #-}
 #endif
@@ -10,6 +11,7 @@ module Distribution.Solver.Modular.Solver
 
 import Distribution.Solver.Compat.Prelude
 import Prelude ()
+import Data.Function ((&))
 
 import qualified Data.Map as M
 import qualified Data.List as L
@@ -140,9 +142,9 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                        validateLinking idx .
                        validateTree cinfo idx pkgConfigDB
     prunePhase       = (if asBool (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
-                       (case onlyConstrained sc of
-                          OnlyConstrainedEq -> P.onlyConstrained (`S.member` allExplicitEq)
-                          OnlyConstrainedAll -> P.onlyConstrained (`S.member` allExplicit)
+                       (let oc = onlyConstrained sc in oc & \case
+                          OnlyConstrainedEq -> P.onlyConstrained oc (`S.member` allExplicitEq)
+                          OnlyConstrainedAll -> P.onlyConstrained oc (`S.member` allExplicit)
                           OnlyConstrainedNone -> id)
     buildPhase       = buildTree idx (independentGoals sc) (S.toList userGoals)
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -192,9 +192,8 @@ isVersionConstrained (LabeledPackageConstraint (PackageConstraint _ c) _) = case
 
 -- | Is this an equality version constraint @== v@?
 isThisVersion :: LabeledPackageConstraint -> Bool
-isThisVersion lpc
-  | LabeledPackageConstraint (PackageConstraint _ (PackagePropertyVersion vr)) _ <- lpc
-  , ThisVersionF _ <- projectVersionRange $ normalise vr = True
+isThisVersion (LabeledPackageConstraint (PackageConstraint _ constraint) _)
+  | PackagePropertyVersion (projectVersionRange . normalise -> ThisVersionF _) <- constraint = True
   | otherwise = False
 
 -- | Dump solver tree to a file (in debugging mode)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ViewPatterns #-}
 #ifdef DEBUG_TRACETREE
 {-# OPTIONS_GHC -Wno-orphans #-}
 #endif
@@ -143,13 +144,16 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                        validateTree cinfo idx pkgConfigDB
     prunePhase       = (if asBool (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
                        (let oc = onlyConstrained sc in oc & \case
-                          OnlyConstrainedEq -> P.onlyConstrained oc (`S.member` allExplicitEq)
-                          OnlyConstrainedAll -> P.onlyConstrained oc (`S.member` allExplicit)
+                          OnlyConstrainedEq -> P.onlyConstrained oc (`S.member` versionEqOrGoals)
+                          OnlyConstrainedAll -> P.onlyConstrained oc (`S.member` versionConstrainedOrGoals)
                           OnlyConstrainedNone -> id)
     buildPhase       = buildTree idx (independentGoals sc) (S.toList userGoals)
 
-    allExplicitEq = M.keysSet (filterThisVersion userConstraints) `S.union` userGoals
-    allExplicit = M.keysSet userConstraints `S.union` userGoals
+    versionEq = filterVersion isThisVersion userConstraints
+    versionEqOrGoals = versionEq `S.union` userGoals
+
+    versionConstrained = filterVersion isVersionConstrained userConstraints
+    versionConstrainedOrGoals = versionConstrained `S.union` userGoals
 
     -- When --reorder-goals is set, we use preferReallyEasyGoalChoices, which
     -- prefers (keeps) goals only if the have 0 or 1 enabled choice.
@@ -167,14 +171,31 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
       | asBool (reorderGoals sc) = P.preferReallyEasyGoalChoices
       | otherwise                = id {- P.firstGoal -}
 
--- | Keep version ranges that normalise to equality version constraints (== v).
-filterThisVersion :: M.Map PN [LabeledPackageConstraint] -> M.Map PN [LabeledPackageConstraint]
-filterThisVersion = M.filter (not . null) . M.map (filter isThisVersion) where
-  normalise = fromVersionIntervals . toVersionIntervals
-  isThisVersion lpc
-    | LabeledPackageConstraint (PackageConstraint _ (PackagePropertyVersion vr)) _ <- lpc
-    , ThisVersionF _ <- projectVersionRange $ normalise vr = True
-    | otherwise = False
+-- | Keep package names of constraints that satisfy the predicate.
+filterVersion :: (LabeledPackageConstraint -> Bool) -> M.Map PN [LabeledPackageConstraint] -> Set PN
+filterVersion versionFilter = M.keysSet . M.filter (not . null) . M.map (filter versionFilter)
+
+normalise :: VersionRange -> VersionRange
+normalise = fromVersionIntervals . toVersionIntervals
+
+-- | Unconstrained with a version range @>=0@ or @<0@ or their flag equivalents
+-- and constrained by other versions ranges.
+--
+-- Both the @-any@ and @-none@ flags are considered unconstrained, because they
+-- don't actually constrain the version of the package. The @-any@ flag allows
+-- any version, and the @-none@ flag effectively excludes a package.
+isVersionConstrained :: LabeledPackageConstraint -> Bool
+isVersionConstrained (LabeledPackageConstraint (PackageConstraint _ c) _) = case c of
+    PackagePropertyVersion (normalise -> vr) -> not (isAnyVersion vr || isNoVersion vr)
+    -- `PackagePropertyFlags` @-any@ and @-none@ are covered below.
+    _ -> False
+
+-- | Is this an equality version constraint @== v@?
+isThisVersion :: LabeledPackageConstraint -> Bool
+isThisVersion lpc
+  | LabeledPackageConstraint (PackageConstraint _ (PackagePropertyVersion vr)) _ <- lpc
+  , ThisVersionF _ <- projectVersionRange $ normalise vr = True
+  | otherwise = False
 
 -- | Dump solver tree to a file (in debugging mode)
 --

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
@@ -35,6 +35,7 @@ import Distribution.Solver.Types.PackagePath
 import Distribution.Types.PkgconfigVersionRange
 import Distribution.Types.UnitId (UnitId)
 import Language.Haskell.Extension (Extension, Language)
+import Distribution.Solver.Types.Settings (OnlyConstrained(..))
 
 type Weight = Double
 
@@ -111,7 +112,7 @@ data FailReason = UnsupportedExtension Extension
                 | PackageRequiresPrivateComponent QPN ExposedComponent
                 | PackageRequiresUnbuildableComponent QPN ExposedComponent
                 | CannotReinstall
-                | NotExplicit
+                | NotExplicit OnlyConstrained
                 | Shadowed
                 | Broken UnitId
                 | UnknownPackage

--- a/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
@@ -59,6 +59,7 @@ newtype AllowBootLibInstalls = AllowBootLibInstalls Bool
 data OnlyConstrained
   = OnlyConstrainedNone
   | OnlyConstrainedAll
+  | OnlyConstrainedEq
   deriving (Eq, Generic, Show)
 
 newtype EnableBackjumping = EnableBackjumping Bool
@@ -106,12 +107,14 @@ instance NFData AllowBootLibInstalls
 instance NFData OnlyConstrained
 
 instance Pretty OnlyConstrained where
+  pretty OnlyConstrainedEq  = PP.text "eq"
   pretty OnlyConstrainedAll  = PP.text "all"
   pretty OnlyConstrainedNone = PP.text "none"
 
 instance Parsec OnlyConstrained where
   parsec = P.choice
-    [ P.string "all"  >> return OnlyConstrainedAll
+    [ P.string "eq"  >> return OnlyConstrainedEq
+    , P.string "all"  >> return OnlyConstrainedAll
     , P.string "none" >> return OnlyConstrainedNone
     ]
 

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -3699,9 +3699,9 @@ optionSolverFlags
         getoc
         setoc
         ( reqArg
-            "none|all"
+            "none|all|eq"
             ( parsecToReadE
-                (const "reject-unconstrained-dependencies must be 'none' or 'all'")
+                (const "reject-unconstrained-dependencies must be 'none', 'all', or 'eq'")
                 (toFlag `fmap` parsec)
             )
             (flagToList . fmap prettyShow)

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -2,7 +2,7 @@
 
 -- | Utilities for creating HUnit test cases with the solver DSL.
 module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
-  ( SolverTest
+  ( SolverTest (..)
   , SolverResult (..)
   , maxBackjumps
   , disableFineGrainedConflicts

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -80,9 +80,9 @@ allowBootLibInstalls :: SolverTest -> SolverTest
 allowBootLibInstalls test =
   test{testAllowBootLibInstalls = AllowBootLibInstalls True}
 
-onlyConstrained :: SolverTest -> SolverTest
-onlyConstrained test =
-  test{testOnlyConstrained = OnlyConstrainedAll}
+onlyConstrained :: OnlyConstrained -> SolverTest -> SolverTest
+onlyConstrained oc test =
+  test{testOnlyConstrained = oc}
 
 disableBackjumping :: SolverTest -> SolverTest
 disableBackjumping test =

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -277,8 +277,14 @@ tests =
             -- ==1 && >0
             eqGt = C.intersectVersionRanges eq1 gt0
 
+            -- ==1 | >0
+            eqOrGt = C.unionVersionRanges eq1 gt0
+
             -- >0 && ==1
             gtEq = C.intersectVersionRanges gt0 eq1
+
+            -- >0 || ==1
+            gtOrEq = C.unionVersionRanges gt0 eq1
 
             -- <=1 && >=1
             lege1 = C.intersectVersionRanges le1 ge1
@@ -304,6 +310,12 @@ tests =
             eqGtConstraints =
               [ mkConstraint "B" eqGt
               , mkConstraint "C" gtEq
+              ]
+
+            -- B ==1 || >0, C >0 || ==1
+            eqOrGtConstraints =
+              [ mkConstraint "B" eqOrGt
+              , mkConstraint "C" gtOrEq
               ]
 
             -- B >=1, C <=1
@@ -361,6 +373,10 @@ tests =
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B >0 && ==1 && <2, C >0 && ==1 && <2" ["A"] solveABC)
                       { testConstraints = gtEqLtConstraints
+                      }
+                , runTest . whenAll $
+                    (mkTest db17 "goal A with B ==1 || >0, C >0 || ==1" ["A"] solveABC)
+                      { testConstraints = eqOrGtConstraints
                       }
                 ]
             , testGroup "=all rejects" $
@@ -461,6 +477,21 @@ tests =
                             )
                         )
                           { testConstraints = legeConstraints
+                          }
+                    , runTest . whenEq $
+                        ( mkTest
+                            db17
+                            "goal A with B ==1 || >0, C >0 || ==1"
+                            ["A"]
+                            ( solverFailure
+                                ( \m ->
+                                    all
+                                      (`isInfixOf` m)
+                                      ("next goal: C (dependency of A)" : neq)
+                                )
+                            )
+                        )
+                          { testConstraints = eqOrGtConstraints
                           }
                     ]
             ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -257,11 +257,21 @@ tests =
             whenNone = onlyConstrained OnlyConstrainedNone
             whenAll = onlyConstrained OnlyConstrainedAll
             whenEq = onlyConstrained OnlyConstrainedEq
+
+            -- ==1
             eq1 = C.thisVersion $ mkSimpleVersion 1
+
+            -- >0
             gt0 = C.laterVersion $ C.mkVersion [0]
+
+            -- <2
             lt2 = C.earlierVersion $ C.mkVersion [2]
+
+            -- >=1
             ge1 = C.orLaterVersion $ C.mkVersion [1]
+
             -- TODO: Find out why <=1 is not the same as <=1.0.0
+            -- <=1
             le1 = C.orEarlierVersion $ C.mkVersion [1, 0, 0]
 
             -- ==1 && >0
@@ -277,31 +287,37 @@ tests =
             gtEqLt = C.intersectVersionRanges gtEq lt2
 
             mkConstraint pkg vr = ExVersionConstraint (ScopeAnyQualifier pkg) vr
+
             -- B ==1, C ==1
             eqConstraints =
               [ mkConstraint "B" eq1
               , mkConstraint "C" eq1
               ]
+
             -- B >0, C >0
             gtConstraints =
               [ mkConstraint "B" gt0
               , mkConstraint "C" gt0
               ]
+
             -- B ==1 && >0, C >0 && ==1
             eqGtConstraints =
               [ mkConstraint "B" eqGt
               , mkConstraint "C" gtEq
               ]
+
             -- B >=1, C <=1
             geleConstraints =
               [ mkConstraint "B" ge1
               , mkConstraint "C" le1
               ]
+
             -- B <=1 && >=1, C <=1 && >=1
             legeConstraints =
               [ mkConstraint "B" lege1
               , mkConstraint "C" lege1
               ]
+
             -- B >0 && ==1 && <2, C >0 && ==1 && <2
             gtEqLtConstraints =
               [ mkConstraint "B" gtEqLt

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -310,21 +310,6 @@ tests =
                 [ runTest . whenAll $
                     mkTest
                       db12
-                      "goal E missing syb failure"
-                      ["E"]
-                      ( solverFailure
-                          ( \m ->
-                              all
-                                (`isInfixOf` m)
-                                [ "next goal: syb (dependency of E)"
-                                , "not a user-provided goal nor mentioned as a constraint"
-                                , "but reject-unconstrained-dependencies=all was set"
-                                ]
-                          )
-                      )
-                , runTest . whenAll $
-                    mkTest
-                      db12
                       "all goals"
                       ["E", "syb"]
                       (solverSuccess [("E", 1), ("syb", 2)])
@@ -334,12 +319,6 @@ tests =
                       "goal A B backtracking"
                       ["A", "B"]
                       (solverSuccess [("A", 2), ("B", 1)])
-                , runTest . whenAll $
-                    mkTest
-                      db17
-                      "goal A failure"
-                      ["A"]
-                      (solverFailure . isInfixOf $ solverMsg "all")
                 , runTest . whenAll $
                     ( mkTest db17 "goal A with B ==1, C ==1" ["A"] $
                         (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
@@ -365,60 +344,93 @@ tests =
                       { testConstraints = geConstraints
                       }
                 ]
+            , testGroup
+                "=all rejects"
+                [ runTest . whenAll $
+                    mkTest
+                      db12
+                      "goal E missing syb"
+                      ["E"]
+                      ( solverFailure
+                          ( \m ->
+                              all
+                                (`isInfixOf` m)
+                                [ "next goal: syb (dependency of E)"
+                                , "not a user-provided goal nor mentioned as a constraint"
+                                , "but reject-unconstrained-dependencies=all was set"
+                                ]
+                          )
+                      )
+                , runTest . whenAll $
+                    mkTest
+                      db17
+                      "goal A"
+                      ["A"]
+                      (solverFailure . isInfixOf $ solverMsg "all")
+                ]
             , testGroup "=eq" $
-                let eGoalFailure m =
+                [ runTest . whenEq $
+                    mkTest
+                      db17
+                      "goal A B backtracking"
+                      ["A", "B"]
+                      (solverSuccess [("A", 2), ("B", 1)])
+                , runTest . whenEq $
+                    ( mkTest
+                        db17
+                        "goal A with B ==1, C ==1"
+                        ["A"]
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = eqConstraints
+                      }
+                , runTest . whenEq $
+                    ( mkTest
+                        db17
+                        "goal A with B >0 && ==1, C >0 && ==1"
+                        ["A"]
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = eqGtConstraints
+                      }
+                ]
+            , testGroup "=eq rejects" $
+                let neq =
+                      [ "not a user-provided goal nor mentioned as a constraint"
+                      , "but reject-unconstrained-dependencies=eq was set"
+                      ]
+                    eGoalFailure m =
                       all
                         (`isInfixOf` m)
-                        [ "next goal: E.base (dependency of E)"
-                        , "not a user-provided goal nor mentioned as a constraint"
-                        , "but reject-unconstrained-dependencies=eq was set"
-                        ]
+                        ("next goal: E.base (dependency of E)" : neq)
                  in [ runTest . whenEq $
                         mkTest
                           db12
-                          "goal E missing syb failure"
+                          "goal E missing syb"
                           ["E"]
                           (solverFailure eGoalFailure)
                     , runTest . whenEq $
                         mkTest
                           db12
-                          "all goals failure"
+                          "all goals"
                           ["E", "syb"]
                           (solverFailure eGoalFailure)
                     , runTest . whenEq $
                         mkTest
                           db17
-                          "goal A B backtracking"
-                          ["A", "B"]
-                          (solverSuccess [("A", 2), ("B", 1)])
-                    , runTest . whenEq $
-                        mkTest
-                          db17
-                          "goal A failure"
+                          "goal A"
                           ["A"]
                           (solverFailure . isInfixOf $ solverMsg "eq")
                     , runTest . whenEq $
                         ( mkTest
                             db17
-                            "goal A with B ==1, C ==1"
-                            ["A"]
-                            (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                        )
-                          { testConstraints = eqConstraints
-                          }
-                    , runTest . whenEq $
-                        ( mkTest
-                            db17
-                            "goal A with B >0, C >0 failure"
+                            "goal A with B >0, C >0"
                             ["A"]
                             ( solverFailure
                                 ( \m ->
                                     all
                                       (`isInfixOf` m)
-                                      [ "next goal: C (dependency of A)"
-                                      , "not a user-provided goal nor mentioned as a constraint"
-                                      , "but reject-unconstrained-dependencies=eq was set"
-                                      ]
+                                      ("next goal: C (dependency of A)" : neq)
                                 )
                             )
                         )
@@ -427,25 +439,13 @@ tests =
                     , runTest . whenEq $
                         ( mkTest
                             db17
-                            "goal A with B >0 && ==1, C >0 && ==1"
-                            ["A"]
-                            (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                        )
-                          { testConstraints = eqGtConstraints
-                          }
-                    , runTest . whenEq $
-                        ( mkTest
-                            db17
-                            "goal A with B >=1, C >=1 failure"
+                            "goal A with B >=1, C >=1"
                             ["A"]
                             ( solverFailure
                                 ( \m ->
                                     all
                                       (`isInfixOf` m)
-                                      [ "next goal: C (dependency of A)"
-                                      , "not a user-provided goal nor mentioned as a constraint"
-                                      , "but reject-unconstrained-dependencies=eq was set"
-                                      ]
+                                      ("next goal: C (dependency of A)" : neq)
                                 )
                             )
                         )

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -259,6 +259,7 @@ tests =
             whenEq = onlyConstrained OnlyConstrainedEq
             eq1 = C.thisVersion $ mkSimpleVersion 1
             gt0 = C.laterVersion $ C.mkVersion [0]
+            ge1 = C.orLaterVersion $ C.mkVersion [1]
             eqGt = C.intersectVersionRanges eq1 gt0
             mkConstraint pkg vr = ExVersionConstraint (ScopeAnyQualifier pkg) vr
             eqConstraints =
@@ -272,6 +273,10 @@ tests =
             eqGtConstraints =
               [ mkConstraint "B" eqGt
               , mkConstraint "C" eqGt
+              ]
+            geConstraints =
+              [ mkConstraint "B" ge1
+              , mkConstraint "C" ge1
               ]
          in [ testGroup
                 "=none"
@@ -305,7 +310,7 @@ tests =
                 [ runTest . whenAll $
                     mkTest
                       db12
-                      "goal E missing syb"
+                      "goal E missing syb failure"
                       ["E"]
                       ( solverFailure
                           ( \m ->
@@ -332,7 +337,7 @@ tests =
                 , runTest . whenAll $
                     mkTest
                       db17
-                      "goal A failure message"
+                      "goal A failure"
                       ["A"]
                       (solverFailure . isInfixOf $ solverMsg "all")
                 , runTest . whenAll $
@@ -353,6 +358,12 @@ tests =
                     )
                       { testConstraints = eqGtConstraints
                       }
+                , runTest . whenAll $
+                    ( mkTest db17 "goal A with B >=1, C >=1" ["A"] $
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = geConstraints
+                      }
                 ]
             , testGroup "=eq" $
                 let eGoalFailure m =
@@ -365,13 +376,13 @@ tests =
                  in [ runTest . whenEq $
                         mkTest
                           db12
-                          "goal E missing syb"
+                          "goal E missing syb failure"
                           ["E"]
                           (solverFailure eGoalFailure)
                     , runTest . whenEq $
                         mkTest
                           db12
-                          "all goals"
+                          "all goals failure"
                           ["E", "syb"]
                           (solverFailure eGoalFailure)
                     , runTest . whenEq $
@@ -383,7 +394,7 @@ tests =
                     , runTest . whenEq $
                         mkTest
                           db17
-                          "goal A failure message"
+                          "goal A failure"
                           ["A"]
                           (solverFailure . isInfixOf $ solverMsg "eq")
                     , runTest . whenEq $
@@ -398,7 +409,7 @@ tests =
                     , runTest . whenEq $
                         ( mkTest
                             db17
-                            "goal A with B >0, C >0 failure message"
+                            "goal A with B >0, C >0 failure"
                             ["A"]
                             ( solverFailure
                                 ( \m ->
@@ -421,6 +432,24 @@ tests =
                             (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
                         )
                           { testConstraints = eqGtConstraints
+                          }
+                    , runTest . whenEq $
+                        ( mkTest
+                            db17
+                            "goal A with B >=1, C >=1 failure"
+                            ["A"]
+                            ( solverFailure
+                                ( \m ->
+                                    all
+                                      (`isInfixOf` m)
+                                      [ "next goal: C (dependency of A)"
+                                      , "not a user-provided goal nor mentioned as a constraint"
+                                      , "but reject-unconstrained-dependencies=eq was set"
+                                      ]
+                                )
+                            )
+                        )
+                          { testConstraints = geConstraints
                           }
                     ]
             ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -262,14 +262,20 @@ tests =
             eq1 = C.thisVersion $ mkSimpleVersion 1
             eq2 = C.thisVersion $ mkSimpleVersion 2
 
-            -- >0
+            -- >0, >1
             gt0 = C.laterVersion $ C.mkVersion [0]
+            gt1 = C.laterVersion $ C.mkVersion [1]
 
-            -- <2
+            -- <1, <2
+            lt1 = C.earlierVersion $ C.mkVersion [2]
             lt2 = C.earlierVersion $ C.mkVersion [2]
 
             -- >=1
             ge1 = C.orLaterVersion $ C.mkVersion [1]
+
+            -- ==1 || >1, ==1 || <1
+            eqOrGt1 = C.unionVersionRanges eq1 gt1
+            eqOrLt1 = C.unionVersionRanges eq1 lt1
 
             -- \^>=1
             ce1 = C.majorBoundVersion $ mkSimpleVersion 1
@@ -282,13 +288,13 @@ tests =
             eqGt = C.intersectVersionRanges eq1 gt0
 
             -- ==1 || >0
-            eqOrGt = C.unionVersionRanges eq1 gt0
+            eq1OrGt0 = C.unionVersionRanges eq1 gt0
 
             -- >0 && ==1
             gtEq = C.intersectVersionRanges gt0 eq1
 
             -- >0 || ==1
-            gtOrEq = C.unionVersionRanges gt0 eq1
+            gt0OrEq1 = C.unionVersionRanges gt0 eq1
 
             -- ==1 || ==2
             eqOrEq = C.unionVersionRanges eq1 eq2
@@ -321,8 +327,8 @@ tests =
 
             -- B ==1 || >0, C >0 || ==1
             eqOrGtConstraints =
-              [ mkConstraint "B" eqOrGt
-              , mkConstraint "C" gtOrEq
+              [ mkConstraint "B" eq1OrGt0
+              , mkConstraint "C" gt0OrEq1
               ]
 
             -- B >=1, C <=1
@@ -335,6 +341,12 @@ tests =
             celeConstraints =
               [ mkConstraint "B" ce1
               , mkConstraint "C" ce1
+              ]
+
+            -- B ==1 || >1, C ==1 || <1
+            eqOrGt1Constraints =
+              [ mkConstraint "B" eqOrGt1
+              , mkConstraint "C" eqOrLt1
               ]
 
             -- B ==1 || ==2, C ==1 || ==2
@@ -392,6 +404,10 @@ tests =
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] solveABC)
                       { testConstraints = legeConstraints
+                      }
+                , runTest . whenAll $
+                    (mkTest db17 "goal A with B ==1 || >1, C ==1 || <1" ["A"] solveABC)
+                      { testConstraints = eqOrGt1Constraints
                       }
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B ==1 || ==2, C ==1 || ==2" ["A"] solveABC)
@@ -478,6 +494,10 @@ tests =
                     , runTest . whenEq $
                         (mkTest db17 "goal A with B ^>=1, C ^>=1" ["A"] eqFailure)
                           { testConstraints = celeConstraints
+                          }
+                    , runTest . whenEq $
+                        (mkTest db17 "goal A with B ==1 || >1, C ==1 || <1" ["A"] eqFailure)
+                          { testConstraints = eqOrGt1Constraints
                           }
                     , runTest . whenEq $
                         (mkTest db17 "goal A with B ==1 || ==2, C ==1 || ==2" ["A"] eqFailure)

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | This is a set of unit tests for the dependency solver,
 -- which uses the solver DSL ("UnitTests.Distribution.Solver.Modular.DSL")
@@ -23,10 +24,12 @@ import Language.Haskell.Extension
   )
 
 -- cabal-install
+
 import Distribution.Solver.Types.Flag
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackagePath as P
+import Distribution.Solver.Types.Settings (OnlyConstrained (..))
 import UnitTests.Distribution.Solver.Modular.DSL
 import UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
 
@@ -238,32 +241,96 @@ tests =
       ]
   , testGroup
       "reject-unconstrained"
-      [ runTest $
-          onlyConstrained $
-            mkTest db12 "missing syb" ["E"] $
-              solverFailure (isInfixOf "not a user-provided goal")
-      , runTest $
-          onlyConstrained $
-            mkTest db12 "all goals" ["E", "syb"] $
-              solverSuccess [("E", 1), ("syb", 2)]
-      , runTest $
-          onlyConstrained $
-            mkTest db17 "backtracking" ["A", "B"] $
-              solverSuccess [("A", 2), ("B", 1)]
-      , runTest $
-          onlyConstrained $
-            mkTest db17 "failure message" ["A"] $
-              solverFailure $
-                isInfixOf $
-                  "Could not resolve dependencies:\n"
-                    ++ "[__0] trying: A-3 (user goal)\n"
-                    ++ "[__1] next goal: C (dependency of A)\n"
-                    ++ "[__1] fail (not a user-provided goal nor mentioned as a constraint, "
-                    ++ "but reject-unconstrained-dependencies was set)\n"
-                    ++ "[__1] fail (backjumping, conflict set: A, C)\n"
-                    ++ "After searching the rest of the dependency tree exhaustively, "
-                    ++ "these were the goals I've had most trouble fulfilling: A, C, B"
-      ]
+      $ let solverMsg condition =
+              "Could not resolve dependencies:\n"
+                ++ "[__0] trying: A-3.0.0 (user goal)\n"
+                ++ "[__1] next goal: C (dependency of A)\n"
+                ++ "[__1] fail (not a user-provided goal nor mentioned as a constraint, "
+                ++ "but reject-unconstrained-dependencies="
+                ++ condition
+                ++ " was set)\n"
+                ++ "[__1] fail (backjumping, conflict set: A, C)\n"
+                ++ "After searching the rest of the dependency tree exhaustively, "
+                ++ "these were the goals I've had most trouble fulfilling: A, C, B"
+            whenNone = onlyConstrained OnlyConstrainedNone
+            whenAll = onlyConstrained OnlyConstrainedAll
+            whenEq = onlyConstrained OnlyConstrainedEq
+         in [ testGroup
+                "=none"
+                [ runTest $
+                    whenNone $
+                      mkTest db12 "goal E" ["E"] $
+                        solverSuccess [("E", 1), ("syb", 2)]
+                , runTest $
+                    whenNone $
+                      mkTest db12 "all goals" ["E", "syb"] $
+                        solverSuccess [("E", 1), ("syb", 2)]
+                , runTest $
+                    whenNone $
+                      mkTest db17 "goal A B: backtracking" ["A", "B"] $
+                        solverSuccess [("A", 3), ("B", 1), ("C", 1)]
+                , runTest $
+                    whenNone $
+                      mkTest db17 "goal A" ["A"] $
+                        solverSuccess [("A", 3), ("B", 1), ("C", 1)]
+                ]
+            , testGroup
+                "=all"
+                [ runTest $
+                    whenAll $
+                      mkTest db12 "goal E: missing syb" ["E"] $
+                        solverFailure
+                          ( \m ->
+                              all
+                                (`isInfixOf` m)
+                                [ "next goal: syb (dependency of E)"
+                                , "not a user-provided goal nor mentioned as a constraint"
+                                , "but reject-unconstrained-dependencies=all was set"
+                                ]
+                          )
+                , runTest $
+                    whenAll $
+                      mkTest db12 "all goals" ["E", "syb"] $
+                        solverSuccess [("E", 1), ("syb", 2)]
+                , runTest $
+                    whenAll $
+                      mkTest db17 "goal A B: backtracking" ["A", "B"] $
+                        solverSuccess [("A", 2), ("B", 1)]
+                , runTest $
+                    whenAll $
+                      mkTest db17 "goal A: failure message" ["A"] $
+                        solverFailure $
+                          isInfixOf $
+                            solverMsg "all"
+                ]
+            , testGroup "=eq" $
+                let eGoalFailure m =
+                      all
+                        (`isInfixOf` m)
+                        [ "next goal: E.base (dependency of E)"
+                        , "not a user-provided goal nor mentioned as a constraint"
+                        , "but reject-unconstrained-dependencies=eq was set"
+                        ]
+                 in [ runTest $
+                        whenEq $
+                          mkTest db12 "goal E: missing syb" ["E"] $
+                            solverFailure eGoalFailure
+                    , runTest $
+                        whenEq $
+                          mkTest db12 "all goals" ["E", "syb"] $
+                            solverFailure eGoalFailure
+                    , runTest $
+                        whenEq $
+                          mkTest db17 "goal A B: backtracking" ["A", "B"] $
+                            solverSuccess [("A", 2), ("B", 1)]
+                    , runTest $
+                        whenEq $
+                          mkTest db17 "goal A: failure message" ["A"] $
+                            solverFailure $
+                              isInfixOf $
+                                solverMsg "eq"
+                    ]
+            ]
   , testGroup
       "Cycles"
       [ runTest $ mkTest db14 "simpleCycle1" ["A"] anySolverFailure

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -257,13 +257,21 @@ tests =
             whenNone = onlyConstrained OnlyConstrainedNone
             whenAll = onlyConstrained OnlyConstrainedAll
             whenEq = onlyConstrained OnlyConstrainedEq
+            eq1 = C.thisVersion $ mkSimpleVersion 1
+            gt0 = C.laterVersion $ C.mkVersion [0]
+            eqGt = C.intersectVersionRanges eq1 gt0
+            mkConstraint pkg vr = ExVersionConstraint (ScopeAnyQualifier pkg) vr
             eqConstraints =
-              [ ExVersionConstraint (ScopeAnyQualifier "B") (C.thisVersion $ mkSimpleVersion 1)
-              , ExVersionConstraint (ScopeAnyQualifier "C") (C.thisVersion $ mkSimpleVersion 1)
+              [ mkConstraint "B" eq1
+              , mkConstraint "C" eq1
               ]
             gtConstraints =
-              [ ExVersionConstraint (ScopeAnyQualifier "B") (C.laterVersion $ mkSimpleVersion 0)
-              , ExVersionConstraint (ScopeAnyQualifier "C") (C.laterVersion $ mkSimpleVersion 0)
+              [ mkConstraint "B" gt0
+              , mkConstraint "C" gt0
+              ]
+            eqGtConstraints =
+              [ mkConstraint "B" eqGt
+              , mkConstraint "C" eqGt
               ]
          in [ testGroup
                 "=none"
@@ -339,6 +347,12 @@ tests =
                     )
                       { testConstraints = gtConstraints
                       }
+                , runTest . whenAll $
+                    ( mkTest db17 "goal A with B >0 && ==1, C >0 && ==1" ["A"] $
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = eqGtConstraints
+                      }
                 ]
             , testGroup "=eq" $
                 let eGoalFailure m =
@@ -398,6 +412,15 @@ tests =
                             )
                         )
                           { testConstraints = gtConstraints
+                          }
+                    , runTest . whenEq $
+                        ( mkTest
+                            db17
+                            "goal A with B >0 && ==1, C >0 && ==1"
+                            ["A"]
+                            (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                        )
+                          { testConstraints = eqGtConstraints
                           }
                     ]
             ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -270,6 +270,9 @@ tests =
             -- >=1
             ge1 = C.orLaterVersion $ C.mkVersion [1]
 
+            -- \^>=1
+            ce1 = C.majorBoundVersion $ mkSimpleVersion 1
+
             -- TODO: Find out why <=1 is not the same as <=1.0.0
             -- <=1
             le1 = C.orEarlierVersion $ C.mkVersion [1, 0, 0]
@@ -324,6 +327,12 @@ tests =
               , mkConstraint "C" le1
               ]
 
+            -- B ^>=1, C <=1
+            celeConstraints =
+              [ mkConstraint "B" ce1
+              , mkConstraint "C" ce1
+              ]
+
             -- B <=1 && >=1, C <=1 && >=1
             legeConstraints =
               [ mkConstraint "B" lege1
@@ -365,6 +374,10 @@ tests =
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B >=1, C <=1" ["A"] solveABC)
                       { testConstraints = geleConstraints
+                      }
+                , runTest . whenAll $
+                    (mkTest db17 "goal A with B ^>=1, C ^>=1" ["A"] solveABC)
+                      { testConstraints = celeConstraints
                       }
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] solveABC)
@@ -447,6 +460,10 @@ tests =
                     , runTest . whenEq $
                         (mkTest db17 "goal A with B >=1, C <=1" ["A"] eqFailure)
                           { testConstraints = geleConstraints
+                          }
+                    , runTest . whenEq $
+                        (mkTest db17 "goal A with B ^>=1, C ^>=1" ["A"] eqFailure)
+                          { testConstraints = celeConstraints
                           }
                     , runTest . whenEq $
                         (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] eqFailure)

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -260,6 +260,8 @@ tests =
             eq1 = C.thisVersion $ mkSimpleVersion 1
             gt0 = C.laterVersion $ C.mkVersion [0]
             ge1 = C.orLaterVersion $ C.mkVersion [1]
+            -- TODO: Find out why <=1 is not the same as <=1.0.0
+            le1 = C.orEarlierVersion $ C.mkVersion [1, 0, 0]
             eqGt = C.intersectVersionRanges eq1 gt0
             mkConstraint pkg vr = ExVersionConstraint (ScopeAnyQualifier pkg) vr
             eqConstraints =
@@ -277,6 +279,10 @@ tests =
             geConstraints =
               [ mkConstraint "B" ge1
               , mkConstraint "C" ge1
+              ]
+            leConstraints =
+              [ mkConstraint "B" le1
+              , mkConstraint "C" le1
               ]
          in [ testGroup
                 "=none"
@@ -342,6 +348,12 @@ tests =
                         (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
                     )
                       { testConstraints = geConstraints
+                      }
+                , runTest . whenAll $
+                    ( mkTest db17 "goal A with B <=1, C <=1" ["A"] $
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = leConstraints
                       }
                 ]
             , testGroup
@@ -450,6 +462,21 @@ tests =
                             )
                         )
                           { testConstraints = geConstraints
+                          }
+                    , runTest . whenEq $
+                        ( mkTest
+                            db17
+                            "goal A with B <=1, C <=1"
+                            ["A"]
+                            ( solverFailure
+                                ( \m ->
+                                    all
+                                      (`isInfixOf` m)
+                                      ("next goal: C (dependency of A)" : neq)
+                                )
+                            )
+                        )
+                          { testConstraints = leConstraints
                           }
                     ]
             ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -258,8 +258,9 @@ tests =
             whenAll = onlyConstrained OnlyConstrainedAll
             whenEq = onlyConstrained OnlyConstrainedEq
 
-            -- ==1
+            -- ==1, ==2
             eq1 = C.thisVersion $ mkSimpleVersion 1
+            eq2 = C.thisVersion $ mkSimpleVersion 2
 
             -- >0
             gt0 = C.laterVersion $ C.mkVersion [0]
@@ -280,7 +281,7 @@ tests =
             -- ==1 && >0
             eqGt = C.intersectVersionRanges eq1 gt0
 
-            -- ==1 | >0
+            -- ==1 || >0
             eqOrGt = C.unionVersionRanges eq1 gt0
 
             -- >0 && ==1
@@ -288,6 +289,9 @@ tests =
 
             -- >0 || ==1
             gtOrEq = C.unionVersionRanges gt0 eq1
+
+            -- ==1 || ==2
+            eqOrEq = C.unionVersionRanges eq1 eq2
 
             -- <=1 && >=1
             lege1 = C.intersectVersionRanges le1 ge1
@@ -331,6 +335,12 @@ tests =
             celeConstraints =
               [ mkConstraint "B" ce1
               , mkConstraint "C" ce1
+              ]
+
+            -- B ==1 || ==2, C ==1 || ==2
+            eqOrEqConstraints =
+              [ mkConstraint "B" eqOrEq
+              , mkConstraint "C" eqOrEq
               ]
 
             -- B <=1 && >=1, C <=1 && >=1
@@ -382,6 +392,10 @@ tests =
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] solveABC)
                       { testConstraints = legeConstraints
+                      }
+                , runTest . whenAll $
+                    (mkTest db17 "goal A with B ==1 || ==2, C ==1 || ==2" ["A"] solveABC)
+                      { testConstraints = eqOrEqConstraints
                       }
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B >0 && ==1 && <2, C >0 && ==1 && <2" ["A"] solveABC)
@@ -464,6 +478,10 @@ tests =
                     , runTest . whenEq $
                         (mkTest db17 "goal A with B ^>=1, C ^>=1" ["A"] eqFailure)
                           { testConstraints = celeConstraints
+                          }
+                    , runTest . whenEq $
+                        (mkTest db17 "goal A with B ==1 || ==2, C ==1 || ==2" ["A"] eqFailure)
+                          { testConstraints = eqOrEqConstraints
                           }
                     , runTest . whenEq $
                         (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] eqFailure)

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -245,7 +245,7 @@ tests =
       "reject-unconstrained"
       $ let solverMsg condition =
               "Could not resolve dependencies:\n"
-                ++ "[__0] trying: A-3.0.0 (user goal)\n"
+                ++ "[__0] trying: A-3 (user goal)\n"
                 ++ "[__1] next goal: C (dependency of A)\n"
                 ++ "[__1] fail (not a user-provided goal nor mentioned as a constraint, "
                 ++ "but reject-unconstrained-dependencies="

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -427,6 +427,13 @@ tests =
                       all
                         (`isInfixOf` m)
                         ("next goal: E.base (dependency of E)" : neq)
+                    eqFailure =
+                      solverFailure
+                        ( \m ->
+                            all
+                              (`isInfixOf` m)
+                              ("next goal: C (dependency of A)" : neq)
+                        )
                  in [ runTest . whenEq $
                         mkTest db12 "goal E missing syb" ["E"] (solverFailure eGoalFailure)
                     , runTest . whenEq $
@@ -434,63 +441,19 @@ tests =
                     , runTest . whenEq $
                         mkTest db17 "goal A" ["A"] (solverFailure . isInfixOf $ solverMsg "eq")
                     , runTest . whenEq $
-                        ( mkTest
-                            db17
-                            "goal A with B >0, C >0"
-                            ["A"]
-                            ( solverFailure
-                                ( \m ->
-                                    all
-                                      (`isInfixOf` m)
-                                      ("next goal: C (dependency of A)" : neq)
-                                )
-                            )
-                        )
+                        (mkTest db17 "goal A with B >0, C >0" ["A"] eqFailure)
                           { testConstraints = gtConstraints
                           }
                     , runTest . whenEq $
-                        ( mkTest
-                            db17
-                            "goal A with B >=1, C <=1"
-                            ["A"]
-                            ( solverFailure
-                                ( \m ->
-                                    all
-                                      (`isInfixOf` m)
-                                      ("next goal: C (dependency of A)" : neq)
-                                )
-                            )
-                        )
+                        (mkTest db17 "goal A with B >=1, C <=1" ["A"] eqFailure)
                           { testConstraints = geleConstraints
                           }
                     , runTest . whenEq $
-                        ( mkTest
-                            db17
-                            "goal A with B <=1 && >=1, C <=1 && >=1"
-                            ["A"]
-                            ( solverFailure
-                                ( \m ->
-                                    all
-                                      (`isInfixOf` m)
-                                      ("next goal: C (dependency of A)" : neq)
-                                )
-                            )
-                        )
+                        (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] eqFailure)
                           { testConstraints = legeConstraints
                           }
                     , runTest . whenEq $
-                        ( mkTest
-                            db17
-                            "goal A with B ==1 || >0, C >0 || ==1"
-                            ["A"]
-                            ( solverFailure
-                                ( \m ->
-                                    all
-                                      (`isInfixOf` m)
-                                      ("next goal: C (dependency of A)" : neq)
-                                )
-                            )
-                        )
+                        (mkTest db17 "goal A with B ==1 || >0, C >0 || ==1" ["A"] eqFailure)
                           { testConstraints = eqOrGtConstraints
                           }
                     ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -262,7 +262,13 @@ tests =
             ge1 = C.orLaterVersion $ C.mkVersion [1]
             -- TODO: Find out why <=1 is not the same as <=1.0.0
             le1 = C.orEarlierVersion $ C.mkVersion [1, 0, 0]
+
+            -- ==1 && >0
             eqGt = C.intersectVersionRanges eq1 gt0
+
+            -- ==1 && >0
+            gtEq = C.intersectVersionRanges gt0 eq1
+
             mkConstraint pkg vr = ExVersionConstraint (ScopeAnyQualifier pkg) vr
             eqConstraints =
               [ mkConstraint "B" eq1
@@ -274,7 +280,7 @@ tests =
               ]
             eqGtConstraints =
               [ mkConstraint "B" eqGt
-              , mkConstraint "C" eqGt
+              , mkConstraint "C" gtEq
               ]
             geleConstraints =
               [ mkConstraint "B" ge1
@@ -334,7 +340,7 @@ tests =
                       { testConstraints = gtConstraints
                       }
                 , runTest . whenAll $
-                    ( mkTest db17 "goal A with B >0 && ==1, C >0 && ==1" ["A"] $
+                    ( mkTest db17 "goal A with B ==1 && >0, C >0 && ==1" ["A"] $
                         (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
                     )
                       { testConstraints = eqGtConstraints
@@ -389,7 +395,7 @@ tests =
                 , runTest . whenEq $
                     ( mkTest
                         db17
-                        "goal A with B >0 && ==1, C >0 && ==1"
+                        "goal A with B ==1 && >0, C >0 && ==1"
                         ["A"]
                         (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
                     )

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -276,12 +276,8 @@ tests =
               [ mkConstraint "B" eqGt
               , mkConstraint "C" eqGt
               ]
-            geConstraints =
+            geleConstraints =
               [ mkConstraint "B" ge1
-              , mkConstraint "C" ge1
-              ]
-            leConstraints =
-              [ mkConstraint "B" le1
               , mkConstraint "C" le1
               ]
          in [ testGroup
@@ -344,16 +340,10 @@ tests =
                       { testConstraints = eqGtConstraints
                       }
                 , runTest . whenAll $
-                    ( mkTest db17 "goal A with B >=1, C >=1" ["A"] $
+                    ( mkTest db17 "goal A with B >=1, C <=1" ["A"] $
                         (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
                     )
-                      { testConstraints = geConstraints
-                      }
-                , runTest . whenAll $
-                    ( mkTest db17 "goal A with B <=1, C <=1" ["A"] $
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
-                      { testConstraints = leConstraints
+                      { testConstraints = geleConstraints
                       }
                 ]
             , testGroup
@@ -451,7 +441,7 @@ tests =
                     , runTest . whenEq $
                         ( mkTest
                             db17
-                            "goal A with B >=1, C >=1"
+                            "goal A with B >=1, C <=1"
                             ["A"]
                             ( solverFailure
                                 ( \m ->
@@ -461,22 +451,7 @@ tests =
                                 )
                             )
                         )
-                          { testConstraints = geConstraints
-                          }
-                    , runTest . whenEq $
-                        ( mkTest
-                            db17
-                            "goal A with B <=1, C <=1"
-                            ["A"]
-                            ( solverFailure
-                                ( \m ->
-                                    all
-                                      (`isInfixOf` m)
-                                      ("next goal: C (dependency of A)" : neq)
-                                )
-                            )
-                        )
-                          { testConstraints = leConstraints
+                          { testConstraints = geleConstraints
                           }
                     ]
             ]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -446,7 +446,9 @@ tests =
                           ["A"]
                           (solverFailure . isInfixOf $ solverMsg "all")
                     ]
-            , testGroup "=eq" [ runTest . whenEq $ mkTest db17 "goal A B backtracking" ["A", "B"] solveAB
+            , testGroup
+                "=eq"
+                [ runTest . whenEq $ mkTest db17 "goal A B backtracking" ["A", "B"] solveAB
                 , runTest . whenEq $
                     (mkTest db17 "goal A with B ==1, C ==1" ["A"] solveABC)
                       { testConstraints = eqConstraints

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -446,8 +446,7 @@ tests =
                           ["A"]
                           (solverFailure . isInfixOf $ solverMsg "all")
                     ]
-            , testGroup "=eq" $
-                [ runTest . whenEq $ mkTest db17 "goal A B backtracking" ["A", "B"] solveAB
+            , testGroup "=eq" [ runTest . whenEq $ mkTest db17 "goal A B backtracking" ["A", "B"] solveAB
                 , runTest . whenEq $
                     (mkTest db17 "goal A with B ==1, C ==1" ["A"] solveABC)
                       { testConstraints = eqConstraints

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -351,13 +351,13 @@ tests =
          in [ testGroup
                 "=none"
                 [ runTest . whenNone $ mkTest db12 "goal E" ["E"] solveEsyb
-                , runTest . whenNone $ mkTest db12 "all goals" ["E", "syb"] solveEsyb
+                , runTest . whenNone $ mkTest db12 "goal all" ["E", "syb"] solveEsyb
                 , runTest . whenNone $ mkTest db17 "goal A B backtracking" ["A", "B"] solveABC
                 , runTest . whenNone $ mkTest db17 "goal A" ["A"] solveABC
                 ]
             , testGroup
                 "=all"
-                [ runTest . whenAll $ mkTest db12 "all goals" ["E", "syb"] solveEsyb
+                [ runTest . whenAll $ mkTest db12 "goal all" ["E", "syb"] solveEsyb
                 , runTest . whenAll $ mkTest db17 "goal A B backtracking" ["A", "B"] solveAB
                 , runTest . whenAll $
                     (mkTest db17 "goal A with B ==1, C ==1" ["A"] solveABC)
@@ -450,7 +450,7 @@ tests =
                  in [ runTest . whenEq $
                         mkTest db12 "goal E missing syb" ["E"] (solverFailure eGoalFailure)
                     , runTest . whenEq $
-                        mkTest db12 "all goals" ["E", "syb"] (solverFailure eGoalFailure)
+                        mkTest db12 "goal all" ["E", "syb"] (solverFailure eGoalFailure)
                     , runTest . whenEq $
                         mkTest db17 "goal A" ["A"] (solverFailure . isInfixOf $ solverMsg "eq")
                     , runTest . whenEq $

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -298,78 +298,39 @@ tests =
               [ mkConstraint "B" lege1
               , mkConstraint "C" lege1
               ]
+
+            solveABC = solverSuccess [("A", 3), ("B", 1), ("C", 1)]
+            solveAB = solverSuccess [("A", 2), ("B", 1)]
+            solveEsyb = solverSuccess [("E", 1), ("syb", 2)]
          in [ testGroup
                 "=none"
-                [ runTest . whenNone $
-                    mkTest
-                      db12
-                      "goal E"
-                      ["E"]
-                      (solverSuccess [("E", 1), ("syb", 2)])
-                , runTest . whenNone $
-                    mkTest
-                      db12
-                      "all goals"
-                      ["E", "syb"]
-                      (solverSuccess [("E", 1), ("syb", 2)])
-                , runTest . whenNone $
-                    mkTest
-                      db17
-                      "goal A B backtracking"
-                      ["A", "B"]
-                      (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                , runTest . whenNone $
-                    mkTest
-                      db17
-                      "goal A"
-                      ["A"]
-                      (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                [ runTest . whenNone $ mkTest db12 "goal E" ["E"] solveEsyb
+                , runTest . whenNone $ mkTest db12 "all goals" ["E", "syb"] solveEsyb
+                , runTest . whenNone $ mkTest db17 "goal A B backtracking" ["A", "B"] solveABC
+                , runTest . whenNone $ mkTest db17 "goal A" ["A"] solveABC
                 ]
             , testGroup
                 "=all"
-                [ runTest . whenAll $
-                    mkTest
-                      db12
-                      "all goals"
-                      ["E", "syb"]
-                      (solverSuccess [("E", 1), ("syb", 2)])
+                [ runTest . whenAll $ mkTest db12 "all goals" ["E", "syb"] solveEsyb
+                , runTest . whenAll $ mkTest db17 "goal A B backtracking" ["A", "B"] solveAB
                 , runTest . whenAll $
-                    mkTest
-                      db17
-                      "goal A B backtracking"
-                      ["A", "B"]
-                      (solverSuccess [("A", 2), ("B", 1)])
-                , runTest . whenAll $
-                    ( mkTest db17 "goal A with B ==1, C ==1" ["A"] $
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
+                    (mkTest db17 "goal A with B ==1, C ==1" ["A"] solveABC)
                       { testConstraints = eqConstraints
                       }
                 , runTest . whenAll $
-                    ( mkTest db17 "goal A with B >0, C >0" ["A"] $
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
+                    (mkTest db17 "goal A with B >0, C >0" ["A"] solveABC)
                       { testConstraints = gtConstraints
                       }
                 , runTest . whenAll $
-                    ( mkTest db17 "goal A with B ==1 && >0, C >0 && ==1" ["A"] $
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
+                    (mkTest db17 "goal A with B ==1 && >0, C >0 && ==1" ["A"] solveABC)
                       { testConstraints = eqGtConstraints
                       }
                 , runTest . whenAll $
-                    ( mkTest db17 "goal A with B >=1, C <=1" ["A"] $
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
+                    (mkTest db17 "goal A with B >=1, C <=1" ["A"] solveABC)
                       { testConstraints = geleConstraints
                       }
                 , runTest . whenAll $
-                    ( mkTest
-                        db17
-                        "goal A with B <=1 && >=1, C <=1 && >=1"
-                        ["A"]
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
+                    (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] solveABC)
                       { testConstraints = legeConstraints
                       }
                 ]
@@ -398,28 +359,13 @@ tests =
                           (solverFailure . isInfixOf $ solverMsg "all")
                     ]
             , testGroup "=eq" $
-                [ runTest . whenEq $
-                    mkTest
-                      db17
-                      "goal A B backtracking"
-                      ["A", "B"]
-                      (solverSuccess [("A", 2), ("B", 1)])
+                [ runTest . whenEq $ mkTest db17 "goal A B backtracking" ["A", "B"] solveAB
                 , runTest . whenEq $
-                    ( mkTest
-                        db17
-                        "goal A with B ==1, C ==1"
-                        ["A"]
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
+                    (mkTest db17 "goal A with B ==1, C ==1" ["A"] solveABC)
                       { testConstraints = eqConstraints
                       }
                 , runTest . whenEq $
-                    ( mkTest
-                        db17
-                        "goal A with B ==1 && >0, C >0 && ==1"
-                        ["A"]
-                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
-                    )
+                    (mkTest db17 "goal A with B ==1 && >0, C >0 && ==1" ["A"] solveABC)
                       { testConstraints = eqGtConstraints
                       }
                 ]
@@ -433,23 +379,11 @@ tests =
                         (`isInfixOf` m)
                         ("next goal: E.base (dependency of E)" : neq)
                  in [ runTest . whenEq $
-                        mkTest
-                          db12
-                          "goal E missing syb"
-                          ["E"]
-                          (solverFailure eGoalFailure)
+                        mkTest db12 "goal E missing syb" ["E"] (solverFailure eGoalFailure)
                     , runTest . whenEq $
-                        mkTest
-                          db12
-                          "all goals"
-                          ["E", "syb"]
-                          (solverFailure eGoalFailure)
+                        mkTest db12 "all goals" ["E", "syb"] (solverFailure eGoalFailure)
                     , runTest . whenEq $
-                        mkTest
-                          db17
-                          "goal A"
-                          ["A"]
-                          (solverFailure . isInfixOf $ solverMsg "eq")
+                        mkTest db17 "goal A" ["A"] (solverFailure . isInfixOf $ solverMsg "eq")
                     , runTest . whenEq $
                         ( mkTest
                             db17

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -259,6 +259,7 @@ tests =
             whenEq = onlyConstrained OnlyConstrainedEq
             eq1 = C.thisVersion $ mkSimpleVersion 1
             gt0 = C.laterVersion $ C.mkVersion [0]
+            lt2 = C.earlierVersion $ C.mkVersion [2]
             ge1 = C.orLaterVersion $ C.mkVersion [1]
             -- TODO: Find out why <=1 is not the same as <=1.0.0
             le1 = C.orEarlierVersion $ C.mkVersion [1, 0, 0]
@@ -266,11 +267,14 @@ tests =
             -- ==1 && >0
             eqGt = C.intersectVersionRanges eq1 gt0
 
-            -- ==1 && >0
+            -- >0 && ==1
             gtEq = C.intersectVersionRanges gt0 eq1
 
             -- <=1 && >=1
             lege1 = C.intersectVersionRanges le1 ge1
+
+            -- >0 && ==1 && <2
+            gtEqLt = C.intersectVersionRanges gtEq lt2
 
             mkConstraint pkg vr = ExVersionConstraint (ScopeAnyQualifier pkg) vr
             -- B ==1, C ==1
@@ -297,6 +301,11 @@ tests =
             legeConstraints =
               [ mkConstraint "B" lege1
               , mkConstraint "C" lege1
+              ]
+            -- B >0 && ==1 && <2, C >0 && ==1 && <2
+            gtEqLtConstraints =
+              [ mkConstraint "B" gtEqLt
+              , mkConstraint "C" gtEqLt
               ]
 
             solveABC = solverSuccess [("A", 3), ("B", 1), ("C", 1)]
@@ -333,6 +342,10 @@ tests =
                     (mkTest db17 "goal A with B <=1 && >=1, C <=1 && >=1" ["A"] solveABC)
                       { testConstraints = legeConstraints
                       }
+                , runTest . whenAll $
+                    (mkTest db17 "goal A with B >0 && ==1 && <2, C >0 && ==1 && <2" ["A"] solveABC)
+                      { testConstraints = gtEqLtConstraints
+                      }
                 ]
             , testGroup "=all rejects" $
                 let nall =
@@ -367,6 +380,10 @@ tests =
                 , runTest . whenEq $
                     (mkTest db17 "goal A with B ==1 && >0, C >0 && ==1" ["A"] solveABC)
                       { testConstraints = eqGtConstraints
+                      }
+                , runTest . whenEq $
+                    (mkTest db17 "goal A with B >0 && ==1 && <2, C >0 && ==1 && <2" ["A"] solveABC)
+                      { testConstraints = gtEqLtConstraints
                       }
                 ]
             , testGroup "=eq rejects" $

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -17,6 +17,8 @@ import Test.Tasty as TF
 import Test.Tasty.ExpectedFailure
 
 -- Cabal
+
+import qualified Distribution.Version as C
 import Language.Haskell.Extension
   ( Extension (..)
   , KnownExtension (..)
@@ -31,7 +33,7 @@ import Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackagePath as P
 import Distribution.Solver.Types.Settings (OnlyConstrained (..))
 import UnitTests.Distribution.Solver.Modular.DSL
-import UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
+import UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils hiding (testMinimizeConflictSet)
 
 tests :: [TF.TestTree]
 tests =
@@ -255,31 +257,49 @@ tests =
             whenNone = onlyConstrained OnlyConstrainedNone
             whenAll = onlyConstrained OnlyConstrainedAll
             whenEq = onlyConstrained OnlyConstrainedEq
+            eqConstraints =
+              [ ExVersionConstraint (ScopeAnyQualifier "B") (C.thisVersion $ mkSimpleVersion 1)
+              , ExVersionConstraint (ScopeAnyQualifier "C") (C.thisVersion $ mkSimpleVersion 1)
+              ]
+            gtConstraints =
+              [ ExVersionConstraint (ScopeAnyQualifier "B") (C.laterVersion $ mkSimpleVersion 0)
+              , ExVersionConstraint (ScopeAnyQualifier "C") (C.laterVersion $ mkSimpleVersion 0)
+              ]
          in [ testGroup
                 "=none"
-                [ runTest $
-                    whenNone $
-                      mkTest db12 "goal E" ["E"] $
-                        solverSuccess [("E", 1), ("syb", 2)]
-                , runTest $
-                    whenNone $
-                      mkTest db12 "all goals" ["E", "syb"] $
-                        solverSuccess [("E", 1), ("syb", 2)]
-                , runTest $
-                    whenNone $
-                      mkTest db17 "goal A B: backtracking" ["A", "B"] $
-                        solverSuccess [("A", 3), ("B", 1), ("C", 1)]
-                , runTest $
-                    whenNone $
-                      mkTest db17 "goal A" ["A"] $
-                        solverSuccess [("A", 3), ("B", 1), ("C", 1)]
+                [ runTest . whenNone $
+                    mkTest
+                      db12
+                      "goal E"
+                      ["E"]
+                      (solverSuccess [("E", 1), ("syb", 2)])
+                , runTest . whenNone $
+                    mkTest
+                      db12
+                      "all goals"
+                      ["E", "syb"]
+                      (solverSuccess [("E", 1), ("syb", 2)])
+                , runTest . whenNone $
+                    mkTest
+                      db17
+                      "goal A B backtracking"
+                      ["A", "B"]
+                      (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                , runTest . whenNone $
+                    mkTest
+                      db17
+                      "goal A"
+                      ["A"]
+                      (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
                 ]
             , testGroup
                 "=all"
-                [ runTest $
-                    whenAll $
-                      mkTest db12 "goal E: missing syb" ["E"] $
-                        solverFailure
+                [ runTest . whenAll $
+                    mkTest
+                      db12
+                      "goal E missing syb"
+                      ["E"]
+                      ( solverFailure
                           ( \m ->
                               all
                                 (`isInfixOf` m)
@@ -288,20 +308,37 @@ tests =
                                 , "but reject-unconstrained-dependencies=all was set"
                                 ]
                           )
-                , runTest $
-                    whenAll $
-                      mkTest db12 "all goals" ["E", "syb"] $
-                        solverSuccess [("E", 1), ("syb", 2)]
-                , runTest $
-                    whenAll $
-                      mkTest db17 "goal A B: backtracking" ["A", "B"] $
-                        solverSuccess [("A", 2), ("B", 1)]
-                , runTest $
-                    whenAll $
-                      mkTest db17 "goal A: failure message" ["A"] $
-                        solverFailure $
-                          isInfixOf $
-                            solverMsg "all"
+                      )
+                , runTest . whenAll $
+                    mkTest
+                      db12
+                      "all goals"
+                      ["E", "syb"]
+                      (solverSuccess [("E", 1), ("syb", 2)])
+                , runTest . whenAll $
+                    mkTest
+                      db17
+                      "goal A B backtracking"
+                      ["A", "B"]
+                      (solverSuccess [("A", 2), ("B", 1)])
+                , runTest . whenAll $
+                    mkTest
+                      db17
+                      "goal A failure message"
+                      ["A"]
+                      (solverFailure . isInfixOf $ solverMsg "all")
+                , runTest . whenAll $
+                    ( mkTest db17 "goal A with B ==1, C ==1" ["A"] $
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = eqConstraints
+                      }
+                , runTest . whenAll $
+                    ( mkTest db17 "goal A with B >0, C >0" ["A"] $
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = gtConstraints
+                      }
                 ]
             , testGroup "=eq" $
                 let eGoalFailure m =
@@ -311,24 +348,57 @@ tests =
                         , "not a user-provided goal nor mentioned as a constraint"
                         , "but reject-unconstrained-dependencies=eq was set"
                         ]
-                 in [ runTest $
-                        whenEq $
-                          mkTest db12 "goal E: missing syb" ["E"] $
-                            solverFailure eGoalFailure
-                    , runTest $
-                        whenEq $
-                          mkTest db12 "all goals" ["E", "syb"] $
-                            solverFailure eGoalFailure
-                    , runTest $
-                        whenEq $
-                          mkTest db17 "goal A B: backtracking" ["A", "B"] $
-                            solverSuccess [("A", 2), ("B", 1)]
-                    , runTest $
-                        whenEq $
-                          mkTest db17 "goal A: failure message" ["A"] $
-                            solverFailure $
-                              isInfixOf $
-                                solverMsg "eq"
+                 in [ runTest . whenEq $
+                        mkTest
+                          db12
+                          "goal E missing syb"
+                          ["E"]
+                          (solverFailure eGoalFailure)
+                    , runTest . whenEq $
+                        mkTest
+                          db12
+                          "all goals"
+                          ["E", "syb"]
+                          (solverFailure eGoalFailure)
+                    , runTest . whenEq $
+                        mkTest
+                          db17
+                          "goal A B backtracking"
+                          ["A", "B"]
+                          (solverSuccess [("A", 2), ("B", 1)])
+                    , runTest . whenEq $
+                        mkTest
+                          db17
+                          "goal A failure message"
+                          ["A"]
+                          (solverFailure . isInfixOf $ solverMsg "eq")
+                    , runTest . whenEq $
+                        ( mkTest
+                            db17
+                            "goal A with B ==1, C ==1"
+                            ["A"]
+                            (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                        )
+                          { testConstraints = eqConstraints
+                          }
+                    , runTest . whenEq $
+                        ( mkTest
+                            db17
+                            "goal A with B >0, C >0 failure message"
+                            ["A"]
+                            ( solverFailure
+                                ( \m ->
+                                    all
+                                      (`isInfixOf` m)
+                                      [ "next goal: C (dependency of A)"
+                                      , "not a user-provided goal nor mentioned as a constraint"
+                                      , "but reject-unconstrained-dependencies=eq was set"
+                                      ]
+                                )
+                            )
+                        )
+                          { testConstraints = gtConstraints
+                          }
                     ]
             ]
   , testGroup

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -269,22 +269,34 @@ tests =
             -- ==1 && >0
             gtEq = C.intersectVersionRanges gt0 eq1
 
+            -- <=1 && >=1
+            lege1 = C.intersectVersionRanges le1 ge1
+
             mkConstraint pkg vr = ExVersionConstraint (ScopeAnyQualifier pkg) vr
+            -- B ==1, C ==1
             eqConstraints =
               [ mkConstraint "B" eq1
               , mkConstraint "C" eq1
               ]
+            -- B >0, C >0
             gtConstraints =
               [ mkConstraint "B" gt0
               , mkConstraint "C" gt0
               ]
+            -- B ==1 && >0, C >0 && ==1
             eqGtConstraints =
               [ mkConstraint "B" eqGt
               , mkConstraint "C" gtEq
               ]
+            -- B >=1, C <=1
             geleConstraints =
               [ mkConstraint "B" ge1
               , mkConstraint "C" le1
+              ]
+            -- B <=1 && >=1, C <=1 && >=1
+            legeConstraints =
+              [ mkConstraint "B" lege1
+              , mkConstraint "C" lege1
               ]
          in [ testGroup
                 "=none"
@@ -351,31 +363,40 @@ tests =
                     )
                       { testConstraints = geleConstraints
                       }
-                ]
-            , testGroup
-                "=all rejects"
-                [ runTest . whenAll $
-                    mkTest
-                      db12
-                      "goal E missing syb"
-                      ["E"]
-                      ( solverFailure
-                          ( \m ->
-                              all
-                                (`isInfixOf` m)
-                                [ "next goal: syb (dependency of E)"
-                                , "not a user-provided goal nor mentioned as a constraint"
-                                , "but reject-unconstrained-dependencies=all was set"
-                                ]
-                          )
-                      )
                 , runTest . whenAll $
-                    mkTest
-                      db17
-                      "goal A"
-                      ["A"]
-                      (solverFailure . isInfixOf $ solverMsg "all")
+                    ( mkTest
+                        db17
+                        "goal A with B <=1 && >=1, C <=1 && >=1"
+                        ["A"]
+                        (solverSuccess [("A", 3), ("B", 1), ("C", 1)])
+                    )
+                      { testConstraints = legeConstraints
+                      }
                 ]
+            , testGroup "=all rejects" $
+                let nall =
+                      [ "not a user-provided goal nor mentioned as a constraint"
+                      , "but reject-unconstrained-dependencies=all was set"
+                      ]
+                 in [ runTest . whenAll $
+                        mkTest
+                          db12
+                          "goal E missing syb"
+                          ["E"]
+                          ( solverFailure
+                              ( \m ->
+                                  all
+                                    (`isInfixOf` m)
+                                    ("next goal: syb (dependency of E)" : nall)
+                              )
+                          )
+                    , runTest . whenAll $
+                        mkTest
+                          db17
+                          "goal A"
+                          ["A"]
+                          (solverFailure . isInfixOf $ solverMsg "all")
+                    ]
             , testGroup "=eq" $
                 [ runTest . whenEq $
                     mkTest
@@ -458,6 +479,21 @@ tests =
                             )
                         )
                           { testConstraints = geleConstraints
+                          }
+                    , runTest . whenEq $
+                        ( mkTest
+                            db17
+                            "goal A with B <=1 && >=1, C <=1 && >=1"
+                            ["A"]
+                            ( solverFailure
+                                ( \m ->
+                                    all
+                                      (`isInfixOf` m)
+                                      ("next goal: C (dependency of A)" : neq)
+                                )
+                            )
+                        )
+                          { testConstraints = legeConstraints
                           }
                     ]
             ]

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-all.out
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-all.out
@@ -1,0 +1,37 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: b-0 (user goal)
+[__1] next goal: other-lib (dependency of b)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)
+[__1] fail (backjumping, conflict set: b, other-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), other-lib (1)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: b-0 (user goal)
+[__1] next goal: b:some-exe:exe.some-exe (dependency of b)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)
+[__1] fail (backjumping, conflict set: b, b:some-exe:exe.some-exe)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), b:some-exe:exe.some-exe (1)
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)
+# cabal build
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-all.out
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-all.out
@@ -6,7 +6,7 @@ Error: [Cabal-7107]
 Could not resolve dependencies:
 [__0] trying: b-0 (user goal)
 [__1] next goal: other-lib (dependency of b)
-[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=all was set)
 [__1] fail (backjumping, conflict set: b, other-lib)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), other-lib (1)
 # cabal build
@@ -15,7 +15,7 @@ Error: [Cabal-7107]
 Could not resolve dependencies:
 [__0] trying: b-0 (user goal)
 [__1] next goal: b:some-exe:exe.some-exe (dependency of b)
-[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=all was set)
 [__1] fail (backjumping, conflict set: b, b:some-exe:exe.some-exe)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), b:some-exe:exe.some-exe (1)
 # cabal build

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-eq.out
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-eq.out
@@ -24,6 +24,6 @@ Error: [Cabal-7107]
 Could not resolve dependencies:
 [__0] trying: a-0 (user goal)
 [__1] next goal: some-lib (dependency of a)
-[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=eq was set)
 [__1] fail (backjumping, conflict set: a, some-lib)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: a (2), some-lib (1)

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-eq.out
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.multipkg-eq.out
@@ -1,0 +1,29 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: a-0 (user goal)
+[__1] next goal: some-lib (dependency of a)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)
+[__1] fail (backjumping, conflict set: a, some-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: a (2), some-lib (1)

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
@@ -1,16 +1,68 @@
 import Test.Cabal.Prelude
+
 -- See #4332, dep solving output is not deterministic
-main = cabalTest . recordMode DoNotRecord $ withRepo "repo" $ do
-  -- other-lib is a dependency of b, but it's not listed in cabal.project
-  res <- fails $ cabal' "v2-build" ["all", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "some-exe -any"]
-  assertOutputContains "not a user-provided goal" res
 
-  -- and some-exe is a build-tool dependency of b, again not listed
-  res <- fails $ cabal' "v2-build" ["all", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "other-lib -any"]
-  assertOutputContains "not a user-provided goal" res
+assertErr = assertOutputContains "not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set"
 
-  -- everything's listed, good to go
-  cabal "v2-build" ["all", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "other-lib -any", "--constraint", "some-exe -any"]
+constraint x = "--constraint=" ++ x
 
-  -- a depends on b, but b is a local dependency, so it gets a pass
-  cabal "v2-build" ["a", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "other-lib -any", "--constraint", "some-exe -any"]
+main = do
+  cabalTest' "multipkg-all" . withRepo "repo" $ do
+    let opts =
+          [ "--dry-run"
+          , "--reject-unconstrained-dependencies=all"
+          ]
+
+    -- other-lib is a dependency of b, but it's not listed in cabal.project
+    res <- fails $ cabal' "build" ("all" : opts ++ [constraint "some-exe -any"])
+    assertErr res
+
+    -- and some-exe is a build-tool dependency of b, again not listed
+    res <- fails $ cabal' "build" ("all" : opts ++ [constraint "other-lib -any"])
+    assertErr res
+
+    -- everything's listed, good to go
+    cabal "build" $
+      "all"
+        : opts
+        ++ [ constraint "other-lib -any"
+           , constraint "some-exe -any"
+           ]
+
+    -- a depends on b, but b is a local dependency, so it gets a pass
+    cabal "build" $
+      "a"
+        : opts
+        ++ [ constraint "other-lib -any"
+           , constraint "some-exe -any"
+           ]
+
+  cabalTest' "multipkg-eq" . withRepo "repo" $ do
+    -- all the options except for those about some-lib
+    let opts =
+          [ "all"
+          , "--dry-run"
+          , "--reject-unconstrained-dependencies=eq"
+          , constraint "other-lib ==1.0"
+          , constraint "some-exe ==1.0"
+          ]
+
+    -- everything's listed as == constraint
+    cabal "build" (opts ++ [constraint "some-lib ==1.0"])
+
+    -- everything's listed as == constraint when normalised
+    cabal "build" $
+      opts
+        ++ [ constraint "some-lib ==1.0"
+           , constraint "some-lib >0"
+           , constraint "some-lib <2"
+           ]
+
+    -- not everything's listed as == constraint when normalised
+    res <-
+      fails . cabal' "build" $
+        opts
+          ++ [ constraint "some-lib >0"
+             , constraint "some-lib <2"
+             ]
+    assertErr res

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
@@ -20,6 +20,7 @@ main = do
     -- and some-exe is a build-tool dependency of b, again not listed
     res <- fails $ cabal' "build" ("all" : opts ++ [constraint "other-lib -any"])
     assertErr "all" res
+
     -- everything's listed, good to go
     cabal "build" $
       "all"
@@ -54,7 +55,7 @@ main = do
       opts
         ++ [ constraint "some-lib ==1.0"
            , constraint "some-lib >0"
-           , constraint "some-lib <2"
+           , constraint "some-lib <=2"
            ]
 
     -- not everything's listed as == constraint when normalised
@@ -62,6 +63,6 @@ main = do
       fails . cabal' "build" $
         opts
           ++ [ constraint "some-lib >0"
-             , constraint "some-lib <2"
+             , constraint "some-lib <=2"
              ]
     assertErr "eq" res

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
@@ -2,7 +2,7 @@ import Test.Cabal.Prelude
 
 -- See #4332, dep solving output is not deterministic
 
-assertErr = assertOutputContains "not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set"
+assertErr x = assertOutputContains ("not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=" ++ x ++ " was set")
 
 constraint x = "--constraint=" ++ x
 
@@ -15,12 +15,11 @@ main = do
 
     -- other-lib is a dependency of b, but it's not listed in cabal.project
     res <- fails $ cabal' "build" ("all" : opts ++ [constraint "some-exe -any"])
-    assertErr res
+    assertErr "all" res
 
     -- and some-exe is a build-tool dependency of b, again not listed
     res <- fails $ cabal' "build" ("all" : opts ++ [constraint "other-lib -any"])
-    assertErr res
-
+    assertErr "all" res
     -- everything's listed, good to go
     cabal "build" $
       "all"
@@ -65,4 +64,4 @@ main = do
           ++ [ constraint "some-lib >0"
              , constraint "some-lib <2"
              ]
-    assertErr res
+    assertErr "eq" res

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
@@ -7,6 +7,14 @@ assertErr x = assertOutputContains ("not a user-provided goal nor mentioned as a
 constraint x = "--constraint=" ++ x
 
 main = do
+  skipIfOSX "macOS has a different solver output format"
+  -- - - other-lib-1.0 (lib) (requires build)
+  -- - - some-exe-1.0 (exe:some-exe) (requires build)
+  --   - some-lib-1.0 (lib) (requires build)
+  -- + - some-exe-1.0 (exe:some-exe) (requires build)
+  -- + - other-lib-1.0 (lib) (requires build)
+  --   - b-0 (lib) (first run)
+  --   - a-0 (lib) (first run)
   cabalTest' "multipkg-all" . withRepo "repo" $ do
     let opts =
           [ "--dry-run"

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/a/a.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/a/a.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: a
+version: 0
+
+library
+  build-depends:
+    some-lib,
+    b

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/b/b.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/b/b.cabal
@@ -1,0 +1,10 @@
+cabal-version: 2.2
+name: b
+version: 0
+
+library
+  build-tool-depends:
+    some-exe:some-exe -any
+  build-depends:
+    some-lib,
+    other-lib

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.all.no.exe-any.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.all.no.exe-any.project
@@ -1,0 +1,4 @@
+import: cabal.project
+reject-unconstrained-dependencies: all
+constraints:
+    some-exe -any

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.all.no.lib-any.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.all.no.lib-any.project
@@ -1,0 +1,4 @@
+import: cabal.project
+reject-unconstrained-dependencies: all
+constraints:
+    some-lib -any

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.all.no.lib-exe-any.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.all.no.lib-exe-any.project
@@ -1,0 +1,5 @@
+import: cabal.project
+reject-unconstrained-dependencies: all
+constraints:
+    some-exe -any
+  , some-lib -any

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.go.eq-and-range.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.go.eq-and-range.project
@@ -1,0 +1,8 @@
+import: cabal.project
+reject-unconstrained-dependencies: eq
+constraints:
+    some-lib >0
+  , some-lib <=2
+  , some-lib ==1.0
+  , some-exe ==1.0
+  , other-lib ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.go.eq.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.go.eq.project
@@ -1,0 +1,6 @@
+import: cabal.project
+reject-unconstrained-dependencies: eq
+constraints:
+    some-lib ==1.0
+  , some-exe ==1.0
+  , other-lib ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.eq-and-range.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.eq-and-range.project
@@ -1,0 +1,6 @@
+import: cabal.project
+reject-unconstrained-dependencies: eq
+constraints:
+    some-lib >0
+  , some-lib <=2
+  , some-lib ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.exe-eq.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.exe-eq.project
@@ -1,0 +1,4 @@
+import: cabal.project
+reject-unconstrained-dependencies: eq
+constraints:
+    some-exe ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.lib-eq.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.lib-eq.project
@@ -1,0 +1,4 @@
+import: cabal.project
+reject-unconstrained-dependencies: eq
+constraints:
+    some-lib ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.lib-exe-eq.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.lib-exe-eq.project
@@ -1,0 +1,5 @@
+import: cabal.project
+reject-unconstrained-dependencies: eq
+constraints:
+    some-exe ==1.0
+  , some-lib ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.lib-range.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.eq.no.lib-range.project
@@ -1,0 +1,5 @@
+import: cabal.project
+reject-unconstrained-dependencies: eq
+constraints:
+    some-lib >0
+  , some-lib <=2

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.multipkg-all.out
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.multipkg-all.out
@@ -1,0 +1,29 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: a-0 (user goal)
+[__1] next goal: some-lib (dependency of a)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=all was set)
+[__1] fail (backjumping, conflict set: a, some-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: a (2), some-lib (1)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: b-0 (user goal)
+[__1] next goal: other-lib (dependency of b)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=all was set)
+[__1] fail (backjumping, conflict set: b, other-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), other-lib (1)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: b-0 (user goal)
+[__1] next goal: other-lib (dependency of b)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=all was set)
+[__1] fail (backjumping, conflict set: b, other-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), other-lib (1)

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.multipkg-eq.out
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.multipkg-eq.out
@@ -1,0 +1,65 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: b-0 (user goal)
+[__1] next goal: other-lib (dependency of b)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=eq was set)
+[__1] fail (backjumping, conflict set: b, other-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), other-lib (1)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: a-0 (user goal)
+[__1] next goal: some-lib (dependency of a)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=eq was set)
+[__1] fail (backjumping, conflict set: a, some-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: a (2), some-lib (1)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: b-0 (user goal)
+[__1] next goal: other-lib (dependency of b)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=eq was set)
+[__1] fail (backjumping, conflict set: b, other-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), other-lib (1)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: b-0 (user goal)
+[__1] next goal: other-lib (dependency of b)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=eq was set)
+[__1] fail (backjumping, conflict set: b, other-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: b (2), other-lib (1)
+# cabal build
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: a-0 (user goal)
+[__1] next goal: some-lib (dependency of a)
+[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=eq was set)
+[__1] fail (backjumping, conflict set: a, some-lib)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: a (2), some-lib (1)

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  ./a
+  ./b

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.test.hs
@@ -1,0 +1,22 @@
+import Test.Cabal.Prelude
+
+-- See #4332, dep solving output is not deterministic
+-- other-lib is a dependency of b, but it's not listed in cabal.project
+-- and some-exe is a build-tool dependency of b, again not listed
+
+assertErr x = assertOutputContains ("not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies=" ++ x ++ " was set")
+constraint x = "--constraint=" ++ x
+opts = [ "all", "--dry-run" ]
+
+main = do
+  cabalTest' "multipkg-all" . withRepo "repo" $ do
+    let proj n = "--project-file=cabal.all" <.> n <.> ".project" : opts
+    let no n = assertErr "all" =<< fails (cabal' "build" $ proj n)
+    mapM_ (no . ("no" <.>)) ["exe-any", "lib-any", "lib-exe-any"]
+
+  cabalTest' "multipkg-eq" . withRepo "repo" $ do
+    let proj n = "--project-file=cabal.eq" <.> n <.> ".project" : opts
+    let no n = assertErr "eq" =<< fails (cabal' "build" $ proj n)
+    let go n = cabal' "build" $ proj n
+    mapM_ (go . ("go" <.>)) ["eq-and-range", "eq"]
+    mapM_ (no . ("no" <.>)) ["eq-and-range", "exe-eq", "lib-eq", "lib-exe-eq", "lib-range"]

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/cabal.test.hs
@@ -9,6 +9,14 @@ constraint x = "--constraint=" ++ x
 opts = [ "all", "--dry-run" ]
 
 main = do
+  skipIfOSX "macOS has a different solver output format"
+  -- - - other-lib-1.0 (lib) (requires build)
+  -- - - some-exe-1.0 (exe:some-exe) (requires build)
+  --   - some-lib-1.0 (lib) (requires build)
+  -- + - some-exe-1.0 (exe:some-exe) (requires build)
+  -- + - other-lib-1.0 (lib) (requires build)
+  --   - b-0 (lib) (first run)
+  --   - a-0 (lib) (first run)
   cabalTest' "multipkg-all" . withRepo "repo" $ do
     let proj n = "--project-file=cabal.all" <.> n <.> ".project" : opts
     let no n = assertErr "all" =<< fails (cabal' "build" $ proj n)

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/repo/other-lib-1.0/other-lib.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/repo/other-lib-1.0/other-lib.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: other-lib
+version: 1.0
+
+library
+  exposed-modules:
+    Foo

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/repo/some-exe-1.0/some-exe.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/repo/some-exe-1.0/some-exe.cabal
@@ -1,0 +1,6 @@
+cabal-version: 2.2
+name: some-exe
+version: 1.0
+
+executable some-exe
+  main-is: Foo.hs

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/repo/some-lib-1.0/some-lib.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkgInProject/repo/some-lib-1.0/some-lib.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: some-lib
+version: 1.0
+
+library
+  exposed-modules:
+    Foo

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/a/a.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/a/a.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: a
+version: 0
+
+library
+  build-depends:
+    some-lib ==1.0,
+    b ==0

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/b/b.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/b/b.cabal
@@ -1,0 +1,10 @@
+cabal-version: 2.2
+name: b
+version: 0
+
+library
+  build-tool-depends:
+    some-exe:some-exe ==1.0
+  build-depends:
+    some-lib ==1.0,
+    other-lib ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.out
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.out
@@ -1,0 +1,29 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - other-lib-1.0 (lib) (requires build)
+ - some-exe-1.0 (exe:some-exe) (requires build)
+ - some-lib-1.0 (lib) (requires build)
+ - b-0 (lib) (first run)
+ - a-0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.project
@@ -1,0 +1,8 @@
+packages:
+  ./a
+  ./b
+
+constraints:
+    some-lib ==1.0
+  , other-lib ==1.0
+  , some-exe ==1.0

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.test.hs
@@ -1,0 +1,17 @@
+import Test.Cabal.Prelude
+
+
+main = do
+  skipIfOSX "macOS has a different solver output format"
+  -- - - other-lib-1.0 (lib) (requires build)
+  -- - - some-exe-1.0 (exe:some-exe) (requires build)
+  --   - some-lib-1.0 (lib) (requires build)
+  -- + - some-exe-1.0 (exe:some-exe) (requires build)
+  -- + - other-lib-1.0 (lib) (requires build)
+  --   - b-0 (lib) (first run)
+  --   - a-0 (lib) (first run)
+  cabalTest . withRepo "repo" $ do
+    let opts = [ "all", "--dry-run" ]
+    cabal "build" $ opts
+    cabal "build" $ "--reject-unconstrained-dependencies=all" : opts
+    cabal "build" $ "--reject-unconstrained-dependencies=eq" : opts

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/cabal.test.hs
@@ -12,6 +12,6 @@ main = do
   --   - a-0 (lib) (first run)
   cabalTest . withRepo "repo" $ do
     let opts = [ "all", "--dry-run" ]
-    cabal "build" $ opts
+    cabal "build" opts
     cabal "build" $ "--reject-unconstrained-dependencies=all" : opts
     cabal "build" $ "--reject-unconstrained-dependencies=eq" : opts

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/repo/other-lib-1.0/other-lib.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/repo/other-lib-1.0/other-lib.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: other-lib
+version: 1.0
+
+library
+  exposed-modules:
+    Foo

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/repo/some-exe-1.0/some-exe.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/repo/some-exe-1.0/some-exe.cabal
@@ -1,0 +1,6 @@
+cabal-version: 2.2
+name: some-exe
+version: 1.0
+
+executable some-exe
+  main-is: Foo.hs

--- a/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/repo/some-lib-1.0/some-lib.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/VersionEqualitiesInPackages/repo/some-lib-1.0/some-lib.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: some-lib
+version: 1.0
+
+library
+  exposed-modules:
+    Foo

--- a/changelog.d/pr-11470.md
+++ b/changelog.d/pr-11470.md
@@ -1,0 +1,14 @@
+---
+synopsis: Add eq as an option to the flag reject-unconstrained-dependencies
+packages: [cabal-install, cabal-install-solver]
+prs: 11470
+issues: 11468
+---
+
+Extend the flag `reject-unconstrained-dependencies` to have options
+`none|all|eq`.
+
+When set to `eq` or `all`, all non-local packages that aren't goals must be
+explicitly constrained. The difference between `all` and `eq` is that `all`
+accepts any version constraint (even `>0`) but `eq` accepts only version ranges
+that normalise to an equality constraint (== v).

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -816,8 +816,8 @@ The following settings control the behavior of the dependency solver:
       active-repositories: :none
 
 
-.. cfg-field:: reject-unconstrained-dependencies: all, none
-               --reject-unconstrained-dependencies=[all|none]
+.. cfg-field:: reject-unconstrained-dependencies: eq, all, none
+               --reject-unconstrained-dependencies=[eq|all|none]
    :synopsis: Restrict the solver to packages that have constraints on them.
 
    :default: none
@@ -827,9 +827,11 @@ The following settings control the behavior of the dependency solver:
    aware of in a build plan. If you wish to restrict the build plan to
    a closed set of packages (e.g., from a freeze file), use this flag.
 
-   When set to `all`, all non-local packages that aren't goals must be
-   explicitly constrained. When set to `none`, the solver will
-   consider all packages.
+   When set to `eq` or `all`, all non-local packages that aren't goals must be
+   explicitly constrained. where `all` accepts any version constraint and `eq`
+   accepts version ranges that normalise to an equality constraint.
+
+   When set to `none`, the solver will consider all packages.
 
 .. _package-configuration-options:
 


### PR DESCRIPTION
Fixes #11468. Adds an `eq` option for `--reject-unconstrained-dependencies`. Extends the solving failure reason message to include `=all` or `=eq`.

## Manual QA

With this repository, `cabal freeze`.

Edit `cabal.project.freeze` commenting out the line for the `pretty` dependency.

```diff
-             any.pretty ==1.1.3.6,
+          -- any.pretty ==1.1.3.6,
```

Now `cabal build cabal-install-solver --reject-unconstrained-dependencies=?` will only build when ? is none.

Edit `cabal.project.freeze` changing the line for the `pretty` dependency.

```diff
-             any.pretty ==1.1.3.6,
+             any.pretty >0,
```

Now `cabal build --reject-unconstrained-dependencies=?` will build when ? is `none|all` but won't build when ? is `eq`.

```
$ cabal build cabal-install-solver --reject-unconstrained-dependencies=eq
Warning: this is a debug build of cabal-install with assertions enabled.
Resolving dependencies...
Error: [Cabal-7107]
Could not resolve dependencies:
[__0] trying: Cabal-3.17.0.0 (user goal)
[__1] next goal: pretty (dependency of Cabal)
[__1] fail (not a user-provided goal nor mentioned as a constraint,
  but reject-unconstrained-dependencies=eq was set)
[__1] fail (backjumping, conflict set: Cabal, pretty)
After searching the rest of the dependency tree exhaustively,
  these were the goals I've had most trouble fulfilling: Cabal, pretty
```

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
