### PR TITLE
cabal-install: Add newline at end of 'cabal target --help' output

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdTarget.hs
+++ b/cabal-install/src/Distribution/Client/CmdTarget.hs
@@ -65,7 +65,7 @@ targetCommand =
             , caution
             , unique
             ]
-    , commandNotes = Just $ \pname -> render $ examples pname
+    , commandNotes = Just $ \pname -> render (examples pname) ++ "\n"
     , commandDefaultFlags = defaultNixStyleFlags ()
     , commandOptions = nixStyleOptions (const [])
     }


### PR DESCRIPTION
`cabal target` seems to be the first `cabal-install` command that uses a prettyprinter for its `--help` output. This is all very nice, but you do need to add your own newline if you do so. :)

**Template B: This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
