### PR TITLE
HLint: use == and redundant maybe

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,7 +2,7 @@
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
 - ignore: {name: "Avoid lambda"} # 50 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 23 hints
-- ignore: {name: "Eta reduce"} # 136 hints
+- ignore: {name: "Eta reduce"} # 137 hints
 - ignore: {name: "Evaluate"} # 10 hints
 - ignore: {name: "Functor law"} # 10 hints
 - ignore: {name: "Fuse concatMap/map"} # 3 hints
@@ -19,27 +19,25 @@
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 19 hints
-- ignore: {name: "Redundant maybe"} # 2 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
-- ignore: {name: "Redundant return"} # 10 hints
+- ignore: {name: "Redundant return"} # 9 hints
 - ignore: {name: "Replace case with fromMaybe"} # 4 hints
 - ignore: {name: "Replace case with maybe"} # 10 hints
 - ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
-- ignore: {name: "Use :"} # 28 hints
+- ignore: {name: "Use :"} # 29 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 87 hints
+- ignore: {name: "Use <$>"} # 86 hints
 - ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
-- ignore: {name: "Use =="} # 2 hints
 - ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
 - ignore: {name: "Use camelCase"} # 96 hints
 - ignore: {name: "Use catMaybes"} # 4 hints
 - ignore: {name: "Use concatMap"} # 2 hints
-- ignore: {name: "Use const"} # 37 hints
+- ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use fmap"} # 23 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fromMaybe"} # 5 hints

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -2836,7 +2836,7 @@ checkRelocatable verbosity pkg lbi =
 
     -- Check if the Compiler support relocatable builds
     checkCompiler =
-      unless (compilerFlavor comp `elem` [GHC]) $
+      unless (compilerFlavor comp == GHC) $
         dieWithException verbosity $
           NoCompilerSupport (show comp)
       where
@@ -2877,7 +2877,7 @@ checkRelocatable verbosity pkg lbi =
       traverse_ (doCheck $ getSymbolicPath pkgr) ipkgs
       where
         doCheck pkgr ipkg
-          | maybe False (== pkgr) (IPI.pkgRoot ipkg) =
+          | Just pkgr == IPI.pkgRoot ipkg =
               for_ (IPI.libraryDirs ipkg) $ \libdir -> do
                 -- When @prefix@ is not under @pkgroot@,
                 -- @shortRelativePath prefix pkgroot@ will return a path with

--- a/Cabal/src/Distribution/Simple/SrcDist.hs
+++ b/Cabal/src/Distribution/Simple/SrcDist.hs
@@ -513,10 +513,7 @@ createArchive verbosity pkg_descr tmpDir targetPref = do
   let tarBallFilePath = targetPref </> tarBallName pkg_descr <.> "tar.gz"
   (tarProg, _) <- requireProgram verbosity tarProgram defaultProgramDb
   let formatOptSupported =
-        maybe False (== "YES") $
-          Map.lookup
-            "Supports --format"
-            (programProperties tarProg)
+        Just "YES" == Map.lookup "Supports --format" (programProperties tarProg)
   runProgram verbosity tarProg $
     -- Hmm: I could well be skating on thinner ice here by using the -C option
     -- (=> seems to be supported at least by GNU and *BSD tar) [The

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -501,7 +501,7 @@ checkInvalidPath :: String -> a -> PurePrompt a
 checkInvalidPath path act =
   -- The check below is done this way so it's easier to append
   -- more invalid paths in the future, if necessary
-  if path `elem` ["."]
+  if path == "."
     then throwPrompt $ BreakException $ "Invalid path: " ++ path
     else return act
 


### PR DESCRIPTION
See #9110. Discharges and no longer ignores the "Use ==" and "Redundant maybe" suggestions so that these will be suggested by our CI linting. After these changes, the code is simpler.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
