### PR TITLE
Fix parser warnings order

### DIFF
--- a/Cabal-syntax/src/Distribution/Fields/ParseResult.hs
+++ b/Cabal-syntax/src/Distribution/Fields/ParseResult.hs
@@ -68,12 +68,20 @@ runParseResult pr = unPR pr emptyPRState initialCtx failure success
   where
     initialCtx = PRContext PUnknownSource
 
-    failure (PRState warns [] v) = (warns, Left (v, PErrorWithSource PUnknownSource (PError zeroPos "panic") :| []))
-    failure (PRState warns (err : errs) v) = (warns, Left (v, err :| errs))
+    failure (PRState warns errors v) = (sortWarns warns, Left (v, errors'))
+      where
+        errors' = case errors of
+          [] -> PErrorWithSource PUnknownSource (PError zeroPos "panic") :| []
+          err : errs -> err :| errs
 
-    success (PRState warns [] _) x = (warns, Right x)
-    -- If there are any errors, don't return the result
-    success (PRState warns (err : errs) v) _ = (warns, Left (v, err :| errs))
+    success (PRState warns errors v) x = (sortWarns warns, result)
+      where
+        result = case errors of
+          [] -> Right x
+          -- If there are any errors, don't return the result
+          err : errs -> Left (v, err :| errs)
+
+    sortWarns = sortBy (comparing (pwarningPosition . pwarning))
 
 -- | Chain parsing operations that involve 'IO' actions.
 liftParseResult :: (a -> IO (ParseResult src b)) -> ParseResult src a -> IO (ParseResult src b)

--- a/Cabal-tests/tests/ParserTests/regressions/common.format
+++ b/Cabal-tests/tests/ParserTests/regressions/common.format
@@ -1,6 +1,6 @@
-common.cabal:29:3: Unknown field: import. You should set cabal-version: 2.2 or larger to use common stanzas
-common.cabal:20:3: Unknown field: import. You should set cabal-version: 2.2 or larger to use common stanzas
 common.cabal:14:1: Ignoring section: common. You should set cabal-version: 2.2 or larger to use common stanzas.
+common.cabal:20:3: Unknown field: import. You should set cabal-version: 2.2 or larger to use common stanzas
+common.cabal:29:3: Unknown field: import. You should set cabal-version: 2.2 or larger to use common stanzas
 cabal-version:            >=1.10
 name:                     common
 version:                  0

--- a/Cabal-tests/tests/ParserTests/regressions/elif.format
+++ b/Cabal-tests/tests/ParserTests/regressions/elif.format
@@ -1,5 +1,5 @@
-elif.cabal:19:3: invalid subsection "else"
 elif.cabal:17:3: invalid subsection "elif". You should set cabal-version: 2.2 or larger to use elif-conditionals.
+elif.cabal:19:3: invalid subsection "else"
 cabal-version: >=1.10
 name:          elif
 version:       0

--- a/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.format
+++ b/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.format
@@ -1,6 +1,6 @@
-wl-pprint-indef.cabal:28:3: The field "mixins" is available only since the Cabal specification version 2.0. This field will be ignored.
-wl-pprint-indef.cabal:27:3: The field "signatures" is available only since the Cabal specification version 2.0. This field will be ignored.
 wl-pprint-indef.cabal:23:3: The field "mixins" is available only since the Cabal specification version 2.0. This field will be ignored.
+wl-pprint-indef.cabal:27:3: The field "signatures" is available only since the Cabal specification version 2.0. This field will be ignored.
+wl-pprint-indef.cabal:28:3: The field "mixins" is available only since the Cabal specification version 2.0. This field will be ignored.
 cabal-version: >=1.6
 name:          wl-pprint-indef
 version:       1.2

--- a/changelog.d/issue-11269.md
+++ b/changelog.d/issue-11269.md
@@ -1,0 +1,10 @@
+---
+synopsis: Fix parse warnings being emitted in reverse order
+packages: [Cabal-syntax]
+prs: 11479
+issues: 11269
+---
+
+Parse warnings were prepended to the accumulator list, causing them to
+be emitted in reverse file order. They are now sorted so they come out
+in file order, consistent with GHC's behavior.


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/11269 for more information. This PR changes the parse results to append warnings so they're displayed in-order.

---

This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (NOTE: I updated the ordering in existing test files)