### PR TITLE
Remove `configFlagError`

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -206,8 +206,6 @@ data ConfigFlags = ConfigFlags
   , configExactConfiguration :: Flag Bool
   -- ^ All direct dependencies and flags are provided on the command line by
   --  the user via the '--dependency' and '--flags' options.
-  , configFlagError :: Flag String
-  -- ^ Halt and show an error message indicating an error in flag assignment
   , configRelocatable :: Flag Bool
   -- ^ Enable relocatable package built
   , configDebugInfo :: Flag DebugInfoLevel
@@ -319,7 +317,6 @@ instance Eq ConfigFlags where
       && equal configCoverage
       && equal configLibCoverage
       && equal configExactConfiguration
-      && equal configFlagError
       && equal configRelocatable
       && equal configDebugInfo
       && equal configDumpBuildInfo
@@ -366,7 +363,6 @@ defaultConfigFlags progDb =
     , configCoverage = Flag False
     , configLibCoverage = NoFlag
     , configExactConfiguration = Flag False
-    , configFlagError = NoFlag
     , configRelocatable = Flag False
     , configDebugInfo = Flag NoDebugInfo
     , configDumpBuildInfo = NoFlag

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -544,7 +544,6 @@ instance Semigroup SavedConfig where
           , configCoverage = combine configCoverage
           , configLibCoverage = combine configLibCoverage
           , configExactConfiguration = combine configExactConfiguration
-          , configFlagError = combine configFlagError
           , configRelocatable = combine configRelocatable
           , configUseResponseFiles = combine configUseResponseFiles
           , configDumpBuildInfo = combine configDumpBuildInfo

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1140,7 +1140,6 @@ convertToLegacyAllPackageConfig
           , configLibCoverage = mempty -- TODO: don't merge
           , configExactConfiguration = mempty
           , configBenchmarks = mempty
-          , configFlagError = mempty -- TODO: ???
           , configRelocatable = mempty
           , configDebugInfo = mempty
           , configUseResponseFiles = mempty
@@ -1216,7 +1215,6 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , configLibCoverage = packageConfigCoverage -- TODO: don't merge
         , configExactConfiguration = mempty
         , configBenchmarks = packageConfigBenchmarks
-        , configFlagError = mempty -- TODO: ???
         , configRelocatable = packageConfigRelocatable
         , configDebugInfo = packageConfigDebugInfo
         , configUseResponseFiles = mempty

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -4166,7 +4166,6 @@ setupHsConfigureFlags
         ElabComponent _ -> mempty
 
       configExactConfiguration = toFlag True
-      configFlagError = mempty -- TODO: [research required] appears not to be implemented
       configScratchDir = mempty -- never use
       configUserInstall = mempty -- don't rely on defaults
       configPrograms_ = mempty -- never use, shouldn't exist

--- a/changelog.d/pr-11480.md
+++ b/changelog.d/pr-11480.md
@@ -1,0 +1,8 @@
+---
+synopsis: Remove unused config flag `configFlagError`
+packages: [Cabal, cabal-install]
+prs: 11480
+---
+
+Remove unused config flag `configFlagError`. This was added, but never used in any external
+or internal behavior.


### PR DESCRIPTION
This commit removes the `configFlagError` field in ConfigFlags.

This flag was never implemented and is currently not used by any internal or external function. Unless I'm missing some convention against removing flags, this shouldn't exist.

Gimme a second to add in the stuff for template A.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
