### PR TITLE
Fix 11473: Fixes the newline issue for hscolour help command

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Hscolour.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Hscolour.hs
@@ -112,7 +112,7 @@ hscolourCommand =
         "Generate HsColour colourised code, in HTML format."
     , commandDescription = Just (\_ -> "Requires the hscolour program.\n")
     , commandNotes = Just $ \_ ->
-        "Deprecated in favour of 'cabal haddock --hyperlink-source'."
+        "Deprecated in favour of 'cabal haddock --hyperlink-source'.\n"
     , commandUsage = \pname ->
         "Usage: " ++ pname ++ " hscolour [FLAGS]\n"
     , commandDefaultFlags = defaultHscolourFlags


### PR DESCRIPTION
### Description
This PR fixes a formatting issue where the `hscolour` command help output was missing a trailing newline character in its commandNotes section. 

I tried it with many commands and found that only `hscolour` has the issue because of the missing '\n' character, so this should fix it.

### Related Issue
Fixes #11473

### Steps to Reproduce & Verify
To verify the missing newline in the current master branch:
1. Run: `cabal hscolour --help | tail -c 1 | od -An -tc`
2. **Observation:** The output is `.` , so no newline.

To verify the fix in this branch:
1. Run: `cabal run cabal-install -- hscolour --help | tail -c 1 | od -An -tc`
3. **Observation:** The output is `\n`.

### Changes
* Modified `Cabal/src/Distribution/Simple/Setup/Hscolour.hs`.
* Added an explicit `\n` to the `commandNotes` string within the `hscolourCommand` definition.