### PR TITLE
Bump GHC_FOR_QUICK_JOBS to 9.10.3

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -15,7 +15,7 @@ on:
       - created
 
 env:
-  GHC_FOR_QUICK_JOBS: 9.6.5
+  GHC_FOR_QUICK_JOBS: 9.10.3
 
 jobs:
   meta:

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -17,13 +17,13 @@ executable gen-spdx
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.2.1.0
-    , base                  >=4.13     && <4.20
+    , aeson                 ^>=2.2.3.0
+    , base                  >=4.13 && <4.21
     , bytestring
     , containers
     , Diff                  ^>=0.4
-    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1 || ^>=5.2
-    , optparse-applicative  ^>=0.15.1.0 || ^>=0.16.0.0
+    , lens                  ^>=5.3
+    , optparse-applicative  ^>=0.19.0.0
     , text
     , zinza                 ^>=0.2
 
@@ -34,13 +34,13 @@ executable gen-spdx-exc
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.2.1.0
-    , base                  >=4.13     && <4.20
+    , aeson                 ^>=2.2.3.0
+    , base                  >=4.13 && <4.21
     , bytestring
     , containers
     , Diff                  ^>=0.4
-    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1 || ^>=5.2
-    , optparse-applicative  ^>=0.15.1.0 || ^>=0.16.0.0
+    , lens                  ^>=5.3
+    , optparse-applicative  ^>=0.19.0.0
     , text
     , zinza                 ^>=0.2
 

--- a/cabal-dev-scripts/src/AnalyseImports.hs
+++ b/cabal-dev-scripts/src/AnalyseImports.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 module Main (main) where
 
-import Control.Applicative    (liftA2, many, (<|>))
+import Control.Applicative
 import Control.Monad          (void)
 import Data.Foldable          (for_)
 import Data.List              (sortBy)

--- a/cabal-dev-scripts/src/Capture.hs
+++ b/cabal-dev-scripts/src/Capture.hs
@@ -2,7 +2,6 @@ module Capture (capture) where
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax (NameFlavour (..), Name (..))
-import Control.Monad.IO.Class
 
 import Data.Generics as SYB
 


### PR DESCRIPTION
Fixes #11483, bump to `ghc-9.10.3` for quickjobs.

I've altered dependencies and fixed warnings in `cabal.meta.project` so that it builds with GHC from `8.4.4`, the minimum we support, up to `9.10.3` without errors.

```
$ cabal build --builddir=dist-newstyle-meta --project-file=cabal.meta.project all --ghc-options=-Werror
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
