### PR TITLE
Swap transformCaretLower and transformCaretUpper

### DIFF
--- a/Cabal-syntax/src/Distribution/Version.hs
+++ b/Cabal-syntax/src/Distribution/Version.hs
@@ -67,11 +67,16 @@ module Distribution.Version
   , majorUpperBound
 
     -- ** Modification
-  , removeUpperBound
-  , removeLowerBound
+    -- $modification
+
+    -- *** Preserving modification
   , transformCaret
+
+    -- *** Relaxing modification
   , transformCaretUpper
   , transformCaretLower
+  , removeUpperBound
+  , removeLowerBound
 
     -- * Version intervals view
   , asVersionIntervals
@@ -125,6 +130,13 @@ isSpecificVersion vr = case asVersionIntervals vr of
 -- Transformations
 -------------------------------------------------------------------------------
 
+-- $modification
+--
+-- Examples use the following function to map version ranges:
+--
+-- > mapVR :: (VersionRange -> VersionRange) -> [String] -> [String]
+-- > mapVR f xs = [pretty $ f v| Just v <- simpleParsec <$> xs]
+
 -- | Simplify a 'VersionRange' expression. For non-empty version ranges
 -- this produces a canonical form. Empty or inconsistent version ranges
 -- are left as-is because that provides more information.
@@ -161,7 +173,13 @@ removeUpperBound = fromVersionIntervals . relaxLastInterval . toVersionIntervals
 removeLowerBound :: VersionRange -> VersionRange
 removeLowerBound = fromVersionIntervals . relaxHeadInterval . toVersionIntervals
 
--- | Rewrite @^>= x.y.z@ into @>= x.y.z && < x.(y+1)@
+-- | Rewrite @^>= x.y.z@ into @>= x.y.z && < x.(y+1)@ with explicit lower bound
+-- and upper bound. It has the same effect as:
+--
+-- > \v -> transformCaretLower v `intersectVersionRanges` transformCaretUpper v
+--
+-- >>> mapVR transformCaret ["^>=1.2.3.4", "^>=1.2.3", "^>=1.2", "^>=1"]
+-- [>=1.2.3.4 && <1.3,>=1.2.3 && <1.3,>=1.2 && <1.3,>=1 && <1.1]
 --
 -- @since 3.6.0.0
 transformCaret :: VersionRange -> VersionRange
@@ -170,7 +188,12 @@ transformCaret = hyloVersionRange embed projectVersionRange
     embed (MajorBoundVersionF v) = orLaterVersion v `intersectVersionRanges` earlierVersion (majorUpperBound v)
     embed vr = embedVersionRange vr
 
--- | Rewrite @^>= x.y.z@ into @>= x.y.z@
+-- | Rewrite @^>= x.y.z@ into explicit lower bound @>= x.y.z@, removing the
+-- upper bound. This function doesn't transform the lower bound. It changes the
+-- operator from @^>=@ to @>=@.
+--
+-- >>> mapVR transformCaretUpper ["^>=1.2.3.4", "^>=1.2.3", "^>=1.2", "^>=1"]
+-- [>=1.2.3.4,>=1.2.3,>=1.2,>=1]
 --
 -- @since 3.6.0.0
 transformCaretUpper :: VersionRange -> VersionRange
@@ -179,7 +202,14 @@ transformCaretUpper = hyloVersionRange embed projectVersionRange
     embed (MajorBoundVersionF v) = orLaterVersion v
     embed vr = embedVersionRange vr
 
--- | Rewrite @^>= x.y.z@ into @<x.(y+1)@
+-- | Rewrite @^>= x.y.z@ into explicit upper bound @<x.(y+1)@, removing the
+-- lower bound.
+--
+-- >>> mapVR transformCaretLower ["^>=0.0.0.0", "^>=0.0.0", "^>=0.0", "^>=0"]
+-- [<0.1,<0.1,<0.1,<0.1]
+--
+-- >>> mapVR transformCaretLower ["^>=1.1.1.1", "^>=1.1.1", "^>=1.1", "^>=1"]
+-- [<1.2,<1.2,<1.2,<1.1]
 --
 -- @since 3.6.0.0
 transformCaretLower :: VersionRange -> VersionRange
@@ -187,3 +217,10 @@ transformCaretLower = hyloVersionRange embed projectVersionRange
   where
     embed (MajorBoundVersionF v) = earlierVersion (majorUpperBound v)
     embed vr = embedVersionRange vr
+
+-- $setup
+-- >>> :set -XScopedTypeVariables
+-- >>> import Distribution.Parsec
+-- >>> import Distribution.Pretty
+-- >>>
+-- >>> mapVR f xs = [pretty $ f v| Just v <- simpleParsec <$> xs]


### PR DESCRIPTION
Related to #11490 but only adds more explanation and doctest examples for the caret version transforming functions. Add subsections to the modification section, range-preserving and range-relaxing modifications.

<img width="585" height="802" alt="image" src="https://github.com/user-attachments/assets/1b5f733e-ccc7-443d-9f03-cacaa650b5e0" />

> [!NOTE]
> I find the function names, `transformCaretUpper` and `transformCaretLower`, a bit generic and would have preferred `removeCaretUpper` and `removeCaretLower`. There are already `removeUpperBound` and `removeLowerBound` functions.

## QA Notes

For running doctests locally:

```
$ make doctest-install # one time only for the current system GHC compiler
$ cd Cabal-syntax
$ cabal doctest --allow-newer=False
```

For building the haddocks locally:

```
$ cabal haddock Cabal-syntax
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
