### PR TITLE
Remove calibrateMtimeChangeDelay, it's irrelevant for modern file systems

### DIFF
--- a/cabal-install/tests/LongTests.hs
+++ b/cabal-install/tests/LongTests.hs
@@ -2,10 +2,6 @@ module Main (main) where
 
 import Test.Tasty
 
-import Distribution.Compat.Time
-import Distribution.Simple.Utils
-import Distribution.Verbosity
-
 import qualified UnitTests.Distribution.Client.Described
 import qualified UnitTests.Distribution.Client.FileMonitor
 import qualified UnitTests.Distribution.Client.VCS
@@ -13,37 +9,22 @@ import qualified UnitTests.Distribution.Solver.Modular.QuickCheck
 import UnitTests.Options
 
 main :: IO ()
-main = do
-  (mtimeChange, mtimeChange') <- calibrateMtimeChangeDelay
-  let toMillis :: Int -> Double
-      toMillis x = fromIntegral x / 1000.0
-  notice (mkVerbosity defaultVerbosityHandles normal) $
-    "File modification time resolution calibration completed, "
-      ++ "maximum delay observed: "
-      ++ (show . toMillis $ mtimeChange)
-      ++ " ms. "
-      ++ "Will be using delay of "
-      ++ (show . toMillis $ mtimeChange')
-      ++ " for test runs."
+main =
   defaultMainWithIngredients
     (includingOptions extraOptions : defaultIngredients)
-    (tests mtimeChange')
+    tests
 
-tests :: Int -> TestTree
-tests mtimeChangeCalibrated =
-  askOption $ \(OptionMtimeChangeDelay mtimeChangeProvided) ->
-    let mtimeChange =
-          if mtimeChangeProvided /= 0
-            then mtimeChangeProvided
-            else mtimeChangeCalibrated
-     in testGroup
-          "Long-running tests"
-          [ testGroup
-              "Solver QuickCheck"
-              UnitTests.Distribution.Solver.Modular.QuickCheck.tests
-          , testGroup "UnitTests.Distribution.Client.VCS" $
-              UnitTests.Distribution.Client.VCS.tests mtimeChange
-          , testGroup "UnitTests.Distribution.Client.FileMonitor" $
-              UnitTests.Distribution.Client.FileMonitor.tests mtimeChange
-          , UnitTests.Distribution.Client.Described.tests
-          ]
+tests :: TestTree
+tests =
+  askOption $ \(OptionMtimeChangeDelay mtimeChange) ->
+    testGroup
+      "Long-running tests"
+      [ testGroup
+          "Solver QuickCheck"
+          UnitTests.Distribution.Solver.Modular.QuickCheck.tests
+      , testGroup "UnitTests.Distribution.Client.VCS" $
+          UnitTests.Distribution.Client.VCS.tests mtimeChange
+      , testGroup "UnitTests.Distribution.Client.FileMonitor" $
+          UnitTests.Distribution.Client.FileMonitor.tests mtimeChange
+      , UnitTests.Distribution.Client.Described.tests
+      ]

--- a/cabal-install/tests/UnitTests/Options.hs
+++ b/cabal-install/tests/UnitTests/Options.hs
@@ -33,7 +33,8 @@ instance IsOption OptionShowSolverLog where
 newtype OptionMtimeChangeDelay = OptionMtimeChangeDelay Int
 
 instance IsOption OptionMtimeChangeDelay where
-  defaultValue = OptionMtimeChangeDelay 0
+  defaultValue = OptionMtimeChangeDelay 10000
+  showDefaultValue (OptionMtimeChangeDelay v) = Just (show v)
   parseValue = fmap OptionMtimeChangeDelay . safeRead
   optionName = return "mtime-change-delay"
   optionHelp =

--- a/cabal-testsuite/PackageTests/NewBuild/MonitorCabalFiles/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/MonitorCabalFiles/cabal.test.hs
@@ -1,5 +1,5 @@
 import Test.Cabal.Prelude
-main = cabalTest $ withDelay $ do
+main = cabalTest $ do
         copySourceFileTo "q/q-broken.cabal.in" "q/q.cabal"
         fails $ cabal "v2-build" ["q"]
         delay

--- a/cabal-testsuite/PackageTests/Regression/T3294/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3294/setup.test.hs
@@ -3,7 +3,6 @@ import Control.Monad.IO.Class
 -- Test that executable recompilation works
 -- https://github.com/haskell/setup/issues/3294
 main = setupAndCabalTest $ do
-    withDelay $ do
         writeSourceFile "Main.hs" "main = putStrLn \"aaa\""
         setup "configure" []
         setup "build" []

--- a/cabal-testsuite/PackageTests/Regression/T4202/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4202/cabal.test.hs
@@ -1,5 +1,5 @@
 import Test.Cabal.Prelude
-main = cabalTest $ withDelay $ do
+main = cabalTest $ do
         writeSourceFile ("p/P.hs") "module P where\np = \"AAA\""
         cabal "v2-build" ["p","q"]
         delay

--- a/cabal-testsuite/PackageTests/Regression/T5782Diamond/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5782Diamond/cabal.test.hs
@@ -21,8 +21,7 @@
 
 import Test.Cabal.Prelude
 main =
-  cabalTest $ withShorterPathForNewBuildStore .
-    withDelay $ do
+  cabalTest $ withShorterPathForNewBuildStore $ do
         storeDir <- testStoreDir <$> getTestEnv
         writeSourceFile "issue5782/src/Module.hs" "module Module where\nf = \"AAA\""
         recordMode DoNotRecord $

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -439,7 +439,7 @@ runTestM mode m =
                 , testCompilerPath = programPath configuredGhcProg
                 , testPackageDBStack = db_stack
                 , testVerbosityFlags = verbosityFlags verbosity
-                , testMtimeChangeDelay = Nothing
+                , testMtimeChangeDelay = 10000
                 , testScriptEnv = senv
                 , testSetupPath = dist_dir </> "build" </> "setup" </> "setup"
                 , testPackageDbPath = case testArgPackageDb args of [] -> Nothing; xs -> Just xs
@@ -847,10 +847,9 @@ data TestEnv = TestEnv
   -- ^ Package database stack (actually this changes lol)
   , testVerbosityFlags :: VerbosityFlags
   -- ^ How verbose to be
-  , testMtimeChangeDelay :: Maybe Int
+  , testMtimeChangeDelay :: Int
   -- ^ How long we should 'threadDelay' to make sure the file timestamp is
-  -- updated correctly for recompilation tests.  Nothing if we haven't
-  -- calibrated yet.
+  -- updated correctly for recompilation tests.
   , testScriptEnv :: ScriptEnv
   -- ^ Script environment for runghc
   , testSetupPath :: FilePath

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -28,7 +28,6 @@ import Test.Cabal.Run
 import Test.Cabal.Script
 import Test.Cabal.TestCode
 
-import Distribution.Compat.Time (calibrateMtimeChangeDelay)
 import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.Parsec (eitherParsec, simpleParsec)
@@ -1360,22 +1359,7 @@ delay = do
   liftIO . threadDelay $
     if is_old_ghc
       then 1000000
-      else
-        fromMaybe
-          (error "Delay must be enclosed by withDelay")
-          (testMtimeChangeDelay env)
-
--- | Calibrate file modification time delay, if not
--- already determined.
-withDelay :: TestM a -> TestM a
-withDelay m = do
-  env <- getTestEnv
-  case testMtimeChangeDelay env of
-    Nothing -> do
-      -- Figure out how long we need to delay for recompilation tests
-      (_, mtimeChange) <- liftIO $ calibrateMtimeChangeDelay
-      withReaderT (\nenv -> nenv{testMtimeChangeDelay = Just mtimeChange}) m
-    Just _ -> m
+      else (testMtimeChangeDelay env)
 
 -- | Create a symlink for the duration of the provided action. If the symlink
 -- already exists, it is deleted.

--- a/changelog.d/pr-11496.md
+++ b/changelog.d/pr-11496.md
@@ -1,0 +1,7 @@
+---
+synopsis: Remove `Distribution.Compat.Time.calibrateMtimeChangeDelay`
+packages: [Cabal]
+prs: 11496
+---
+
+Remove `calibrateMtimeChangeDelay` from `Distribution.Compat.Time`, it's irrelevant for modern file systems, all of which have submicrosecond precision of file modification times. Inside Cabal this function was used only in the test suite.


### PR DESCRIPTION
There was time long ago when different file systems clocked file modification time with significant granularity and `calibrateMtimeChangeDelay` had its purpose. But this time is long gone and for the past decade all modern file systems (ext4, ntfs, apfs) have submicrosecond granularity.

`calibrateMtimeChangeDelay` was used only in test suites and returned values between 10ms and 1s. We can safely default it to 10ms, because all modern file systems have finer precision. It's a low risk change: after all it's only for tests, not for Cabal itself.

As an extra precaution, modification time delay remains configurable in the test suite via `--mtime-change-delay`.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)