### PR TITLE
Re #11498 Better document, in-app, Cabal's --semaphore=SEMAPHORE option

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Build.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Build.hs
@@ -151,7 +151,7 @@ buildOptions progDb showOrParseArgs =
       , option
           []
           ["semaphore"]
-          "semaphore"
+          "Use the specified semaphore so GHC can compile components in parallel"
           buildUseSemaphore
           (\v flags -> flags{buildUseSemaphore = v})
           (reqArg' "SEMAPHORE" Flag flagToList)

--- a/changelog.d/pr-11503
+++ b/changelog.d/pr-11503
@@ -1,0 +1,10 @@
+synopsis: Better document, in-app, Cabal's `--semaphore=SEMAPHORE` option
+packages: Cabal
+prs: #11503
+significance:
+
+description: {
+
+- Cabal's `--semaphore=SEMAPHORE` option is better documented on `--help`.
+
+}


### PR DESCRIPTION
See:
* #11498

The wording (for Cabal (the library)) is based on Cabal (the tool) for its `--semaphore` flag, which has:
~~~text
> cabal build --help
...
Flags for build:
...
--semaphore                    Use a semaphore so GHC can compile components
                               in parallel
...
~~~ 

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary. N/A
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included. N/A
* [x] Tests have been added. N/A