### PR TITLE
Remove extra space between @since and x.y.z

### DIFF
--- a/Cabal-syntax/src/Distribution/Utils/MD5.hs
+++ b/Cabal-syntax/src/Distribution/Utils/MD5.hs
@@ -33,7 +33,7 @@ type MD5 = Fingerprint
 -- >>> showMD5 $ md5 $ BS.pack [0..127]
 -- "37eff01866ba3f538421b30b7cbefcac"
 --
--- @since  3.2.0.0
+-- @since 3.2.0.0
 showMD5 :: MD5 -> String
 showMD5 (Fingerprint a b) = pad a' ++ pad b'
   where
@@ -41,18 +41,18 @@ showMD5 (Fingerprint a b) = pad a' ++ pad b'
     b' = showHex b ""
     pad s = replicate (16 - length s) '0' ++ s
 
--- | @since  3.2.0.0
+-- | @since 3.2.0.0
 md5 :: BS.ByteString -> MD5
 md5 bs = unsafeDupablePerformIO $ BS.unsafeUseAsCStringLen bs $ \(ptr, len) ->
   fingerprintData (castPtr ptr) len
 
--- | @since  3.2.0.0
+-- | @since 3.2.0.0
 binaryPutMD5 :: MD5 -> Put
 binaryPutMD5 (Fingerprint a b) = do
   putWord64le a
   putWord64le b
 
--- | @since  3.2.0.0
+-- | @since 3.2.0.0
 binaryGetMD5 :: Get MD5
 binaryGetMD5 = do
   a <- getWord64le


### PR DESCRIPTION
Fixes #11504.

Before the fix, rendered in Firefox:

<img width="188" height="110" alt="image" src="https://github.com/user-attachments/assets/01fad752-d2fc-40c2-a87d-4f61bc955e87" />

After the fix:

<img width="188" height="110" alt="image" src="https://github.com/user-attachments/assets/036a9099-5c45-484e-a94e-cbc175d509de" />

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
