### PR TITLE
Hlint suggestions; max, unwords, rights, concatMap and catMaybes

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,7 +2,7 @@
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
 - ignore: {name: "Avoid lambda"} # 50 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 23 hints
-- ignore: {name: "Eta reduce"} # 137 hints
+- ignore: {name: "Eta reduce"} # 138 hints
 - ignore: {name: "Evaluate"} # 10 hints
 - ignore: {name: "Functor law"} # 10 hints
 - ignore: {name: "Fuse concatMap/map"} # 3 hints
@@ -27,7 +27,7 @@
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 29 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 86 hints
+- ignore: {name: "Use <$>"} # 87 hints
 - ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
@@ -35,8 +35,6 @@
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
 - ignore: {name: "Use camelCase"} # 96 hints
-- ignore: {name: "Use catMaybes"} # 4 hints
-- ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use fmap"} # 23 hints
 - ignore: {name: "Use fold"} # 1 hint
@@ -47,16 +45,13 @@
 - ignore: {name: "Use map once"} # 7 hints
 - ignore: {name: "Use map with tuple-section"} # 3 hints
 - ignore: {name: "Use mapMaybe"} # 13 hints
-- ignore: {name: "Use max"} # 2 hints
 - ignore: {name: "Use maybe"} # 8 hints
 - ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints
 - ignore: {name: "Use replicateM_"} # 2 hints
-- ignore: {name: "Use rights"} # 2 hints
 - ignore: {name: "Use typeRep"} # 2 hints
 - ignore: {name: "Use unless"} # 23 hints
-- ignore: {name: "Use unwords"} # 8 hints
 - ignore: {name: "Use void"} # 23 hints
 
 - arguments:
@@ -64,6 +59,7 @@
     - --ignore-glob=Cabal-tests/tests/custom-setup/CabalDoctestSetup.hs
     - --ignore-glob=Cabal-tests/tests/custom-setup/IdrisSetup.hs
     - --ignore-glob=cabal-testsuite/PackageTests/BuildWays/q/app/Main.hs
+    - --ignore-glob=cabal-testsuite/PackageTests/CMain/10168/src/Lib.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSources/src/Demo.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSourcesDyn/src/Demo.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSourcesExe/src/Demo.hs
@@ -78,7 +74,7 @@
     - --ignore-glob=cabal-testsuite/PackageTests/TemplateHaskell/dynamic/TH.hs
     - --ignore-glob=cabal-testsuite/PackageTests/TemplateHaskell/profiling/TH.hs
     - --ignore-glob=cabal-testsuite/PackageTests/TemplateHaskell/vanilla/TH.hs
+    - --ignore-glob=dist-*
     - --ignore-glob=templates/Paths_pkg.template.hs
     - --ignore-glob=templates/SPDX.LicenseExceptionId.template.hs
     - --ignore-glob=templates/SPDX.LicenseId.template.hs
-    - --ignore-glob=dist-*

--- a/Cabal/src/Distribution/Simple/Command.hs
+++ b/Cabal/src/Distribution/Simple/Command.hs
@@ -91,6 +91,7 @@ import Distribution.Compat.Prelude hiding (get)
 import Prelude ()
 
 import qualified Data.Array as Array
+import Data.Either (rights)
 import qualified Data.List as List
 import Distribution.Compat.Lens (ALens', (#~), (^#))
 import qualified Distribution.GetOpt as GetOpt
@@ -589,7 +590,7 @@ commandParseArgs command global args =
     -- Note: It is crucial to use reverse function composition here or to
     -- reverse the flags here as we want to process the flags left to right
     -- but data flow in function composition is right to left.
-    accum flags = foldr (flip (.)) id [f | Right f <- flags]
+    accum flags = foldr (flip (.)) id (rights flags)
     unrecognised opts =
       [ "unrecognized "
         ++ "'"

--- a/Cabal/src/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/src/Distribution/Simple/PackageIndex.hs
@@ -734,7 +734,7 @@ dependencyGraph index = (graph, vertex_to_pkg, id_to_vertex)
     graph =
       Array.listArray
         bounds
-        [ [v | Just v <- map id_to_vertex (installedDepends pkg)]
+        [ mapMaybe id_to_vertex (installedDepends pkg)
         | pkg <- pkgs
         ]
 

--- a/Cabal/src/Distribution/Simple/Program/Script.hs
+++ b/Cabal/src/Distribution/Simple/Program/Script.hs
@@ -82,7 +82,7 @@ invocationAsBatchFile
         ++ ["cd \"" ++ cwd ++ "\"" | cwd <- maybeToList mcwd]
         ++ case minput of
           Nothing ->
-            [path ++ concatMap (' ' :) args]
+            [unwords (path : args)]
           Just input ->
             ["("]
               ++ ["echo " ++ escape line | line <- lines $ iodataToText input]

--- a/Cabal/src/Distribution/Simple/Setup/Test.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Test.hs
@@ -86,7 +86,7 @@ instance Monoid TestShowDetails where
   mappend = (<>)
 
 instance Semigroup TestShowDetails where
-  a <> b = if a < b then b else a
+  a <> b = max a b
 
 data TestFlags = TestFlags
   { testCommonFlags :: !CommonSetupFlags

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
@@ -147,7 +147,7 @@ data DependencyReason qpn = DependencyReason qpn (Map Flag FlagValue) (S.Set Sta
 -- | Print the reason that a dependency was introduced.
 showDependencyReason :: DependencyReason QPN -> String
 showDependencyReason (DependencyReason qpn flags stanzas) =
-    intercalate " " $
+    unwords $
         showQPN qpn
       : map (uncurry showFlagValue) (M.toList flags)
      ++ map (\s -> showSBool s True) (S.toList stanzas)

--- a/cabal-install/src/Distribution/Client/BuildReports/Anonymous.hs
+++ b/cabal-install/src/Distribution/Client/BuildReports/Anonymous.hs
@@ -31,6 +31,7 @@ module Distribution.Client.BuildReports.Anonymous
   --    showList,
   ) where
 
+import Data.Either (rights)
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
@@ -152,7 +153,7 @@ parseFields input = do
 
 parseBuildReportList :: BS.ByteString -> [BuildReport]
 parseBuildReportList str =
-  [report | Right report <- map parseBuildReport (split str)]
+  rights (map parseBuildReport $ split str)
   where
     split :: BS.ByteString -> [BS.ByteString]
     split = filter (not . BS.null) . unfoldr chunk . BS8.lines

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -992,7 +992,7 @@ installLibraries
               . take 1
               . sortBy (comparing (Down . fst))
               . PI.lookupPackageName installedIndex
-          globalLatest = concat (getLatest <$> globalPackages)
+          globalLatest = concatMap getLatest globalPackages
           globalEntries = GhcEnvFilePackageId . installedUnitId <$> globalLatest
           baseEntries =
             GhcEnvFileClearPackageDbStack : fmap GhcEnvFilePackageDb packageDbs

--- a/cabal-install/src/Distribution/Client/Errors/Parser.hs
+++ b/cabal-install/src/Distribution/Client/Errors/Parser.hs
@@ -232,7 +232,7 @@ renderParseErrorGeneral header err_header provenance extra_info errors warnings 
   unlines $
     [ warningsOrErrors <> " parsing" <> header' <> ":"
     ]
-      ++ [p | Just p <- [provenance]]
+      ++ catMaybes [provenance]
       ++ [""] -- Place a newline between the header and the errors/warnings
       -- Place a newline between each error and warning
       ++ intersperse "" (renderedWarnings ++ renderedErrors)

--- a/cabal-install/src/Distribution/Client/SavedFlags.hs
+++ b/cabal-install/src/Distribution/Client/SavedFlags.hs
@@ -69,13 +69,13 @@ data SavedArgsError
 instance Show SavedArgsError where
   show (SavedArgsErrorHelp args) =
     "unexpected flag '--help', saved command line was:\n"
-      ++ intercalate " " args
+      ++ unwords args
   show (SavedArgsErrorList args) =
     "unexpected flag '--list-options', saved command line was:\n"
-      ++ intercalate " " args
+      ++ unwords args
   show (SavedArgsErrorOther args errs) =
     "saved command line was:\n"
-      ++ intercalate " " args
+      ++ unwords args
       ++ "\n"
       ++ "encountered errors:\n"
       ++ intercalate "\n" errs

--- a/cabal-install/src/Distribution/Client/Upload.hs
+++ b/cabal-install/src/Distribution/Client/Upload.hs
@@ -61,7 +61,7 @@ upload verbosity repoCtxt mToken mUsername mPassword isCandidate paths = do
       repos = repoContextRepos repoCtxt
   transport <- repoContextGetTransport repoCtxt
   targetRepo <-
-    case [remoteRepo | Just remoteRepo <- map maybeRepoRemote repos] of
+    case mapMaybe maybeRepoRemote repos of
       [] -> dieWithException verbosity NoRemoteRepositories
       (r : rs) -> remoteRepoTryUpgradeToHttps verbosity transport (last (r :| rs))
   let targetRepoURI :: URI
@@ -120,7 +120,7 @@ uploadDoc verbosity repoCtxt mToken mUsername mPassword isCandidate path = do
   let repos = repoContextRepos repoCtxt
   transport <- repoContextGetTransport repoCtxt
   targetRepo <-
-    case [remoteRepo | Just remoteRepo <- map maybeRepoRemote repos] of
+    case mapMaybe maybeRepoRemote repos of
       [] -> dieWithException verbosity NoRemoteRepositories
       (r : rs) -> remoteRepoTryUpgradeToHttps verbosity transport (last (r :| rs))
   let targetRepoURI = remoteRepoURI targetRepo

--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -396,9 +396,9 @@ main = do
             then logAll "OK"
             else do
                 unless (null unexpected_passes) . logAll $
-                    "UNEXPECTED OK: " ++ intercalate " " unexpected_passes
+                    "UNEXPECTED OK: " ++ unwords unexpected_passes
                 unless (null unexpected_fails) . logAll $
-                    "UNEXPECTED FAIL: " ++ intercalate " " unexpected_fails
+                    "UNEXPECTED FAIL: " ++ unwords unexpected_fails
                 exitFailure
 
 findTests :: IO [FilePath]

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -70,7 +70,7 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as C
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Char as Char
-import Data.List (intercalate, isInfixOf, isPrefixOf, stripPrefix)
+import Data.List (isInfixOf, isPrefixOf, stripPrefix)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Network.Wait (waitTcpVerbose)
 import System.Directory
@@ -778,7 +778,7 @@ recordHeader :: [String] -> TestM ()
 recordHeader args = do
   env <- getTestEnv
   let mode = testRecordMode env
-      str_header = "# " ++ intercalate " " args ++ "\n"
+      str_header = "# " ++ unwords args ++ "\n"
       rec_header = C.pack str_header
   case mode of
     DoNotRecord -> return ()

--- a/cabal-validate/src/ANSI.hs
+++ b/cabal-validate/src/ANSI.hs
@@ -15,7 +15,7 @@ rawSGR code = "\x1b[" <> show code <> "m"
 
 -- | Render a series of `SGR` escape sequences.
 setSGR :: [SGR] -> String
-setSGR = concat . map renderSGR
+setSGR = concatMap renderSGR
 
 -- | All of the SGR sequences we want to use.
 data SGR


### PR DESCRIPTION
See #9110. Discharges and no longer ignores the following suggestions so that these will be suggested by our CI linting. After these changes, the code is simpler.

* "Use max"
* "Use unwords"
* "Use rights"
* "Use concatMap"
* "Use catMaybes"

I fixed some cascading additions of "Use mapMaybe" but held back the rest of those suggestions, not wanting to add a lot more review items this time around.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
