### PR TITLE
configure GHC: reduce verbosity of newer version warn to info

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -188,7 +188,7 @@ configureCompiler verbosity hcPath conf0 = do
   -- Cabal currently supports GHC less than `maxGhcVersion`
   let maxGhcVersion = mkVersion [9, 16]
   unless (ghcVersion < maxGhcVersion) $
-    warn verbosity $
+    info verbosity $
       "Unknown/unsupported 'ghc' version detected "
         ++ "(Cabal "
         ++ prettyShow cabalVersion

--- a/changelog.d/pr-11514.md
+++ b/changelog.d/pr-11514.md
@@ -1,0 +1,8 @@
+synopsis: Change unsupported ghc version warning to info
+packages: Cabal
+prs: #11514
+issues: #9734
+
+description: {
+The warning "Unknown/unsupported 'ghc' version detected (Cabal 3.12.1.0 supports 'ghc' version < 9.12): /usr/bin/ghc-9.12.3 is version 9.12.3" is now only shown at Info level of verbosity.
+}


### PR DESCRIPTION
"Warning: Unknown/unsupported 'ghc' version detected (Cabal 3.12.1.0 supports 'ghc' version < 9.12): /usr/bin/ghc-9.12.3 is version 9.12.3" is now only shown at Info level of verbosity

Closes #9734

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
