### PR TITLE
Fix broken link to accessing-data-files

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -3156,7 +3156,7 @@ package-related constants:
     copyright :: String
     homepage :: String
 
-Unlike :file:`Paths_{pkgname}` (see <#accessing-data-files-from-package-code>),
+Unlike :file:`Paths_{pkgname}` (see :ref:`accessing-data-files`),
 :file:`PackageInfo_{pkgname}` is system- and path-independent. It aims to be
 easier to work with for hash-based tools such as Nix.
 


### PR DESCRIPTION
Follow on from #7469. The nitpick `-n` option did not catch the bad link. The `accessing-data-files` section label was added in #6971.

When using the `:ref:label` syntax nitpicking finds a bad link:

```diff
$ git diff
...
-Unlike :file:`Paths_{pkgname}` (see :ref:`accessing-data-files`),
+Unlike :file:`Paths_{pkgname}` (see :ref:`accessing-data-folies`),
```

```
$ make users-guide
...
/.../cabal/doc/cabal-package-description-file.rst:3159:
  WARNING: undefined label: 'accessing-data-folies' [ref.ref]
...
make: *** [Makefile:287: users-guide] Error 2
```

When using the ``` `description <#anchor>`_ ``` syntax nitpicking fails to report the bad link:

```diff
...
-Unlike :file:`Paths_{pkgname}` (see `accessing data files <#accessing-data-files-from-package-code>`_),
+Unlike :file:`Paths_{pkgname}` (see `accessing data files <#accessing-data-folies-from-package-code>`_),
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
