### PR TITLE
Fix haddock inline code needing escaping

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
@@ -209,7 +209,7 @@ unionBound _ _ = InclusiveBound
 -- Each interval is non-empty. The sequence is in increasing order and no
 -- intervals overlap or touch. Therefore only the first and last can be
 -- unbounded. The sequence can be empty if the range is empty
--- (e.g. a range expression like @< 1 && > 2@).
+-- (e.g. a range expression like @\< 1 && > 2@).
 --
 -- Other checks are trivial to implement using this view. For example:
 --

--- a/Cabal-syntax/src/Distribution/Version.hs
+++ b/Cabal-syntax/src/Distribution/Version.hs
@@ -163,13 +163,13 @@ simplifyVersionRange vr
     vi = toVersionIntervals vr
 
 -- | Given a version range, remove the highest upper bound. Example: @(>= 1 && <
--- 3) || (>= 4 && < 5)@ is converted to @(>= 1 && < 3) || (>= 4)@.
+-- 3) || (>= 4 && < 5)@ is converted to @(>= 1 && < 3) || (\>= 4)@.
 removeUpperBound :: VersionRange -> VersionRange
 removeUpperBound = fromVersionIntervals . relaxLastInterval . toVersionIntervals
 
 -- | Given a version range, remove the lowest lower bound.
--- Example: @(>= 1 && < 3) || (>= 4 && < 5)@ is converted to
--- @(>= 0 && < 3) || (>= 4 && < 5)@.
+-- Example: @(>= 1 && < 3) || (\>= 4 && < 5)@ is converted to
+-- @(>= 0 && < 3) || (\>= 4 && < 5)@.
 removeLowerBound :: VersionRange -> VersionRange
 removeLowerBound = fromVersionIntervals . relaxHeadInterval . toVersionIntervals
 


### PR DESCRIPTION
Minor rendering fix in haddock markup. Escaping is [sometimes needed](https://kowainik.github.io/posts/haddock-tips#escaping) for [special characters](https://haskell-haddock.readthedocs.io/latest/markup.html#special-characters) within inline code blocks, within `@...@`. The problem haddocks are for functions `removeLowerBound`, `removeUpperBound` and `asVersionIntervals`.

* Before the fix:

<img width="780" height="427" alt="image" src="https://github.com/user-attachments/assets/6d609e4e-9e45-483c-ae9b-584f87dac253" />

* After the fix:

<img width="782" height="763" alt="image" src="https://github.com/user-attachments/assets/d0efb69c-194f-47af-8b8e-a979e5937ed9" />

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
