### PR TITLE
Add HLint hint to use findWithDefault

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -54,6 +54,15 @@
 - ignore: {name: "Use unless"} # 23 hints
 - ignore: {name: "Use void"} # 23 hints
 
+- group:
+    name: cabal-suggestions
+    enabled: true
+    rules:
+    - hint:
+        lhs: fromMaybe x (Data.Map.lookup k m)
+        rhs: Map.findWithDefault x k m
+        name: Use findWithDefault
+
 - arguments:
     - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs
     - --ignore-glob=Cabal-tests/tests/custom-setup/CabalDoctestSetup.hs

--- a/Cabal/src/Distribution/Backpack/LinkedComponent.hs
+++ b/Cabal/src/Distribution/Backpack/LinkedComponent.hs
@@ -161,9 +161,7 @@ toLinkedComponent
 
       lookupUid :: ComponentId -> (OpenUnitId, ModuleShape)
       lookupUid cid =
-        fromMaybe
-          (error "linkComponent: lookupUid")
-          (Map.lookup cid pkg_map)
+        Map.findWithDefault (error "linkComponent: lookupUid") cid pkg_map
 
     let orErr (Right x) = return x
         orErr (Left [err]) = dieProgress err

--- a/cabal-dev-scripts/src/GenUtils.hs
+++ b/cabal-dev-scripts/src/GenUtils.hs
@@ -133,7 +133,7 @@ combine f t
     unDiff (Diff.Both _ a) = a -- important we prefer latter versions!
 
     addTags :: a -> (a, Set.Set tag)
-    addTags a = (a, fromMaybe Set.empty (Map.lookup (f a) tags))
+    addTags a = (a, Map.findWithDefault Set.empty (f a) tags)
 
     process :: tag -> [a] -> [a]
     process tag as = map unDiff $ Diff.getDiffBy (\x y -> f x == f y) (t tag) as

--- a/cabal-install-solver/src/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PackageIndex.hs
@@ -120,7 +120,7 @@ internalError name = error ("PackageIndex." ++ name ++ ": internal error")
 -- case-sensitively.
 --
 lookup :: PackageIndex pkg -> PackageName -> [pkg]
-lookup (PackageIndex m) name = fromMaybe [] $ Map.lookup name m
+lookup (PackageIndex m) name = Map.findWithDefault [] name m
 
 --
 -- * Construction

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -885,7 +885,7 @@ interpretPackagesPreference selected defaultPref prefs =
   where
     versionPref :: PackageName -> [VersionRange]
     versionPref pkgname =
-      fromMaybe [anyVersion] (Map.lookup pkgname versionPrefs)
+      Map.findWithDefault [anyVersion] pkgname versionPrefs
     versionPrefs =
       Map.fromListWith
         (++)
@@ -895,7 +895,7 @@ interpretPackagesPreference selected defaultPref prefs =
 
     installPref :: PackageName -> InstalledPreference
     installPref pkgname =
-      fromMaybe (installPrefDefault pkgname) (Map.lookup pkgname installPrefs)
+      Map.findWithDefault (installPrefDefault pkgname) pkgname installPrefs
     installPrefs =
       Map.fromList
         [ (pkgname, pref)
@@ -914,7 +914,7 @@ interpretPackagesPreference selected defaultPref prefs =
 
     stanzasPref :: PackageName -> [OptionalStanza]
     stanzasPref pkgname =
-      fromMaybe [] (Map.lookup pkgname stanzasPrefs)
+      Map.findWithDefault [] pkgname stanzasPrefs
     stanzasPrefs =
       Map.fromListWith
         (\a b -> nub (a ++ b))

--- a/cabal-install/src/Distribution/Client/List.hs
+++ b/cabal-install/src/Distribution/Client/List.hs
@@ -157,9 +157,7 @@ getPkgList verbosity packageDBs repoCtxt mcompprogdb listFlags pats = do
 
   let sourcePkgIndex = packageIndex sourcePkgDb
       prefs name =
-        fromMaybe
-          anyVersion
-          (Map.lookup name (packagePreferences sourcePkgDb))
+        Map.findWithDefault anyVersion name (packagePreferences sourcePkgDb)
 
       pkgsInfoMatching
         :: [(PackageName, [Installed.InstalledPackageInfo], [UnresolvedSourcePackage])]
@@ -269,9 +267,7 @@ info
     sourcePkgDb <- getSourcePackages verbosity repoCtxt
     let sourcePkgIndex = packageIndex sourcePkgDb
         prefs name =
-          fromMaybe
-            anyVersion
-            (Map.lookup name (packagePreferences sourcePkgDb))
+          Map.findWithDefault anyVersion name (packagePreferences sourcePkgDb)
 
     -- Users may specify names of packages that are only installed, not
     -- just available source packages, so we must resolve targets using


### PR DESCRIPTION
Fixes #11534.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
