### PR TITLE
Remove make doctest --allow-newer=False

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@
 CABALBUILD := cabal build
 CABALRUN   := cabal run
 
-# We have to avoid allow-newer.
-# SEE: https://github.com/haskell/cabal/issues/6859
-DOCTEST := cabal doctest --allow-newer=False
+DOCTEST := cabal doctest
 
 # default rules
 


### PR DESCRIPTION
Follow on from #8732. We no longer need this option if using `cabal repl`. I'm not so sure about `cabal doctest`.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
