### PR TITLE
Add prefer-version setting

### DIFF
--- a/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
+++ b/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
@@ -35,6 +35,7 @@ data CabalSpecVersion
   | CabalSpecV3_16
   | -- 3.18: remove build-type: Make
     CabalSpecV3_18
+  | CabalSpecV3_20
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Data, Generic)
 
 instance Binary CabalSpecVersion
@@ -45,6 +46,7 @@ instance NFData CabalSpecVersion
 --
 -- @since 3.0.0.0
 showCabalSpecVersion :: CabalSpecVersion -> String
+showCabalSpecVersion CabalSpecV3_20 = "3.20"
 showCabalSpecVersion CabalSpecV3_18 = "3.18"
 showCabalSpecVersion CabalSpecV3_16 = "3.16"
 showCabalSpecVersion CabalSpecV3_14 = "3.14"
@@ -76,6 +78,7 @@ cabalSpecLatest = CabalSpecV3_16
 -- It may fail if for recent versions the version is not exact.
 cabalSpecFromVersionDigits :: [Int] -> Maybe CabalSpecVersion
 cabalSpecFromVersionDigits v
+  | v == [3, 20] = Just CabalSpecV3_20
   | v == [3, 18] = Just CabalSpecV3_18
   | v == [3, 16] = Just CabalSpecV3_16
   | v == [3, 14] = Just CabalSpecV3_14
@@ -102,6 +105,7 @@ cabalSpecFromVersionDigits v
 
 -- | @since 3.4.0.0
 cabalSpecToVersionDigits :: CabalSpecVersion -> [Int]
+cabalSpecToVersionDigits CabalSpecV3_20 = [3, 20]
 cabalSpecToVersionDigits CabalSpecV3_18 = [3, 18]
 cabalSpecToVersionDigits CabalSpecV3_16 = [3, 16]
 cabalSpecToVersionDigits CabalSpecV3_14 = [3, 14]

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,8 +33,8 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
-    0xfbca1c1f2a700fb3a174ec5346e86cbb
+    0x2ab5eeae7337cba494221e344aaaaafc
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0xd9542841ab7584d348aa142053fe934f
+    0x3398bd7f316ecb8f535cbe78498a89a4

--- a/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
@@ -1,7 +1,7 @@
 module Distribution.Solver.Types.Settings
     ( ReorderGoals(..)
     , IndependentGoals(..)
-    , PreferOldest(..)
+    , PreferVersion(..)
     , MinimizeConflictSet(..)
     , AvoidReinstalls(..)
     , ShadowPkgs(..)
@@ -39,8 +39,11 @@ newtype MinimizeConflictSet = MinimizeConflictSet Bool
 newtype IndependentGoals = IndependentGoals Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
-newtype PreferOldest = PreferOldest Bool
-  deriving (BooleanFlag, Eq, Generic, Show)
+data PreferVersion =
+  PreferOldest
+  | PreferLatest
+  | PreferInstalledOrLatest
+  deriving (Eq, Generic, Show)
 
 newtype AvoidReinstalls = AvoidReinstalls Bool
   deriving (BooleanFlag, Eq, Generic, Show)
@@ -71,7 +74,7 @@ instance Binary ReorderGoals
 instance Binary CountConflicts
 instance Binary FineGrainedConflicts
 instance Binary IndependentGoals
-instance Binary PreferOldest
+instance Binary PreferVersion
 instance Binary MinimizeConflictSet
 instance Binary AvoidReinstalls
 instance Binary ShadowPkgs
@@ -84,7 +87,7 @@ instance Structured ReorderGoals
 instance Structured CountConflicts
 instance Structured FineGrainedConflicts
 instance Structured IndependentGoals
-instance Structured PreferOldest
+instance Structured PreferVersion
 instance Structured MinimizeConflictSet
 instance Structured AvoidReinstalls
 instance Structured ShadowPkgs
@@ -97,7 +100,7 @@ instance NFData ReorderGoals
 instance NFData CountConflicts
 instance NFData FineGrainedConflicts
 instance NFData IndependentGoals
-instance NFData PreferOldest
+instance NFData PreferVersion
 instance NFData MinimizeConflictSet
 instance NFData AvoidReinstalls
 instance NFData ShadowPkgs
@@ -108,6 +111,11 @@ instance NFData OnlyConstrained
 instance Pretty OnlyConstrained where
   pretty OnlyConstrainedAll  = PP.text "all"
   pretty OnlyConstrainedNone = PP.text "none"
+
+instance Pretty PreferVersion where
+  pretty PreferOldest = PP.text "oldest"
+  pretty PreferLatest = PP.text "latest"
+  pretty PreferInstalledOrLatest = PP.text "installed-or-latest"
 
 instance Parsec OnlyConstrained where
   parsec = P.choice
@@ -133,8 +141,12 @@ instance Parsec StrongFlags where
 instance Parsec AllowBootLibInstalls where
   parsec = AllowBootLibInstalls <$> parsec
 
-instance Parsec PreferOldest where
-  parsec = PreferOldest <$> parsec
+instance Parsec PreferVersion where
+  parsec = P.choice
+    [ P.string "oldest"  >> return PreferOldest
+    , P.string "latest" >> return PreferLatest
+    , P.string "installed-or-latest" >> return PreferInstalledOrLatest
+    ]
 
 instance Parsec IndependentGoals where
   parsec = IndependentGoals <$> parsec

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -44,7 +44,7 @@ import Distribution.Solver.Types.Settings
   , IndependentGoals (..)
   , MinimizeConflictSet (..)
   , OnlyConstrained (..)
-  , PreferOldest (..)
+  , PreferVersion (..)
   , ReorderGoals (..)
   , StrongFlags (..)
   )
@@ -59,6 +59,7 @@ import Distribution.Types.Version (mkVersion)
 import Distribution.Types.VersionRange.Internal (VersionRange (..))
 import Distribution.Utils.NubList
 import Distribution.Verbosity
+import GHC.Stack (HasCallStack)
 import Network.URI (parseURI)
 import System.Directory (canonicalizePath, doesFileExist)
 import System.FilePath ((</>))
@@ -228,7 +229,7 @@ testProjectConfigShared = do
     projectConfigOnlyConstrained = Flag OnlyConstrainedAll
     projectConfigPerComponent = Flag True
     projectConfigIndependentGoals = Flag (IndependentGoals True)
-    projectConfigPreferOldest = Flag (PreferOldest True)
+    projectConfigPreferVersion = Flag PreferOldest
     projectConfigProgPathExtra = toNubList ["/foo/bar", "/baz/quux"]
     projectConfigMultiRepl = toFlag True
 
@@ -578,7 +579,7 @@ readConfig testSubDir projectFileName = do
         readProjectFileSkeletonLegacy verbosity httpTransport distDirLayout ProjectFileKeyMain
   return (parsec, legacy)
 
-assertConfigEquals :: (Eq a, Show a) => a -> ProjectConfigSkeleton -> ProjectConfigSkeleton -> (ProjectConfigSkeleton -> a) -> Assertion
+assertConfigEquals :: (Eq a, Show a, HasCallStack) => a -> ProjectConfigSkeleton -> ProjectConfigSkeleton -> (ProjectConfigSkeleton -> a) -> Assertion
 assertConfigEquals expected config configLegacy access = do
   assertEqual "Expectation does not match result of Legacy parser" expected actualLegacy
   assertEqual "Parsed Config does not match expected" expected actual

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -421,7 +421,7 @@ instance Semigroup SavedConfig where
           , installFineGrainedConflicts = combine installFineGrainedConflicts
           , installMinimizeConflictSet = combine installMinimizeConflictSet
           , installIndependentGoals = combine installIndependentGoals
-          , installPreferOldest = combine installPreferOldest
+          , installPreferVersion = combine installPreferVersion
           , installShadowPkgs = combine installShadowPkgs
           , installStrongFlags = combine installStrongFlags
           , installAllowBootLibInstalls = combine installAllowBootLibInstalls

--- a/cabal-install/src/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/src/Distribution/Client/Dependency/Types.hs
@@ -44,11 +44,12 @@ data PackagesPreferenceDefault
     -- installed version.
     --
     -- * This is the standard policy for upgrade.
+    -- * This is enabled by --prefer-version=latest for install
     PreferAllLatest
   | -- | Always prefer the oldest version irrespective of any existing
     -- installed version or packages explicitly requested.
     --
-    -- * This is enabled by --prefer-oldest.
+    -- * This is enabled by --prefer-version=oldest for install.
     PreferAllOldest
   | -- | Always prefer the installed versions over ones that would need to be
     -- installed. Secondarily, prefer latest versions (eg the latest installed

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -367,7 +367,7 @@ resolveSolverSettings
       solverSettingIndexState = flagToMaybe projectConfigIndexState
       solverSettingActiveRepos = flagToMaybe projectConfigActiveRepos
       solverSettingIndependentGoals = fromFlag projectConfigIndependentGoals
-      solverSettingPreferOldest = fromFlag projectConfigPreferOldest
+      solverSettingPreferVersion = fromFlag projectConfigPreferVersion
       -- solverSettingShadowPkgs        = fromFlag projectConfigShadowPkgs
       -- solverSettingReinstall         = fromFlag projectConfigReinstall
       -- solverSettingAvoidReinstalls   = fromFlag projectConfigAvoidReinstalls
@@ -390,7 +390,7 @@ resolveSolverSettings
           , projectConfigAllowBootLibInstalls = Flag (AllowBootLibInstalls False)
           , projectConfigOnlyConstrained = Flag OnlyConstrainedNone
           , projectConfigIndependentGoals = Flag (IndependentGoals False)
-          , projectConfigPreferOldest = Flag (PreferOldest False)
+          , projectConfigPreferVersion = Flag PreferInstalledOrLatest
           -- projectConfigShadowPkgs        = Flag False,
           -- projectConfigReinstall         = Flag False,
           -- projectConfigAvoidReinstalls   = Flag False,

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -8,6 +8,7 @@ module Distribution.Client.ProjectConfig.FieldGrammar
   , packageConfigFieldGrammar
   ) where
 
+import Data.Bool (bool)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Set as Set
 import Distribution.CabalSpecVersion (CabalSpecVersion (..))
@@ -21,6 +22,7 @@ import Distribution.Simple.Flag
 import Distribution.Simple.InstallDirs
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource (..))
 import Distribution.Solver.Types.ProjectConfigPath
+import Distribution.Solver.Types.Settings (PreferVersion (..))
 import Distribution.Types.PackageVersionConstraint (PackageVersionConstraint (..))
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
@@ -102,7 +104,7 @@ projectConfigSharedFieldGrammar source = do
   projectConfigOnlyConstrained <- optionalFieldDef "reject-unconstrained-dependencies" L.projectConfigOnlyConstrained mempty
   projectConfigPerComponent <- optionalFieldDef "per-component" L.projectConfigPerComponent mempty
   projectConfigIndependentGoals <- optionalFieldDef "independent-goals" L.projectConfigIndependentGoals mempty
-  projectConfigPreferOldest <- optionalFieldDef "prefer-oldest" L.projectConfigPreferOldest mempty
+  projectConfigPreferVersion <- packageConfigPreferVersion
   projectConfigProgPathExtra <- monoidalFieldAla "extra-prog-path-shared-only" (alaNubList' FSep FilePathNT) L.projectConfigProgPathExtra
   projectConfigMultiRepl <- optionalFieldDef "multi-repl" L.projectConfigMultiRepl mempty
   pure ProjectConfigShared{..}
@@ -198,3 +200,10 @@ packageConfigCoverageGrammar =
     <$> optionalFieldDef "coverage" L.packageConfigCoverage mempty
     <*> optionalFieldDef "library-coverage" L.packageConfigCoverage mempty
       ^^^ deprecatedSince CabalSpecV1_22 "Please use 'coverage' field instead."
+
+packageConfigPreferVersion :: ParsecFieldGrammar ProjectConfigShared (Flag PreferVersion)
+packageConfigPreferVersion =
+  mappend . fmap (bool PreferInstalledOrLatest PreferOldest)
+    <$> optionalFieldDef "prefer-oldest" L.projectConfigPreferOldest mempty
+      ^^^ deprecatedSince CabalSpecV3_20 "Please use 'prefer-version' field instead."
+    <*> optionalFieldDef "prefer-version" L.projectConfigPreferVersion mempty

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -712,7 +712,7 @@ convertLegacyAllPackageFlags globalFlags configFlags configExFlags installFlags 
       , installMinimizeConflictSet = projectConfigMinimizeConflictSet
       , installPerComponent = projectConfigPerComponent
       , installIndependentGoals = projectConfigIndependentGoals
-      , installPreferOldest = projectConfigPreferOldest
+      , installPreferVersion = projectConfigPreferVersion
       , -- installShadowPkgs         = projectConfigShadowPkgs,
       installStrongFlags = projectConfigStrongFlags
       , installAllowBootLibInstalls = projectConfigAllowBootLibInstalls
@@ -998,7 +998,7 @@ convertToLegacySharedConfig
           , installFineGrainedConflicts = projectConfigFineGrainedConflicts
           , installMinimizeConflictSet = projectConfigMinimizeConflictSet
           , installIndependentGoals = projectConfigIndependentGoals
-          , installPreferOldest = projectConfigPreferOldest
+          , installPreferVersion = projectConfigPreferVersion
           , installShadowPkgs = mempty -- projectConfigShadowPkgs,
           , installStrongFlags = projectConfigStrongFlags
           , installAllowBootLibInstalls = projectConfigAllowBootLibInstalls
@@ -1464,6 +1464,7 @@ legacySharedConfigFieldDescrs constraintSrc =
           , "minimize-conflict-set"
           , "independent-goals"
           , "prefer-oldest"
+          , "prefer-version"
           , "strong-flags"
           , "allow-boot-library-installs"
           , "reject-unconstrained-dependencies"

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Lens.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Lens.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Distribution.Client.ProjectConfig.Lens where
 
 import Distribution.Client.BuildReports.Types (ReportLevel (..))
@@ -38,6 +40,9 @@ import Distribution.Simple.Setup
   , Flag
   , HaddockTarget (..)
   , TestShowDetails (..)
+  , flagToMaybe
+  , pattern Flag
+  , pattern NoFlag
   )
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource)
 import Distribution.Solver.Types.Settings
@@ -47,7 +52,7 @@ import Distribution.Solver.Types.Settings
   , IndependentGoals (..)
   , MinimizeConflictSet (..)
   , OnlyConstrained (..)
-  , PreferOldest (..)
+  , PreferVersion (..)
   , ReorderGoals (..)
   , StrongFlags (..)
   )
@@ -296,9 +301,24 @@ projectConfigOnlyConstrained :: Lens' ProjectConfigShared (Flag OnlyConstrained)
 projectConfigOnlyConstrained f s = fmap (\x -> s{T.projectConfigOnlyConstrained = x}) (f (T.projectConfigOnlyConstrained s))
 {-# INLINEABLE projectConfigOnlyConstrained #-}
 
-projectConfigPreferOldest :: Lens' ProjectConfigShared (Flag PreferOldest)
-projectConfigPreferOldest f s = fmap (\x -> s{T.projectConfigPreferOldest = x}) (f (T.projectConfigPreferOldest s))
+projectConfigPreferOldest :: Lens' ProjectConfigShared (Flag Bool)
+projectConfigPreferOldest f s = fmap (\x -> s{T.projectConfigPreferVersion = fromBool x}) (f (toBool $ T.projectConfigPreferVersion s))
+  where
+    toBool :: Flag PreferVersion -> Flag Bool
+    toBool mpv = case flagToMaybe mpv of
+      Just PreferOldest -> Flag True
+      Just PreferInstalledOrLatest -> Flag False
+      _ -> NoFlag
+    fromBool :: Flag Bool -> Flag PreferVersion
+    fromBool mpo = case flagToMaybe mpo of
+      Just True -> Flag PreferOldest
+      Just False -> Flag PreferInstalledOrLatest
+      _ -> NoFlag
 {-# INLINEABLE projectConfigPreferOldest #-}
+
+projectConfigPreferVersion :: Lens' ProjectConfigShared (Flag PreferVersion)
+projectConfigPreferVersion f s = fmap (\x -> s{T.projectConfigPreferVersion = x}) (f (T.projectConfigPreferVersion s))
+{-# INLINEABLE projectConfigPreferVersion #-}
 
 projectConfigProgPathExtra :: Lens' ProjectConfigShared (NubList FilePath)
 projectConfigProgPathExtra f s = fmap (\x -> s{T.projectConfigProgPathExtra = x}) (f (T.projectConfigProgPathExtra s))

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -232,7 +232,7 @@ data ProjectConfigShared = ProjectConfigShared
   , projectConfigOnlyConstrained :: Flag OnlyConstrained
   , projectConfigPerComponent :: Flag Bool
   , projectConfigIndependentGoals :: Flag IndependentGoals
-  , projectConfigPreferOldest :: Flag PreferOldest
+  , projectConfigPreferVersion :: Flag PreferVersion
   , projectConfigProgPathExtra :: NubList FilePath
   , projectConfigMultiRepl :: Flag Bool
   -- More things that only make sense for manual mode, not --local mode
@@ -445,7 +445,7 @@ data SolverSettings = SolverSettings
   , solverSettingIndexState :: Maybe TotalIndexState
   , solverSettingActiveRepos :: Maybe ActiveRepos
   , solverSettingIndependentGoals :: IndependentGoals
-  , solverSettingPreferOldest :: PreferOldest
+  , solverSettingPreferVersion :: PreferVersion
   -- Things that only make sense for manual mode, not --local mode
   -- too much control!
   -- solverSettingShadowPkgs        :: Bool,

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1375,19 +1375,12 @@ planPackages
           . setAllowBootLibInstalls solverSettingAllowBootLibInstalls
           . setOnlyConstrained solverSettingOnlyConstrained
           . setSolverVerbosity (verbosityLevel verbosity)
-          -- TODO: [required eventually] decide if we need to prefer
-          -- installed for global packages, or prefer latest even for
-          -- global packages. Perhaps should be configurable but with a
-          -- different name than "upgrade-dependencies".
           . setPreferenceDefault
-            ( if Cabal.asBool solverSettingPreferOldest
-                then PreferAllOldest
-                else PreferLatestForSelected
+            ( case solverSettingPreferVersion of
+                PreferOldest -> PreferAllOldest
+                PreferLatest -> PreferAllLatest
+                PreferInstalledOrLatest -> PreferLatestForSelected
             )
-          {-(if solverSettingUpgradeDeps
-               then PreferAllLatest
-               else PreferLatestForSelected)-}
-
           . removeLowerBounds solverSettingAllowOlder
           . removeUpperBounds solverSettingAllowNewer
           . addDefaultSetupDependencies

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -238,6 +238,7 @@ import Distribution.Version
 import Control.Exception
   ( assert
   )
+import Data.Functor (($>))
 import Data.List
   ( deleteFirstsBy
   )
@@ -1389,7 +1390,7 @@ data FetchFlags = FetchFlags
   , fetchFineGrainedConflicts :: Flag FineGrainedConflicts
   , fetchMinimizeConflictSet :: Flag MinimizeConflictSet
   , fetchIndependentGoals :: Flag IndependentGoals
-  , fetchPreferOldest :: Flag PreferOldest
+  , fetchPreferVersion :: Flag PreferVersion
   , fetchShadowPkgs :: Flag ShadowPkgs
   , fetchStrongFlags :: Flag StrongFlags
   , fetchAllowBootLibInstalls :: Flag AllowBootLibInstalls
@@ -1412,7 +1413,7 @@ defaultFetchFlags =
     , fetchFineGrainedConflicts = Flag (FineGrainedConflicts True)
     , fetchMinimizeConflictSet = Flag (MinimizeConflictSet False)
     , fetchIndependentGoals = Flag (IndependentGoals False)
-    , fetchPreferOldest = Flag (PreferOldest False)
+    , fetchPreferVersion = Flag PreferInstalledOrLatest
     , fetchShadowPkgs = Flag (ShadowPkgs False)
     , fetchStrongFlags = Flag (StrongFlags False)
     , fetchAllowBootLibInstalls = Flag (AllowBootLibInstalls False)
@@ -1495,8 +1496,8 @@ fetchCommand =
             (\v flags -> flags{fetchMinimizeConflictSet = v})
             fetchIndependentGoals
             (\v flags -> flags{fetchIndependentGoals = v})
-            fetchPreferOldest
-            (\v flags -> flags{fetchPreferOldest = v})
+            fetchPreferVersion
+            (\v flags -> flags{fetchPreferVersion = v})
             fetchShadowPkgs
             (\v flags -> flags{fetchShadowPkgs = v})
             fetchStrongFlags
@@ -1524,7 +1525,7 @@ data FreezeFlags = FreezeFlags
   , freezeFineGrainedConflicts :: Flag FineGrainedConflicts
   , freezeMinimizeConflictSet :: Flag MinimizeConflictSet
   , freezeIndependentGoals :: Flag IndependentGoals
-  , freezePreferOldest :: Flag PreferOldest
+  , freezePreferVersion :: Flag PreferVersion
   , freezeShadowPkgs :: Flag ShadowPkgs
   , freezeStrongFlags :: Flag StrongFlags
   , freezeAllowBootLibInstalls :: Flag AllowBootLibInstalls
@@ -1545,7 +1546,7 @@ defaultFreezeFlags =
     , freezeFineGrainedConflicts = Flag (FineGrainedConflicts True)
     , freezeMinimizeConflictSet = Flag (MinimizeConflictSet False)
     , freezeIndependentGoals = Flag (IndependentGoals False)
-    , freezePreferOldest = Flag (PreferOldest False)
+    , freezePreferVersion = Flag PreferInstalledOrLatest
     , freezeShadowPkgs = Flag (ShadowPkgs False)
     , freezeStrongFlags = Flag (StrongFlags False)
     , freezeAllowBootLibInstalls = Flag (AllowBootLibInstalls False)
@@ -1617,8 +1618,8 @@ freezeCommand =
             (\v flags -> flags{freezeMinimizeConflictSet = v})
             freezeIndependentGoals
             (\v flags -> flags{freezeIndependentGoals = v})
-            freezePreferOldest
-            (\v flags -> flags{freezePreferOldest = v})
+            freezePreferVersion
+            (\v flags -> flags{freezePreferVersion = v})
             freezeShadowPkgs
             (\v flags -> flags{freezeShadowPkgs = v})
             freezeStrongFlags
@@ -2214,7 +2215,7 @@ data InstallFlags = InstallFlags
   , installFineGrainedConflicts :: Flag FineGrainedConflicts
   , installMinimizeConflictSet :: Flag MinimizeConflictSet
   , installIndependentGoals :: Flag IndependentGoals
-  , installPreferOldest :: Flag PreferOldest
+  , installPreferVersion :: Flag PreferVersion
   , installShadowPkgs :: Flag ShadowPkgs
   , installStrongFlags :: Flag StrongFlags
   , installAllowBootLibInstalls :: Flag AllowBootLibInstalls
@@ -2261,7 +2262,7 @@ defaultInstallFlags =
     , installFineGrainedConflicts = Flag (FineGrainedConflicts True)
     , installMinimizeConflictSet = Flag (MinimizeConflictSet False)
     , installIndependentGoals = Flag (IndependentGoals False)
-    , installPreferOldest = Flag (PreferOldest False)
+    , installPreferVersion = Flag PreferInstalledOrLatest
     , installShadowPkgs = Flag (ShadowPkgs False)
     , installStrongFlags = Flag (StrongFlags False)
     , installAllowBootLibInstalls = Flag (AllowBootLibInstalls False)
@@ -2621,8 +2622,8 @@ installOptions showOrParseArgs =
       (\v flags -> flags{installMinimizeConflictSet = v})
       installIndependentGoals
       (\v flags -> flags{installIndependentGoals = v})
-      installPreferOldest
-      (\v flags -> flags{installPreferOldest = v})
+      installPreferVersion
+      (\v flags -> flags{installPreferVersion = v})
       installShadowPkgs
       (\v flags -> flags{installShadowPkgs = v})
       installStrongFlags
@@ -3572,8 +3573,8 @@ optionSolverFlags
   -> (Flag MinimizeConflictSet -> flags -> flags)
   -> (flags -> Flag IndependentGoals)
   -> (Flag IndependentGoals -> flags -> flags)
-  -> (flags -> Flag PreferOldest)
-  -> (Flag PreferOldest -> flags -> flags)
+  -> (flags -> Flag PreferVersion)
+  -> (Flag PreferVersion -> flags -> flags)
   -> (flags -> Flag ShadowPkgs)
   -> (Flag ShadowPkgs -> flags -> flags)
   -> (flags -> Flag StrongFlags)
@@ -3660,9 +3661,23 @@ optionSolverFlags
         []
         ["prefer-oldest"]
         "Prefer the oldest (instead of the latest) versions of packages available. Useful to determine lower bounds in the build-depends section."
-        (fmap asBool . getpo)
-        (setpo . fmap PreferOldest)
+        ((\x -> if x == Flag PreferOldest then Flag True else NoFlag) . getpo)
+        (setpo . ($> PreferOldest))
         (yesNoOpt showOrParseArgs)
+    , option
+        []
+        ["prefer-version"]
+        "Select which version of a package that the solver should prefer. Oldest is useful to determine lower bounds in build-depends section. Latest will prefer the latest version. Installed-or-latest will prefer installed versions and the latest version otherwise."
+        getpo
+        setpo
+        ( reqArg
+            "oldest|latest|installed-or-latest"
+            ( parsecToReadE
+                (\err -> "Error parsing prefer-version: " ++ err)
+                (toFlag `fmap` parsec)
+            )
+            (flagToList . fmap prettyShow)
+        )
     , option
         []
         ["shadow-installed-packages"]

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -2620,6 +2620,7 @@ testConfigOptionComments = do
   "-- minimize-conflict-set" `assertHasCommentLine` "minimize-conflict-set"
   "-- independent-goals" `assertHasCommentLine` "independent-goals"
   "-- prefer-oldest" `assertHasCommentLine` "prefer-oldest"
+  "-- prefer-version" `assertHasCommentLine` "prefer-version"
   "-- shadow-installed-packages" `assertHasCommentLine` "shadow-installed-packages"
   "-- strong-flags" `assertHasCommentLine` "strong-flags"
   "-- allow-boot-library-installs" `assertHasCommentLine` "allow-boot-library-installs"

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -618,7 +618,7 @@ instance Arbitrary ProjectConfigShared where
     projectConfigOnlyConstrained <- arbitrary
     projectConfigPerComponent <- arbitrary
     projectConfigIndependentGoals <- arbitrary
-    projectConfigPreferOldest <- arbitrary
+    projectConfigPreferVersion <- arbitrary
     projectConfigProgPathExtra <- toNubList <$> listOf arbitraryShortToken
     projectConfigMultiRepl <- arbitrary
     return ProjectConfigShared{..}
@@ -665,7 +665,7 @@ instance Arbitrary ProjectConfigShared where
         <*> shrinker projectConfigOnlyConstrained
         <*> shrinker projectConfigPerComponent
         <*> shrinker projectConfigIndependentGoals
-        <*> shrinker projectConfigPreferOldest
+        <*> shrinker projectConfigPreferVersion
         <*> shrinker projectConfigProgPathExtra
         <*> shrinker projectConfigMultiRepl
     where
@@ -1030,8 +1030,13 @@ instance Arbitrary MinimizeConflictSet where
 instance Arbitrary IndependentGoals where
   arbitrary = IndependentGoals <$> arbitrary
 
-instance Arbitrary PreferOldest where
-  arbitrary = PreferOldest <$> arbitrary
+instance Arbitrary PreferVersion where
+  arbitrary =
+    oneof
+      [ pure PreferOldest
+      , pure PreferLatest
+      , pure PreferInstalledOrLatest
+      ]
 
 instance Arbitrary StrongFlags where
   arbitrary = StrongFlags <$> arbitrary

--- a/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
@@ -56,7 +56,7 @@ instance ToExpr OverwritePolicy
 instance ToExpr PackageConfig
 instance ToExpr (PackageDBX FilePath)
 instance ToExpr PackageProperty
-instance ToExpr PreferOldest
+instance ToExpr PreferVersion
 instance ToExpr PreSolver
 instance ToExpr ProjectConfig
 instance ToExpr ProjectConfigBuildOnly

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -793,7 +793,7 @@ exResolve
   -> FineGrainedConflicts
   -> MinimizeConflictSet
   -> IndependentGoals
-  -> PreferOldest
+  -> PreferVersion
   -> ReorderGoals
   -> AllowBootLibInstalls
   -> OnlyConstrained
@@ -817,7 +817,7 @@ exResolve
   fineGrainedConflicts
   minimizeConflictSet
   indepGoals
-  prefOldest
+  prefVersion
   reorder
   allowBootLibInstalls
   onlyConstrained
@@ -856,23 +856,27 @@ exResolve
         | otherwise = []
       targets' = fmap (\p -> NamedPackage (C.mkPackageName p) []) targets
       params =
-        addConstraints (fmap toConstraint constraints) $
-          addConstraints (fmap toLpc enableTests) $
-            addPreferences (fmap toPref prefs) $
-              setCountConflicts countConflicts $
-                setFineGrainedConflicts fineGrainedConflicts $
-                  setMinimizeConflictSet minimizeConflictSet $
-                    setIndependentGoals indepGoals $
-                      (if asBool prefOldest then setPreferenceDefault PreferAllOldest else id) $
-                        setReorderGoals reorder $
-                          setMaxBackjumps mbj $
-                            setAllowBootLibInstalls allowBootLibInstalls $
-                              setOnlyConstrained onlyConstrained $
-                                setEnableBackjumping enableBj $
-                                  setSolveExecutables solveExes $
-                                    setGoalOrder goalOrder $
-                                      setSolverVerbosity (C.verbosityLevel verbosity) $
-                                        standardInstallPolicy instIdx avaiIdx targets'
+        addConstraints (fmap toConstraint constraints)
+          $ addConstraints (fmap toLpc enableTests)
+          $ addPreferences (fmap toPref prefs)
+          $ setCountConflicts countConflicts
+          $ setFineGrainedConflicts fineGrainedConflicts
+          $ setMinimizeConflictSet minimizeConflictSet
+          $ setIndependentGoals indepGoals
+          $ ( case prefVersion of
+                PreferOldest -> setPreferenceDefault PreferAllOldest
+                PreferLatest -> setPreferenceDefault PreferAllLatest
+                PreferInstalledOrLatest -> setPreferenceDefault PreferLatestForSelected
+            )
+          $ setReorderGoals reorder
+          $ setMaxBackjumps mbj
+          $ setAllowBootLibInstalls allowBootLibInstalls
+          $ setOnlyConstrained onlyConstrained
+          $ setEnableBackjumping enableBj
+          $ setSolveExecutables solveExes
+          $ setGoalOrder goalOrder
+          $ setSolverVerbosity (C.verbosityLevel verbosity)
+          $ standardInstallPolicy instIdx avaiIdx targets'
       toLpc pc = LabeledPackageConstraint pc ConstraintSourceUnknown
 
       toConstraint (ExVersionConstraint scope v) =

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -9,6 +9,7 @@ module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
   , minimizeConflictSet
   , independentGoals
   , preferOldest
+  , preferLatest
   , allowBootLibInstalls
   , onlyConstrained
   , disableBackjumping
@@ -74,7 +75,11 @@ independentGoals test = test{testIndepGoals = IndependentGoals True}
 
 -- | Combinator to turn on --prefer-oldest
 preferOldest :: SolverTest -> SolverTest
-preferOldest test = test{testPreferOldest = PreferOldest True}
+preferOldest test = test{testPreferVersion = PreferOldest}
+
+-- | Combinator to turn on --prefer-version=latest
+preferLatest :: SolverTest -> SolverTest
+preferLatest test = test{testPreferVersion = PreferLatest}
 
 allowBootLibInstalls :: SolverTest -> SolverTest
 allowBootLibInstalls test =
@@ -131,7 +136,7 @@ data SolverTest = SolverTest
   , testFineGrainedConflicts :: FineGrainedConflicts
   , testMinimizeConflictSet :: MinimizeConflictSet
   , testIndepGoals :: IndependentGoals
-  , testPreferOldest :: PreferOldest
+  , testPreferVersion :: PreferVersion
   , testAllowBootLibInstalls :: AllowBootLibInstalls
   , testOnlyConstrained :: OnlyConstrained
   , testEnableBackjumping :: EnableBackjumping
@@ -235,7 +240,7 @@ mkTestExtLangPC exts langs mPkgConfigDb db label targets result =
     , testFineGrainedConflicts = FineGrainedConflicts True
     , testMinimizeConflictSet = MinimizeConflictSet False
     , testIndepGoals = IndependentGoals False
-    , testPreferOldest = PreferOldest False
+    , testPreferVersion = PreferInstalledOrLatest
     , testAllowBootLibInstalls = AllowBootLibInstalls False
     , testOnlyConstrained = OnlyConstrainedNone
     , testEnableBackjumping = EnableBackjumping True
@@ -268,7 +273,7 @@ runTest SolverTest{..} = withFrozenCallStack $ askOption $ \(OptionShowSolverLog
             testFineGrainedConflicts
             testMinimizeConflictSet
             testIndepGoals
-            testPreferOldest
+            testPreferVersion
             (ReorderGoals False)
             testAllowBootLibInstalls
             testOnlyConstrained

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -78,7 +78,7 @@ tests =
                 (ReorderGoals False)
                 (CountConflicts True)
                 indepGoals
-                (PreferOldest False)
+                PreferInstalledOrLatest
                 (getBlind <$> goalOrder)
             targets = testTargets test
             targets2 = case targetOrder of
@@ -99,7 +99,7 @@ tests =
                 reorderGoals
                 (CountConflicts True)
                 indep
-                (PreferOldest False)
+                PreferInstalledOrLatest
                 Nothing
          in counterexample (showResults r1 r2) $
               noneReachedBackjumpLimit [r1, r2] ==>
@@ -115,7 +115,7 @@ tests =
                 reorderGoals
                 (CountConflicts True)
                 indepGoals
-                (PreferOldest False)
+                PreferInstalledOrLatest
                 Nothing
          in counterexample (showResults r1 r2) $
               noneReachedBackjumpLimit [r1, r2] ==>
@@ -131,15 +131,15 @@ tests =
                 reorderGoals
                 (CountConflicts True)
                 indepGoals
-                (PreferOldest False)
+                PreferInstalledOrLatest
                 Nothing
          in counterexample (showResults r1 r2) $
               noneReachedBackjumpLimit [r1, r2] ==>
                 isRight (resultPlan r1) === isRight (resultPlan r2)
-  , testPropertyWithSeed "prefer oldest does not affect solvability" $
-      \test reorderGoals indepGoals ->
-        let r1 = solve' (PreferOldest True) test
-            r2 = solve' (PreferOldest False) test
+  , testPropertyWithSeed "PreferVersion does not affect solvability" $
+      \test reorderGoals indepGoals preferVersion ->
+        let r1 = solve' preferVersion test
+            r2 = solve' PreferInstalledOrLatest test
             solve' prefOldest =
               solve
                 (EnableBackjumping True)
@@ -172,7 +172,7 @@ tests =
                 reorderGoals
                 (CountConflicts False)
                 indepGoals
-                (PreferOldest False)
+                PreferInstalledOrLatest
                 Nothing
          in counterexample (showResults r1 r2) $
               noneReachedBackjumpLimit [r1, r2] ==>
@@ -189,7 +189,7 @@ tests =
                 reorderGoals
                 (CountConflicts False)
                 indepGoals
-                (PreferOldest False)
+                PreferInstalledOrLatest
                 Nothing
          in counterexample (showResults r1 r2) $
               noneReachedBackjumpLimit [r1, r2] ==>
@@ -230,7 +230,7 @@ solve
   -> ReorderGoals
   -> CountConflicts
   -> IndependentGoals
-  -> PreferOldest
+  -> PreferVersion
   -> Maybe VarOrdering
   -> SolverTest
   -> Result
@@ -531,10 +531,13 @@ instance Arbitrary IndependentGoals where
 
   shrink (IndependentGoals indep) = [IndependentGoals False | indep]
 
-instance Arbitrary PreferOldest where
-  arbitrary = PreferOldest <$> arbitrary
-
-  shrink (PreferOldest prefOldest) = [PreferOldest False | prefOldest]
+instance Arbitrary PreferVersion where
+  arbitrary =
+    oneof
+      [ pure PreferOldest
+      , pure PreferLatest
+      , pure PreferInstalledOrLatest
+      ]
 
 instance Arbitrary Component where
   arbitrary =

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -36,6 +36,12 @@ tests =
       "Simple dependencies"
       [ runTest $ mkTest db1 "alreadyInstalled" ["A"] (solverSuccess [])
       , runTest $ mkTest db1 "installLatest" ["B"] (solverSuccess [("B", 2)])
+      , -- NB: we cannot try to install A directly here, since a directly selected will always pick the latest version
+        -- and ignores the default behaviour of preferring the installed version.
+        runTest $ mkTest dbLatest "preferInstalledOverLatest" ["B"] (solverSuccess [("B", 1)])
+      , runTest $
+          preferLatest $
+            mkTest dbLatest "installLatestOverInstalled" ["B"] (solverSuccess [("A", 2), ("B", 1)])
       , runTest $
           preferOldest $
             mkTest db1 "installOldest" ["B"] (solverSuccess [("B", 1)])
@@ -1013,6 +1019,14 @@ db1 =
       , Right $ exAv "G" 1 [ExFix "B" 2, ExAny "E"]
       , Right $ exAv "Z" 1 []
       ]
+
+-- db for testing PreferLatest
+dbLatest :: ExampleDb
+dbLatest =
+  [ Left $ exInst "A" 1 "A-1" []
+  , Right $ exAv "A" 2 []
+  , Right $ exAv "B" 1 [ExAny "A"]
+  ]
 
 -- In this example, we _can_ install C and D as independent goals, but we have
 -- to pick two different versions for B (arbitrarily)

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -2021,17 +2021,34 @@ Most users generally won't need these.
                --no-prefer-oldest
     :synopsis: Prefer the oldest versions of packages available.
     :since:    3.10
+    :deprecated:
 
     :default:  False
 
     By default, when solver has a choice of multiple versions of the same
     package, it will first try to derive a build plan with the latest
-    version. This flag switches the behaviour, making the solver
-    to prefer the oldest packages available.
+    version, except if it can use a version from the global package database.
+    This flag switches the behaviour, making the solver to prefer the oldest packages available.
 
     The primary use case is to help users in establishing lower bounds
     of upstream dependencies.
 
     The command line variant of this field is ``--(no-)prefer-oldest``.
+
+.. cfg-field:: prefer-version: (oldest|latest|installed-or-latest)
+               --prefer-version=(oldest|latest|installed-or-latest)
+    :synopsis: Specify how to pick package versions
+    :since:    3.20
+
+    :default:  installed
+
+    By default, when solver has a choice of multiple versions of the same
+    package, it will first try to derive a build plan with the latest version,
+    except if it can use a version from the global package database (``installed-or-latest``).  This flag
+    switches the behaviour, allowing the solver to prefer the latest packages
+    (irrespective of the global package DB) (``latest``) or the oldest packages available (``oldest``).
+
+    The primary use case of picking the oldest package is to help users in
+    establishing lower bounds of upstream dependencies.
 
 .. include:: references.inc


### PR DESCRIPTION
The default behaviour of the solver is that we pick the latest version
of each package EXCEPT if it is a package installed in the global pkg
db, ie, package shipped with GHC.

Here we extend the existing `--prefer-oldest` flag into a
`--prefer-version=` option, which allows us to pick between
- oldest
- latest (new)
- installed-or-latest (old default)

Resolves https://github.com/haskell/cabal/issues/9669

## Manual QA instructions

1. Create a project where you have a package that depends on a package that ships with GHC but has a newer release on hackage.
2. Solve without any flags and confirm that the version from GHC is picked.
3. Solve with `--prefer-version=latest` and confirm that the version from Hackage is picked

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
