### PR TITLE
block windows-latest ghc-9.2.8 for now

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,6 +72,10 @@ jobs:
             "8.8.4",
           ]
         exclude:
+          # ghc-pkg.exe starts silently failing for a few hours
+          - sys:
+              { os: windows-latest, shell: "C:/msys64/usr/bin/bash.exe -e {0}" }
+            ghc: "9.2.8"
           # Throws fatal "cabal-tests.exe: fd:8: hGetLine: end of file" exception
           # even with --io-manager=native
           - sys:


### PR DESCRIPTION
Over the past week or so it's been prone to `ghc-pkg.exe` starting to fail for a couple hours and then mysteriously recovering. Spike it for now so we don't need to nursemaid CI.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). (only if we need to make commits to the release branch)
