### PR TITLE
Make renameFile in writeFileAtomic more robust

### DIFF
--- a/Cabal-syntax/src/Distribution/Utils/Generic.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Generic.hs
@@ -85,11 +85,12 @@ module Distribution.Utils.Generic
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Data.Char (isAsciiLower, isAsciiUpper)
-
+import Control.Concurrent (threadDelay)
+import qualified Control.Exception as Exception
 import Data.Bits (shiftL, (.&.), (.|.))
 import qualified Data.ByteString as SBS
 import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isAsciiLower, isAsciiUpper)
 import Data.List
   ( isInfixOf
   )
@@ -99,8 +100,7 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
-
-import qualified Control.Exception as Exception
+import GHC.IO.Exception (IOErrorType (UnsupportedOperation))
 import System.Directory
   ( copyFile
   , getTemporaryDirectory
@@ -119,6 +119,7 @@ import System.IO
   , withBinaryFile
   , withFile
   )
+import System.IO.Error (ioeGetErrorType)
 
 -- -----------------------------------------------------------------------------
 -- Helper functions
@@ -197,13 +198,36 @@ writeFileAtomic targetPath content = do
     ( \(tmpPath, handle) -> do
         LBS.hPut handle content
         hClose handle
-        Exception.catch
-          (renameFile tmpPath targetPath)
-          ( \(_ :: Exception.SomeException) -> do
-              copyFile tmpPath targetPath
-              removeFile tmpPath
-          )
+        renameFileWithRetry tmpPath targetPath
     )
+
+-- | A robust 'renameFile' which retries with delay and
+-- switches to 'copyFile' as a backup implementation.
+renameFileWithRetry :: FilePath -> FilePath -> IO ()
+renameFileWithRetry srcPath targetPath =
+  renameFile srcPath targetPath `Exception.catch` retryRename 3
+  where
+    retryRename :: Word -> IOException -> IO ()
+    -- If no retries left then throw whatever exception we ended up with.
+    retryRename 0 exception = throwIO exception
+    retryRename retriesLeft exception
+      -- UnsupportedOperation means EXDEV from rename(2) with source and target
+      -- on different devices. In such case we resort to copying instead of renaming.
+      | ioeGetErrorType exception == UnsupportedOperation =
+          copyFile srcPath targetPath `Exception.catch` retryCopy (retriesLeft - 1)
+      | otherwise = do
+          -- Wait 1ms between retries: maybe device is busy, maybe antivirus locked srcPath.
+          threadDelay 1000
+          renameFile srcPath targetPath `Exception.catch` retryRename (retriesLeft - 1)
+
+    retryCopy :: Word -> IOException -> IO ()
+    retryCopy 0 exception = throwIO exception
+    retryCopy retriesLeft _ = do
+      -- Wait 1ms between retries: maybe device is busy, maybe antivirus locked srcPath.
+      threadDelay 1000
+      copyFile srcPath targetPath `Exception.catch` retryCopy retriesLeft
+      -- It's nice to clean up, but not critical, so ignoring any exceptions.
+      removeFile srcPath `Exception.catch` (\(_ :: IOException) -> pure ())
 
 -- ------------------------------------------------------------
 


### PR DESCRIPTION
Closes #10938. 

The existing `writeFileAtomic` executes `renameFile` under assumption that the only reason it can fail is `EXDEV` error from `rename(2)` (see https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html). The error means that source and target files are on different devices and physical copying must be performed instead of simply renaming a file system node. So `writeFileAtomic` catches an exception and immediately tries to `copyFile` instead of `renameFile`. If `copyFile` fails, the exception is not caught and crashes the entire Cabal process.

In practice however there are could be multiple reasons why `renameFile` might be unsuccessful, such as busy device or files temporarily locked by third party (for example, an antivirus). In such cases going for `copyFile` without delay only makes things worse.

Cabal often runs `writeFileAtomic` in a middle of long `cabal build` process. It's very discouraging when the entire build fails because of a temporary issue with file system.

The patch implements a more robust strategy for `renameFile`: we retry renaming thrice with a 1ms delay between them. We only switch to `copyFile` if the caught exception is precisely `UnsupportedOperation` (which is how `EXDEV` is mapped to `IOException`).

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)