### PR TITLE
Follow hlint suggestion: use list comprehension

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,6 +1,6 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
-- ignore: {name: "Avoid lambda"} # 50 hints
+- ignore: {name: "Avoid lambda"} # 51 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 23 hints
 - ignore: {name: "Eta reduce"} # 138 hints
 - ignore: {name: "Evaluate"} # 10 hints
@@ -12,7 +12,7 @@
 - ignore: {name: "Move guards forward"} # 4 hints
 - ignore: {name: "Redundant $!"} # 1 hint
 - ignore: {name: "Redundant <$>"} # 17 hints
-- ignore: {name: "Redundant bracket"} # 257 hints
+- ignore: {name: "Redundant bracket"} # 256 hints
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 19 hints
@@ -35,7 +35,6 @@
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
-- ignore: {name: "Use list comprehension"} # 19 hints
 - ignore: {name: "Use map once"} # 7 hints
 - ignore: {name: "Use map with tuple-section"} # 3 hints
 - ignore: {name: "Use newtype instead of data"} # 31 hints

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -1074,13 +1074,10 @@ checkMissingDocs dgs esgs edgs efgs = do
       -> [FilePath] -- Actuals.
       -> [PackageCheck]
     checkDoc b ds as =
-      let fds = map ("." </>) $ filter (`notElem` as) ds
-       in if null fds
-            then []
-            else
-              [ PackageDistSuspiciousWarn $
-                  MissingExpectedDocFiles b fds
-              ]
+      [ PackageDistSuspiciousWarn $ MissingExpectedDocFiles b fds
+      | let fds = map ("." </>) $ filter (`notElem` as) ds
+      , not (null fds)
+      ]
 
     checkDocMove
       :: Bool -- Cabal spec ≥ 1.18?
@@ -1089,13 +1086,10 @@ checkMissingDocs dgs esgs edgs efgs = do
       -> [FilePath] -- Actuals.
       -> [PackageCheck]
     checkDocMove b field ds as =
-      let fds = filter (`elem` as) ds
-       in if null fds
-            then []
-            else
-              [ PackageDistSuspiciousWarn $
-                  WrongFieldForExpectedDocFiles b field fds
-              ]
+      [ PackageDistSuspiciousWarn $ WrongFieldForExpectedDocFiles b field fds
+      | let fds = filter (`elem` as) ds
+      , not (null fds)
+      ]
 
 -- Predicate for desirable documentation file on Hackage server.
 isDesirableExtraDocFile :: FilePath -> Bool

--- a/Cabal/src/Distribution/PackageDescription/Check/Conditional.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Conditional.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -252,15 +253,7 @@ checkDuplicateModules pkg =
               t
           dupLibsStrict = Map.keys $ Map.filter ((> 1) . fst) libMap
           dupLibsLax = Map.keys $ Map.filter ((> 1) . snd) libMap
-       in if not (null dupLibsLax)
-            then
-              [ PackageBuildImpossible
-                  (DuplicateModule s dupLibsLax)
-              ]
-            else
-              if not (null dupLibsStrict)
-                then
-                  [ PackageDistSuspicious
-                      (PotentialDupModule s dupLibsStrict)
-                  ]
-                else []
+       in if
+              | not (null dupLibsLax) -> [PackageBuildImpossible (DuplicateModule s dupLibsLax)]
+              | not (null dupLibsStrict) -> [PackageDistSuspicious (PotentialDupModule s dupLibsStrict)]
+              | otherwise -> []

--- a/Cabal/src/Distribution/Simple/ConfigureScript.hs
+++ b/Cabal/src/Distribution/Simple/ConfigureScript.hs
@@ -183,7 +183,7 @@ runConfigureScript verbHandles cfg flags programDb hp = do
           : [("CXXFLAGS", Just (mkFlagsEnv cxxFlags "CXXFLAGS")) | Just cxxFlags <- [mcxxFlags]]
           ++ [("PATH", Just pathEnv) | not (null extraPath)]
           ++ cabalFlagEnv
-      maybeHostFlag = if hp == buildPlatform then [] else ["--host=" ++ show (pretty hp)]
+      maybeHostFlag = ["--host=" ++ show (pretty hp) | hp /= buildPlatform]
       args' =
         configureFile'
           : args

--- a/Cabal/src/Distribution/Simple/Glob.hs
+++ b/Cabal/src/Distribution/Simple/Glob.hs
@@ -440,10 +440,7 @@ runDirFileGlob verbosity mspec rawRoot pat = do
         then pure [GlobMatchesDirectory filepath]
         else do
           exist <- doesFileExist (root </> filepath)
-          pure $
-            if exist
-              then [GlobMatch filepath]
-              else []
+          pure [GlobMatch filepath | exist]
     Right variablePattern -> do
       debug verbosity $ "Expanding glob '" ++ show (pretty pat) ++ "' in directory '" ++ root ++ "'."
       directoryExists <- doesDirectoryExist (root </> joinedPrefix)

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -1240,9 +1240,7 @@ renderPureArgs version comp platform args =
                 [ "--source-module=" ++ m
                 , "--source-entity=" ++ e
                 ]
-                  ++ if isVersion 2 14
-                    then ["--source-entity-line=" ++ l]
-                    else []
+                  ++ ["--source-entity-line=" ++ l | isVersion 2 14]
             )
             . flagToMaybe
             . argLinkSource
@@ -1316,13 +1314,7 @@ renderPureArgs version comp platform args =
                       | otherwise ->
                           ""
                 ]
-              , if haddockSupportsVisibility
-                  then
-                    [ case visibility of
-                        Visible -> "visible"
-                        Hidden -> "hidden"
-                    ]
-                  else []
+              , [case visibility of Visible -> "visible"; Hidden -> "hidden" | haddockSupportsVisibility]
               , [i]
               ]
           )

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -465,10 +465,7 @@ ppCpphs extraArgs _bi lbi clbi =
             : inFile
             : "--noline"
             : "--strip"
-            : ( if cpphsVersion >= mkVersion [1, 6]
-                  then ["--include=" ++ u (autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName)]
-                  else []
-              )
+            : ["--include=" ++ u (autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName) | cpphsVersion >= mkVersion [1, 6]]
             ++ extraArgs
     }
   where

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -807,10 +807,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
             then case ghcOptNumJobs opts of
               NoFlag -> []
               Flag Serial -> []
-              Flag (UseSem name) ->
-                if jsemSupported comp
-                  then ["-jsem " ++ name]
-                  else []
+              Flag (UseSem name) -> ["-jsem " ++ name | jsemSupported comp]
               Flag (NumJobs n) -> ["-j" ++ maybe "" show n]
             else []
         , --------------------

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -541,10 +541,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     , IPI.libraryDynDirs = dynlibdirs
     , IPI.dataDir = datadir installDirs
     , IPI.hsLibraries =
-        ( if hasLibrary
-            then [getHSLibraryName (componentUnitId clbi)]
-            else []
-        )
+        [getHSLibraryName (componentUnitId clbi) | hasLibrary]
           ++ extraBundledLibs bi
     , IPI.extraLibraries = extraLibs bi
     , IPI.extraLibrariesStatic = extraLibsStatic bi

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RankNTypes #-}
 
 -----------------------------------------------------------------------------
@@ -278,14 +279,7 @@ constructUHCCmdLine
   -> Verbosity
   -> [String]
 constructUHCCmdLine user system lbi bi clbi odir verbosity =
-  -- verbosity
-  ( if verbosityLevel verbosity >= Deafening
-      then ["-v4"]
-      else
-        if verbosityLevel verbosity >= Normal
-          then []
-          else ["-v0"]
-  )
+  vFlags
     ++ hcOptions UHC bi
     -- flags for language extensions
     ++ languageToFlags (compiler lbi) (defaultLanguage bi)
@@ -312,6 +306,11 @@ constructUHCCmdLine user system lbi bi clbi odir verbosity =
        )
   where
     u = interpretSymbolicPathCWD -- See Note [Symbolic paths] in Distribution.Utils.Path
+    vFlags =
+      if
+          | verbosityLevel verbosity >= Deafening -> ["-v4"]
+          | verbosityLevel verbosity < Normal -> ["-v0"]
+          | otherwise -> []
 
 uhcPackageDbOptions :: FilePath -> FilePath -> PackageDBStack -> [String]
 uhcPackageDbOptions user system db =

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -808,13 +808,7 @@ checkPrintPlan
               "The following packages are likely to be broken by the reinstalls:"
                 : map (prettyShow . mungedId) newBrokenPkgs
                 ++ if overrideReinstall
-                  then
-                    if dryRun
-                      then []
-                      else
-                        [ "Continuing even though "
-                            ++ "the plan contains dangerous reinstalls."
-                        ]
+                  then ["Continuing even though the plan contains dangerous reinstalls." | not dryRun]
                   else ["Use --force-reinstalls if you want to install anyway."]
       if breaksPkgs
         then do

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2881,7 +2881,7 @@ instantiateInstallPlan storeDirLayout defaultInstallDirs elaboratedShared plan =
                               ElabComponent
                                 comp
                                   { compOrderLibDependencies =
-                                      (if Map.null insts then [] else [newSimpleUnitId cid])
+                                      [newSimpleUnitId cid | not (Map.null insts)]
                                         ++ ordNub
                                           ( map
                                               unDefUnitId

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -1142,9 +1142,7 @@ getExternalSetupMethod verbosity options pkg bt = do
                         ]
                   , ghcOptExtra = extraOpts
                   , ghcOptExtensions = toNubListR $
-                      if bt == Custom || any (isBasePkgId . snd) selectedDeps
-                      then []
-                      else [ Simple.DisableExtension Simple.ImplicitPrelude ]
+                      [Simple.DisableExtension Simple.ImplicitPrelude | not (bt == Custom || any (isBasePkgId . snd) selectedDeps)]
                         -- Pass -WNoImplicitPrelude to avoid depending on base
                         -- when compiling a Simple Setup.hs file.
                   , ghcOptExtensionMap = Map.fromList . Simple.compilerExtensions $ compiler

--- a/cabal-install/src/Distribution/Client/Types/PackageSpecifier.hs
+++ b/cabal-install/src/Distribution/Client/Types/PackageSpecifier.hs
@@ -59,7 +59,4 @@ mkNamedPackage :: PackageIdentifier -> PackageSpecifier pkg
 mkNamedPackage pkgId =
   NamedPackage
     (pkgName pkgId)
-    ( if pkgVersion pkgId == nullVersion
-        then []
-        else [PackagePropertyVersion (thisVersion (pkgVersion pkgId))]
-    )
+    [PackagePropertyVersion (thisVersion $ pkgVersion pkgId) | pkgVersion pkgId /= nullVersion]

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -185,12 +185,9 @@ tests config =
       [ testCaseSteps "Setup script styles" (testSetupScriptStyles config)
       , testCase "keep-going" (testBuildKeepGoing config)
       ]
-        ++ if System.Info.os == "mingw32"
-          then -- disabled because https://github.com/haskell/cabal/issues/6272
-            []
-          else
-            [ testCase "local tarball" (testBuildLocalTarball config)
-            ]
+        ++
+        -- disabled because https://github.com/haskell/cabal/issues/6272
+        [testCase "local tarball" (testBuildLocalTarball config) | System.Info.os /= "mingw32"]
   , sequentialTestGroup
       "Regression tests"
       AllFinish

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -186,9 +186,9 @@ renderCommonArgs args =
     ++ maybe [] (\x -> ["--with-ghc", x]) (argGhcPath args)
     ++ maybe [] (\x -> ["--with-haddock", x]) (argHaddockPath args)
     ++ maybe [] (\x -> ["--with-hackage-repo-tool", x]) (argHackageRepoToolPath args)
-    ++ (if argAccept args then ["--accept"] else [])
-    ++ (if argKeepTmpFiles args then ["--keep-tmp-files"] else [])
-    ++ (if argSkipSetupTests args then ["--skip-setup-tests"] else [])
+    ++ ["--accept" | argAccept args]
+    ++ ["--keep-tmp-files" | argKeepTmpFiles args]
+    ++ ["--skip-setup-tests" | argSkipSetupTests args]
 
 data TestArgs = TestArgs
   { testArgDistDir :: FilePath


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use list comprehension" suggestion so that this will be suggested by our CI linting. After this change, the code is shorter.

Most of these are `[ expression | generator, guard, ... ]` without the generator. I have to confess it took me a while to start using list comprehensions that way.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
