### PR TITLE
Replace getDirectoryContents with listDirectory

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -79,7 +79,7 @@ import qualified Data.ByteString.Lazy as BS
 import qualified Distribution.SPDX as SPDX
 import qualified System.Directory as System
 
-import qualified System.Directory (getDirectoryContents)
+import qualified System.Directory (listDirectory)
 import qualified System.FilePath.Windows as FilePath.Windows (isValid)
 
 import qualified Data.Set as Set
@@ -171,14 +171,14 @@ checkPackageFilesGPD verbosity gpd root =
       CheckPackageContentOps
         { doesFileExist = System.doesFileExist . relative
         , doesDirectoryExist = System.doesDirectoryExist . relative
-        , getDirectoryContents = System.Directory.getDirectoryContents . relative
+        , listDirectory = System.Directory.listDirectory . relative
         , getFileContents = BS.readFile . relative
         }
 
     checkPreIO =
       CheckPreDistributionOps
         { runDirFileGlobM = \fp g -> runDirFileGlob verbosity (Just . specVersion $ packageDescription gpd) (root </> fp) g
-        , getDirectoryContentsM = System.Directory.getDirectoryContents . relative
+        , listDirectoryM = System.Directory.listDirectory . relative
         }
 
     relative :: FilePath -> FilePath
@@ -754,7 +754,7 @@ checkGitProtocol mloc =
 findPackageDesc :: Monad m => CheckPackageContentOps m -> m [FilePath]
 findPackageDesc ops = do
   let dir = "."
-  files <- getDirectoryContents ops dir
+  files <- listDirectory ops dir
   -- to make sure we do not mistake a ~/.cabal/ dir for a <name>.cabal
   -- file we filter to exclude dirs and null base file names:
   cabalFiles <-
@@ -1024,8 +1024,8 @@ checkMissingDocs dgs esgs edgs efgs = do
     ciPreDistOps
     ( \ops -> do
         -- 1. Get root files, see if they are interesting to us.
-        rootContents <- getDirectoryContentsM ops "."
-        -- Recall getDirectoryContentsM arg is relative to root path.
+        rootContents <- listDirectoryM ops "."
+        -- Recall listDirectoryM arg is relative to root path.
         let des = filter isDesirableExtraDocFile rootContents
 
         -- 2. Realise Globs.

--- a/Cabal/src/Distribution/PackageDescription/Check/Monad.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Monad.hs
@@ -92,7 +92,7 @@ data CheckInterface m = CheckInterface
 data CheckPackageContentOps m = CheckPackageContentOps
   { doesFileExist :: FilePath -> m Bool
   , doesDirectoryExist :: FilePath -> m Bool
-  , getDirectoryContents :: FilePath -> m [FilePath]
+  , listDirectory :: FilePath -> m [FilePath]
   , getFileContents :: FilePath -> m BS.ByteString
   }
 
@@ -102,7 +102,7 @@ data CheckPackageContentOps m = CheckPackageContentOps
 -- (e.g. a VCS work tree).
 data CheckPreDistributionOps m = CheckPreDistributionOps
   { runDirFileGlobM :: FilePath -> Glob -> m [GlobResult FilePath]
-  , getDirectoryContentsM :: FilePath -> m [FilePath]
+  , listDirectoryM :: FilePath -> m [FilePath]
   }
 
 -- | Context to perform checks (will be the Reader part in your monad).

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -78,7 +78,7 @@ import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import qualified Distribution.InstalledPackageInfo as IPI
 import Distribution.Package
 import Distribution.PackageDescription
-import Distribution.PackageDescription.Check hiding (doesFileExist)
+import Distribution.PackageDescription.Check hiding (doesFileExist, listDirectory)
 import Distribution.PackageDescription.Configuration
 import Distribution.PackageDescription.PrettyPrint
 import Distribution.Simple.BuildTarget

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -142,7 +142,7 @@ import System.Directory
   , doesDirectoryExist
   , doesFileExist
   , getAppUserDataDirectory
-  , getDirectoryContents
+  , listDirectory
 #ifndef mingw32_HOST_OS
   , renameFile
 #endif
@@ -1039,7 +1039,7 @@ installLib verbosity lbi targetDir dynlibTargetDir _builtDir pkg lib clbi = do
                   ]
                 sequence_
                   [ do
-                    files <- getDirectoryContents (i builtDir)
+                    files <- listDirectory (i builtDir)
                     let l' =
                           mkGenericSharedBundledLibName
                             platform

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -86,7 +86,7 @@ import Distribution.Utils.Path
 import Distribution.Verbosity
 import Distribution.Version (Version)
 import Language.Haskell.Extension
-import System.Directory (getDirectoryContents)
+import System.Directory (listDirectory)
 import System.Environment (getEnv)
 import System.FilePath
   ( takeDirectory
@@ -673,7 +673,7 @@ getHaskellObjects _implInfo lib lbi clbi pref wanted_obj_ext allow_split_objs
             [ pref </> makeRelativePathEx (ModuleName.toFilePath x ++ splitSuffix)
             | x <- allLibModules lib clbi
             ]
-      objss <- traverse (getDirectoryContents . i) dirs
+      objss <- traverse (listDirectory . i) dirs
       let objs =
             [ dir </> makeRelativePathEx obj
             | (objs', dir) <- zip objss dirs

--- a/Cabal/src/Distribution/Simple/Glob.hs
+++ b/Cabal/src/Distribution/Simple/Glob.hs
@@ -389,7 +389,7 @@ runDirFileGlob verbosity mspec rawRoot pat = do
       Nothing -> if matchGlobPieces glob str then Just (GlobMatch ()) else Nothing
 
     go (GlobFile glob) dir = do
-      entries <- getDirectoryContents (root </> dir)
+      entries <- listDirectory (root </> dir)
       catMaybes
         <$> mapM
           ( \s -> do
@@ -420,7 +420,7 @@ runDirFileGlob verbosity mspec rawRoot pat = do
           )
           entries
     go (GlobDir glob globPath) dir = do
-      entries <- getDirectoryContents (root </> dir)
+      entries <- listDirectory (root </> dir)
       subdirs <-
         filterM
           ( \subdir ->

--- a/Cabal/src/Distribution/Simple/Test.hs
+++ b/Cabal/src/Distribution/Simple/Test.hs
@@ -55,7 +55,7 @@ import Distribution.Types.LocalBuildInfo (LocalBuildInfo (..))
 import System.Directory
   ( createDirectoryIfMissing
   , doesFileExist
-  , getDirectoryContents
+  , listDirectory
   , removeFile
   )
 
@@ -150,7 +150,7 @@ test args verbHandles pkg_descr lbi0 flags = do
   createDirectoryIfMissing True $ i testLogDir
 
   -- Delete ordinary files from test log directory.
-  getDirectoryContents (i testLogDir)
+  listDirectory (i testLogDir)
     >>= filterM doesFileExist . map (i testLogDir </>)
     >>= traverse_ removeFile
 

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -126,7 +126,7 @@ getInstalledPackages verbosity comp mbWorkDir packagedbs progdb = do
   pkgs <-
     liftM (map addBuiltinVersions . concat) $
       traverse
-        (\d -> getDirectoryContents d >>= filterM (isPkgDir (prettyShow compilerid) d))
+        (\d -> listDirectory d >>= filterM (isPkgDir (prettyShow compilerid) d))
         pkgDirs
   -- putStrLn $ "pkgs: " ++ show pkgs
   let iPkgs =

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -254,10 +254,10 @@ import System.Directory
   , createDirectory
   , doesDirectoryExist
   , doesFileExist
-  , getDirectoryContents
   , getModificationTime
   , getPermissions
   , getTemporaryDirectory
+  , listDirectory
   , removeDirectoryRecursive
   , removeFile
   )
@@ -1572,7 +1572,7 @@ getDirectoryContentsRecursive topdir = recurseDirectories [""]
     recurseDirectories :: [FilePath] -> IO [FilePath]
     recurseDirectories [] = return []
     recurseDirectories (dir : dirs) = unsafeInterleaveIO $ do
-      (files, dirs') <- collect [] [] =<< getDirectoryContents (topdir </> dir)
+      (files, dirs') <- collect [] [] =<< listDirectory (topdir </> dir)
       files' <- recurseDirectories (dirs' ++ dirs)
       return (files ++ files')
       where
@@ -1581,19 +1581,12 @@ getDirectoryContentsRecursive topdir = recurseDirectories [""]
             ( reverse files
             , reverse dirs'
             )
-        collect files dirs' (entry : entries)
-          | ignore entry =
-              collect files dirs' entries
         collect files dirs' (entry : entries) = do
           let dirEntry = dir </> entry
           isDirectory <- doesDirectoryExist (topdir </> dirEntry)
           if isDirectory
             then collect files (dirEntry : dirs') entries
             else collect (dirEntry : files) dirs' entries
-
-        ignore ['.'] = True
-        ignore ['.', '.'] = True
-        ignore _ = False
 
 ------------------------
 -- Environment variables
@@ -2108,7 +2101,7 @@ findPackageDesc
 findPackageDesc mbPkgDir =
   do
     let pkgDir = maybe "." getSymbolicPath mbPkgDir
-    files <- getDirectoryContents pkgDir
+    files <- listDirectory pkgDir
     -- to make sure we do not mistake a ~/.cabal/ dir for a <pkgname>.cabal
     -- file we filter to exclude dirs and null base file names:
     cabalFiles <-
@@ -2144,7 +2137,7 @@ findHookedPackageDesc
   -> IO (Maybe (SymbolicPath Pkg File))
   -- ^ /dir/@\/@/pkgname/@.buildinfo@, if present
 findHookedPackageDesc verbosity mbWorkDir dir = do
-  files <- getDirectoryContents $ interpretSymbolicPath mbWorkDir dir
+  files <- listDirectory $ interpretSymbolicPath mbWorkDir dir
   buildInfoFiles <-
     filterM
       (doesFileExist . interpretSymbolicPath mbWorkDir)

--- a/cabal-install/src/Distribution/Client/CmdClean.hs
+++ b/cabal-install/src/Distribution/Client/CmdClean.hs
@@ -82,7 +82,6 @@ import System.Directory
   ( canonicalizePath
   , doesDirectoryExist
   , doesFileExist
-  , getDirectoryContents
   , listDirectory
   , removeDirectoryRecursive
   , removeFile
@@ -220,4 +219,4 @@ cleanAction (ProjectFlags{..}, CleanFlags{..}) extraArgs _ = do
 removeEnvFiles :: FilePath -> IO ()
 removeEnvFiles dir =
   (traverse_ (removeFile . (dir </>)) . filter ((".ghc.environment" ==) . take 16))
-    =<< getDirectoryContents dir
+    =<< listDirectory dir

--- a/cabal-install/src/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/FileMonitor.hs
@@ -565,7 +565,7 @@ probeMonitorStateGlobRel
                  in liftIO $ doesDirectoryExist subdir
             )
             . filter (matchGlobPieces glob)
-            =<< liftIO (getDirectoryContents (root </> dirName))
+            =<< liftIO (listDirectory (root </> dirName))
 
         children' <-
           traverse probeMergeResult $
@@ -651,7 +651,7 @@ probeMonitorStateGlobRel
         -- a matching file may have been added or deleted
         matches <-
           return . filter (matchGlobPieces glob)
-            =<< liftIO (getDirectoryContents (root </> dirName))
+            =<< liftIO (listDirectory (root </> dirName))
 
         traverse_ probeMergeResult $
           mergeBy
@@ -913,7 +913,7 @@ buildMonitorStateGlobRel
   dir
   globPath = do
     let absdir = root </> dir
-    dirEntries <- getDirectoryContents absdir
+    dirEntries <- listDirectory absdir
     dirMTime <- getModTime absdir
     case globPath of
       GlobDirRecursive{} -> error "Monitoring directory-recursive globs (i.e. ../**/...) is currently unsupported"

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -93,7 +93,7 @@ guessLicense flags = return . defaultLicense $ getCabalVersionNoPrompt flags
 guessExtraDocFiles :: Interactive m => InitFlags -> m (Maybe (Set FilePath))
 guessExtraDocFiles flags = do
   pkgDir <- fromFlagOrDefault getCurrentDirectory $ return <$> packageDir flags
-  files <- getDirectoryContents pkgDir
+  files <- listDirectory pkgDir
 
   let extraDocCandidates = ["CHANGES", "CHANGELOG", "README"]
       extraDocs = [y | x <- extraDocCandidates, y <- files, x == map toUpper (takeBaseName y)]

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -341,7 +341,6 @@ class Monad m => Interactive m where
   readFile :: FilePath -> m String
   getCurrentDirectory :: m FilePath
   getHomeDirectory :: m FilePath
-  getDirectoryContents :: FilePath -> m [FilePath]
   listDirectory :: FilePath -> m [FilePath]
   doesDirectoryExist :: FilePath -> m Bool
   doesFileExist :: FilePath -> m Bool
@@ -385,7 +384,6 @@ instance Interactive PromptIO where
   readFile = liftIO <$> P.readFile
   getCurrentDirectory = liftIO P.getCurrentDirectory
   getHomeDirectory = liftIO P.getHomeDirectory
-  getDirectoryContents = liftIO <$> P.getDirectoryContents
   listDirectory = liftIO <$> P.listDirectory
   doesDirectoryExist = liftIO <$> P.doesDirectoryExist
   doesFileExist = liftIO <$> P.doesFileExist
@@ -433,7 +431,6 @@ instance Interactive PurePrompt where
   getHomeDirectory = popAbsolute
 
   -- expects stack input of form "[\"foo\", \"bar\", \"baz\"]"
-  getDirectoryContents !_ = popList
   listDirectory !_ = popList
   doesDirectoryExist !_ = popBool
   doesFileExist !_ = popBool

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -49,8 +49,8 @@ import System.Directory
   ( createDirectoryIfMissing
   , doesDirectoryExist
   , doesFileExist
-  , getDirectoryContents
   , getTemporaryDirectory
+  , listDirectory
   , removeFile
   , renameDirectory
   )
@@ -2038,7 +2038,7 @@ installUnpackedPackage
             -- configurations is well formed
 
               traverse (readPkgConf (getSymbolicPath pkgConfDest)) . sort . filter notHidden
-                =<< getDirectoryContents (getSymbolicPath pkgConfDest)
+                =<< listDirectory (getSymbolicPath pkgConfDest)
             else fmap (: []) $ readPkgConf "." (getSymbolicPath pkgConfDest)
 
       readPkgConf

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -245,8 +245,8 @@ import System.Directory
   , doesFileExist
   , doesPathExist
   , getCurrentDirectory
-  , getDirectoryContents
   , getHomeDirectory
+  , listDirectory
   , pathIsSymbolicLink
   )
 import System.FilePath hiding (combine)
@@ -1700,7 +1700,7 @@ syncAndReadSourcePackagesRemoteRepos
         let packageDir :: FilePath
             packageDir = maybe repoPath (repoPath </>) (srpSubdir repo)
 
-        entries <- liftIO $ getDirectoryContents packageDir
+        entries <- liftIO $ listDirectory packageDir
         -- TODO: dcoutts 2018-06-23: wrap exceptions
         case filter (\e -> takeExtension e == ".cabal") entries of
           [] -> liftIO $ throwIO $ NoCabalFileFound packageDir

--- a/cabal-install/src/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/src/Distribution/Client/RebuildMonad.hs
@@ -270,7 +270,7 @@ getDirectoryContentsMonitored :: FilePath -> Rebuild [FilePath]
 getDirectoryContentsMonitored dir = do
   exists <- monitorDirectoryStatus dir
   if exists
-    then liftIO $ getDirectoryContents dir
+    then liftIO $ listDirectory dir
     else return []
 
 createDirectoryMonitored :: Bool -> FilePath -> Rebuild ()

--- a/cabal-install/src/Distribution/Client/Upload.hs
+++ b/cabal-install/src/Distribution/Client/Upload.hs
@@ -232,7 +232,7 @@ report verbosity repoCtxt mToken mUsername mPassword = do
     -- from this repo yet.
     srcExists <- doesDirectoryExist srcDir
     when srcExists $ do
-      contents <- getDirectoryContents srcDir
+      contents <- listDirectory srcDir
       for_ (filter (\c -> takeExtension c == ".log") contents) $ \logFile ->
         do
           inp <- readFile (srcDir </> logFile)

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -90,7 +90,7 @@ import System.Directory
   ( canonicalizePath
   , doesDirectoryExist
   , doesFileExist
-  , getDirectoryContents
+  , listDirectory
   , removeFile
   )
 import qualified System.Directory as Directory
@@ -508,12 +508,9 @@ listFilesInside test dir = ifNotM (test $ dropTrailingPathSeparator dir) (pure [
 listFilesRecursive :: FilePath -> IO [FilePath]
 listFilesRecursive = listFilesInside (const $ pure True)
 
--- | From System.Directory.Extra
---   https://hackage.haskell.org/package/extra-1.7.9
 listContents :: FilePath -> IO [FilePath]
-listContents dir = do
-  xs <- getDirectoryContents dir
-  pure $ sort [dir </> x | x <- xs, not $ all (== '.') x]
+listContents dir =
+  map (dir </>) . sort <$> listDirectory dir
 
 -- | From Control.Monad.Extra
 --   https://hackage.haskell.org/package/extra-1.7.9

--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -738,7 +738,7 @@ getDirectoryContentsRecursive
   -> FilePath
   -> IO [(FilePath, Bool)]
 getDirectoryContentsRecursive ignore dir0 dir = do
-  entries <- getDirectoryContents (dir0 </> dir)
+  entries <- listDirectory (dir0 </> dir)
   entries' <-
     sequence
       [ do

--- a/cabal-testsuite/PackageTests/InternalLibraries/setup-gen-pkg-config.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/setup-gen-pkg-config.test.hs
@@ -17,7 +17,7 @@ main = setupAndCabalTest $ do
                 notHidden = not . isHidden
                 isHidden name = "." `isPrefixOf` name
             confs <- fmap (sort . filter notHidden)
-                   . liftIO $ getDirectoryContents (cwd </> dir)
+                   . liftIO $ listDirectory (cwd </> dir)
             forM_ confs $ \conf -> ghcPkg "register" [cwd </> dir </> conf]
 
         -- Make sure we can see p

--- a/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
@@ -1,5 +1,5 @@
 import Test.Cabal.Prelude
-import System.Directory-- (getDirectoryContents, removeFile)
+import System.Directory -- (listDirectory, removeFile)
 main = cabalTest $ do
     cabal "v2-build" ["inplace-dep"]
     env <- getTestEnv
@@ -14,4 +14,4 @@ main = cabalTest $ do
 removeEnvFiles :: FilePath -> IO ()
 removeEnvFiles dir =
   (mapM_ (removeFile . (dir </>)) . filter ((".ghc.environment" ==) . take 16))
-  =<< getDirectoryContents dir
+  =<< listDirectory dir

--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -163,7 +163,7 @@ buildCabalLibsProject projString verb mbGhc dir = do
       ] ) { progInvokeCwd = Just dir })
 
   -- Determine the path to the packagedb in the store for this ghc version
-  storesByGhc <- getDirectoryContents storeRoot
+  storesByGhc <- listDirectory storeRoot
   case filter (prettyShow pv `isInfixOf`) storesByGhc of
     [] -> return [final_package_db]
     storeForGhc:_ -> do
@@ -284,7 +284,7 @@ main = do
             test_scripts <- if null user_paths
                                 then findTests
                                 else return user_paths
-            -- NB: getDirectoryContentsRecursive is lazy IO, but it
+            -- NB: listDirectory is lazy IO, but it
             -- doesn't handle directories disappearing gracefully. Fix
             -- this!
             (single_tests, multi_tests) <- evaluate (partitionTests testPattern test_scripts)

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -621,7 +621,7 @@ withRepoNoUpdate repo_dir m = do
   liftIO $ createDirectoryIfMissing True package_dir
 
   -- 2. Create tarballs
-  pkgs <- liftIO $ getDirectoryContents (testCurrentDir env </> repo_dir)
+  pkgs <- liftIO $ listDirectory (testCurrentDir env </> repo_dir)
   forM_ pkgs $ \pkg -> do
     let srcPath = testCurrentDir env </> repo_dir </> pkg
     let destPath = package_dir </> pkg
@@ -708,7 +708,7 @@ withRemoteRepo repoDir m = do
   liftIO $ createDirectoryIfMissing True keysDir
 
   -- 2. Create tarballs
-  entries <- liftIO $ getDirectoryContents (testCurrentDir env </> repoDir)
+  entries <- liftIO $ listDirectory (testCurrentDir env </> repoDir)
   forM_ entries $ \entry -> do
     let srcPath = testCurrentDir env </> repoDir </> entry
     let destPath = packageDir </> entry

--- a/changelog.d/pr-11599.md
+++ b/changelog.d/pr-11599.md
@@ -1,0 +1,7 @@
+---
+synopsis: Replace getDirectoryContents with listDirectory
+packages: [Cabal, cabal-install]
+prs: 11599
+---
+
+In course of an internal refactoring, replacing uses of `getDirectoryContents` with `listDirectory`, we also renamed a field of `Distribution.PackageDescription.Check.CheckPackageContentOps` of the same name.


### PR DESCRIPTION
Closes #11589.

Cabal code is littered with calls to `getDirectoryContents`, which lists all entries including `.` and `..`. This is pretty much never what we want; we should migrate to `listDirectory`.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)