### PR TITLE
Follow hlint suggestion: redundant $

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -10,10 +10,9 @@
 - ignore: {name: "Monoid law, right identity"} # 3 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Move guards forward"} # 4 hints
-- ignore: {name: "Redundant $"} # 202 hints
 - ignore: {name: "Redundant $!"} # 1 hint
 - ignore: {name: "Redundant <$>"} # 17 hints
-- ignore: {name: "Redundant bracket"} # 276 hints
+- ignore: {name: "Redundant bracket"} # 257 hints
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 19 hints
@@ -23,7 +22,7 @@
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 29 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 87 hints
+- ignore: {name: "Use <$>"} # 78 hints
 - ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints

--- a/Cabal-hooks/src/Distribution/Simple/SetupHooks.hs
+++ b/Cabal-hooks/src/Distribution/Simple/SetupHooks.hs
@@ -424,7 +424,7 @@ registerRule
 registerRule nm !newRule = RulesT $ do
   RulesEnv { rulesEnvNameSpace = ns
            , rulesEnvVerbosity = verbosity } <- Reader.ask
-  oldRules <- lift $ State.get
+  oldRules <- lift State.get
   let rId = RuleId { ruleNameSpace = ns, ruleName = nm }
       (mbDup, newRules) = Map.insertLookupWithKey (\ _ new _old -> new) rId newRule oldRules
   for_ mbDup $ \ oldRule ->

--- a/Cabal-syntax/src/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/Parsec.hs
@@ -270,7 +270,7 @@ goSections specVer = traverse_ process
     parseSection (Name pos name) args fields
       | hasCommonStanzas == NoCommonStanzas
       , name == "common" = lift $ do
-          parseWarning pos PWTUnknownSection $ "Ignoring section: common. You should set cabal-version: 2.2 or larger to use common stanzas."
+          parseWarning pos PWTUnknownSection "Ignoring section: common. You should set cabal-version: 2.2 or larger to use common stanzas."
       | name == "common" = do
           commonStanzas <- use stateCommonStanzas
           name' <- lift $ parseCommonName pos args
@@ -286,8 +286,7 @@ goSections specVer = traverse_ process
           prev <- use $ stateGpd . L.condLibrary
           when (isJust prev) $
             lift $
-              parseFailure pos $
-                "Multiple main libraries; have you forgotten to specify a name for an internal library?"
+              parseFailure pos "Multiple main libraries; have you forgotten to specify a name for an internal library?"
 
           commonStanzas <- use stateCommonStanzas
           let name'' = LMainLibName
@@ -440,7 +439,7 @@ parseCommonName pos args = case args of
   [SecArgStr _pos secName] ->
     pure $ fromUTF8BS secName
   [] -> do
-    parseFailure pos $ "name required"
+    parseFailure pos "name required"
     pure ""
   _ -> do
     -- TODO: pretty print args
@@ -528,7 +527,7 @@ parseCondTree v hasElif grammar commonStanzas fromBuildInfo cond = go
           a <- parseFieldGrammar v mempty grammar
           return (Just $ CondNode a (cond a) [CondBranch test' fields' elseFields], sections')
     parseElseIfs (MkSection (Name pos name) _ _ : sections) | name == "elif" = do
-      parseWarning pos PWTInvalidSubsection $ "invalid subsection \"elif\". You should set cabal-version: 2.2 or larger to use elif-conditionals."
+      parseWarning pos PWTInvalidSubsection "invalid subsection \"elif\". You should set cabal-version: 2.2 or larger to use elif-conditionals."
       (,) Nothing <$> parseIfs sections
     parseElseIfs sections = (,) Nothing <$> parseIfs sections
 
@@ -682,7 +681,7 @@ processImports v fromBuildInfo commonStanzas = go []
     -- parse actual CondTree
     go acc fields = do
       fields' <- catMaybes <$> traverse (warnImport v) fields
-      pure $ (fields', \x -> foldr (mergeCommonStanza fromBuildInfo) x acc)
+      pure (fields', \x -> foldr (mergeCommonStanza fromBuildInfo) x acc)
 
 -- | Warn on "import" fields, also map to Maybe, so erroneous fields can be filtered
 warnImport :: CabalSpecVersion -> Field Position -> ParseResult src (Maybe (Field Position))
@@ -763,12 +762,10 @@ checkForUndefinedCustomSetup gpd = do
 
   when (buildType pd == Custom && isNothing (setupBuildInfo pd)) $
     when (csv >= CabalSpecV1_24) $
-      parseFailure zeroPos $
-        "Since cabal-version: 1.24 specifying custom-setup section is mandatory"
+      parseFailure zeroPos "Since cabal-version: 1.24 specifying custom-setup section is mandatory"
 
   when (buildType pd == Hooks && isNothing (setupBuildInfo pd)) $
-    parseFailure zeroPos $
-      "Packages with build-type: Hooks require a custom-setup stanza"
+    parseFailure zeroPos "Packages with build-type: Hooks require a custom-setup stanza"
 
 -------------------------------------------------------------------------------
 -- Post processing of internal dependencies

--- a/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
@@ -401,8 +401,7 @@ versionRangeParser digitParser csv = expr
           ( do
               (wild, v) <- verOrWild
               when wild $
-                P.unexpected $
-                  "wild-card version after ^>= operator"
+                P.unexpected "wild-card version after ^>= operator"
               majorBoundVersion' v
               <|> (verSet' majorBoundVersion =<< verSet)
             )

--- a/Cabal-tests/tests/ParserTests.hs
+++ b/Cabal-tests/tests/ParserTests.hs
@@ -212,15 +212,12 @@ regressionTests = testGroup "regressions"
     ]
 
 regressionTest :: FilePath -> TestTree
-regressionTest fp = testGroup fp
-{- FOURMOLU_DISABLE -}
-    [ formatGoldenTest fp
-    , formatRoundTripTest fp
+regressionTest fp = let formatTests = [ formatGoldenTest fp, formatRoundTripTest fp ] in
 #ifdef MIN_VERSION_tree_diff
-    , treeDiffGoldenTest fp
+    testGroup fp $ formatTests ++ [ treeDiffGoldenTest fp ]
+#else
+    testGroup fp formatTests
 #endif
-    ]
-{- FOURMOLU_ENABLE -}
 
 formatGoldenTest :: FilePath -> TestTree
 formatGoldenTest fp = cabalGoldenTest "format" correct $ do
@@ -264,7 +261,6 @@ formatRoundTripTest fp = testCase "roundtrip" $ do
 
     let checkField field =
           field x == field y @?
-{- FOURMOLU_DISABLE -}
 #ifdef MIN_VERSION_tree_diff
             unlines
                 [ "re-parsed doesn't match"
@@ -301,7 +297,6 @@ formatRoundTripTest fp = testCase "roundtrip" $ do
                 void $ assertFailure $ unlines (map (showPErrorWithSource . fmap renderCabalFileSource) $ NE.toList errs)
                 fail "failure"
     input = "tests" </> "ParserTests" </> "regressions" </> fp
-{- FOURMOLU_ENABLE -}
 
 -------------------------------------------------------------------------------
 -- InstalledPackageInfo regressions
@@ -316,15 +311,12 @@ ipiTests = testGroup "ipis"
     ]
 
 ipiTest :: FilePath -> TestTree
-{- FOURMOLU_DISABLE -}
-ipiTest fp = testGroup fp $
+ipiTest fp = let formatTests = [ ipiFormatGoldenTest fp , ipiFormatRoundTripTest fp ] in
 #ifdef MIN_VERSION_tree_diff
-    [ ipiTreeDiffGoldenTest fp ] ++
+    testGroup fp $ [ ipiTreeDiffGoldenTest fp ] ++ formatTests
+#else
+    testGroup fp formatTests
 #endif
-    [ ipiFormatGoldenTest fp
-    , ipiFormatRoundTripTest fp
-    ]
-{- FOURMOLU_ENABLE -}
 
 ipiFormatGoldenTest :: FilePath -> TestTree
 ipiFormatGoldenTest fp = cabalGoldenTest "format" correct $ do

--- a/Cabal-tests/tests/UnitTests.hs
+++ b/Cabal-tests/tests/UnitTests.hs
@@ -49,8 +49,7 @@ tests =
         UnitTests.Distribution.Simple.Utils.tests ghcPath
     , testGroup "Distribution.Utils.Generic"
         UnitTests.Distribution.Utils.Generic.tests
-    , testGroup "Distribution.Utils.Json" $
-        UnitTests.Distribution.Utils.Json.tests
+    , testGroup "Distribution.Utils.Json" UnitTests.Distribution.Utils.Json.tests
     , testGroup "Distribution.Utils.NubList"
         UnitTests.Distribution.Utils.NubList.tests
     , testGroup "Distribution.PackageDescription.Check"

--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -92,16 +92,11 @@ dropExeExtensionTest =
 
 tests :: FilePath -> [TestTree]
 tests ghcPath =
-    [ testCase "withTempFile works as expected" $
-      withTempFileTest
-    , testCase "withTempFile can handle removed files" $
-      withTempFileRemovedTest
-    , testCase "withTempDirectory works as expected" $
-      withTempDirTest
-    , testCase "withTempDirectory can handle removed directories" $
-      withTempDirRemovedTest
+    [ testCase "withTempFile works as expected" withTempFileTest
+    , testCase "withTempFile can handle removed files" withTempFileRemovedTest
+    , testCase "withTempDirectory works as expected" withTempDirTest
+    , testCase "withTempDirectory can handle removed directories" withTempDirRemovedTest
     , testCase "rawSystemStdInOut reports text decoding errors" $
       rawSystemStdInOutTextDecodingTest ghcPath
-    , testCase "dropExeExtension drops exe extension" $
-      dropExeExtensionTest
+    , testCase "dropExeExtension drops exe extension" dropExeExtensionTest
     ]

--- a/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
@@ -83,7 +83,7 @@ dispConfiguredComponent cc =
     (text "component" <+> pretty (cc_cid cc))
     4
     ( vcat
-        [ hsep $
+        [ hsep
           [ text "include"
           , pretty (ci_id incl)
           , pretty (ci_renaming incl)

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -586,8 +586,7 @@ checkPackageId (PackageIdentifier pkgName_ _pkgVersion_) = do
   checkP
     (not . FilePath.Windows.isValid . prettyShow $ pkgName_)
     (PackageDistInexcusable $ InvalidNameWin pkgName_)
-  checkP (isPrefixOf "z-" . prettyShow $ pkgName_) $
-    (PackageDistInexcusable ZPrefix)
+  checkP (isPrefixOf "z-" . prettyShow $ pkgName_) (PackageDistInexcusable ZPrefix)
 
 checkNewLicense :: Monad m => SPDX.License -> CheckM m ()
 checkNewLicense lic = do
@@ -629,7 +628,7 @@ checkOldLicense nullLicFiles lic = do
         -- licenses so don't need license files.
         nullLicFiles
     )
-    $ (PackageDistSuspicious NoLicenseFile)
+    (PackageDistSuspicious NoLicenseFile)
   case unknownLicenseVersion lic of
     Just knownVersions ->
       tellP

--- a/Cabal/src/Distribution/PackageDescription/Check/Target.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Target.hs
@@ -91,7 +91,7 @@ checkLibrary
             (flip elem (allExplicitIncludes lib) . getSymbolicPath)
             (view L.autogenIncludes lib)
       )
-      $ (PackageBuildImpossible AutogenIncludesNotIncluded)
+      (PackageBuildImpossible AutogenIncludesNotIncluded)
 
     -- § Build infos.
     checkBuildInfo
@@ -157,7 +157,7 @@ checkExecutable
     checkP
       ( pid /= fakePackageId
           && not (null modulePath_)
-          && not (fileExtensionSupportedLanguage $ modulePath_)
+          && not (fileExtensionSupportedLanguage modulePath_)
       )
       (PackageBuildImpossible NoHsLhsMain)
 
@@ -540,8 +540,7 @@ checkBuildInfoFeatures bi sv = do
     (not . null $ extraDynLibFlavours bi)
     (PackageDistInexcusable $ CVExtraDynamic [extraDynLibFlavours bi])
   -- virtual-modules requires ≥ 2.2
-  checkSpecVer CabalSpecV2_2 (not . null $ virtualModules bi) $
-    (PackageDistInexcusable CVVirtualModules)
+  checkSpecVer CabalSpecV2_2 (not . null $ virtualModules bi) (PackageDistInexcusable CVVirtualModules)
   -- Check use of thinning and renaming.
   checkSpecVer
     CabalSpecV2_0

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -458,7 +458,7 @@ getCommonFlags verbHandles globalFlags hooks commonFlags args = do
   let verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity commonFlags)
   lbi <- getBuildConfig globalFlags hooks verbosity distPref
   let common' = configCommonFlags $ configFlags lbi
-  return $
+  return
     ( lbi
     , commonFlags
         { setupDistPref = toFlag distPref
@@ -802,7 +802,7 @@ sanityCheckHookedBuildInfo
   verbosity
   (PackageDescription{library = Nothing})
   (Just _, _) =
-    dieWithException verbosity $ NoLibraryForPackage
+    dieWithException verbosity NoLibraryForPackage
 sanityCheckHookedBuildInfo verbosity pkg_descr (_, hookExes)
   | exe1 : _ <- nonExistant =
       dieWithException verbosity $ SanityCheckHookedBuildInfo exe1

--- a/Cabal/src/Distribution/Simple/Build.hs
+++ b/Cabal/src/Distribution/Simple/Build.hs
@@ -222,7 +222,7 @@ build_setupHooks
         toFlag <$> case buildUseSemaphore flags of
           Flag sem_name -> case numJobs of
             Flag{} -> do
-              warn verbosity $ "Ignoring -j due to --semaphore"
+              warn verbosity "Ignoring -j due to --semaphore"
               return $ UseSem sem_name
             NoFlag -> return $ UseSem sem_name
           NoFlag -> return $ case numJobs of
@@ -367,9 +367,9 @@ repl_setupHooks
         -- This seems DEEPLY questionable.
         [] -> case allTargetsInBuildOrder' pkg_descr lbi of
           (target : _) -> return target
-          [] -> dieWithException verbosity $ FailedToDetermineTarget
+          [] -> dieWithException verbosity FailedToDetermineTarget
         [target] -> return target
-        _ -> dieWithException verbosity $ NoMultipleTargets
+        _ -> dieWithException verbosity NoMultipleTargets
     let componentsToBuild = neededTargetsInBuildOrder' pkg_descr lbi [nodeKey target]
     debug verbosity $
       "Component build order: "
@@ -549,8 +549,7 @@ buildComponent
                         flip addExtraCmmSources extras $
                           flip addExtraCxxSources extras $
                             flip addExtraCSources extras $
-                              flip addExtraJsSources extras $
-                                libbi
+                              addExtraJsSources libbi extras
                   }
 
           buildLib verbHandles flags numJobs pkg_descr lbi lib' clbi

--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -328,7 +328,7 @@ resolveBuildTarget pkg userTarget fexists =
               (things, got :| _) = unzip' expected'
            in BuildTargetExpected userTarget (NE.toList things) got
       | not (null nosuch) = BuildTargetNoSuch userTarget nosuch
-      | otherwise = error $ "resolveBuildTarget: internal error in matching"
+      | otherwise = error "resolveBuildTarget: internal error in matching"
       where
         expected = [(thing, got) | MatchErrorExpected thing got <- errs]
         nosuch = [(thing, got) | MatchErrorNoSuch thing got <- errs]

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1554,7 +1554,7 @@ dependencySatisfiable
          in if null $ PackageIndex.matchingDependencies vr allVersions
               then
                 if null eligibleVersions
-                  then Unsatisfied $ MissingPackage
+                  then Unsatisfied MissingPackage
                   else Unsatisfied $ WrongVersion eligibleVersions
               else Satisfied
 

--- a/Cabal/src/Distribution/Simple/ConfigureScript.hs
+++ b/Cabal/src/Distribution/Simple/ConfigureScript.hs
@@ -67,8 +67,7 @@ runConfigureScript verbHandles cfg flags programDb hp = do
   confExists <- doesFileExist configureScriptPath
   unless confExists $
     dieWithException verbosity (ConfigureScriptNotFound configureScriptPath)
-  configureFile <-
-    makeAbsolute $ configureScriptPath
+  configureFile <- makeAbsolute configureScriptPath
   env <- getEnvironment
   (ccProg, ccFlags) <- configureCCompiler verbosity programDb
   ccProgShort <- getShortPathName ccProg

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -209,10 +209,8 @@ configureCompiler verbosity hcPath conf0 = do
       filterJS = if ghcVersion < mkVersion [9, 8] then filterExt JavaScriptFFI else id
       extensions =
         -- workaround https://gitlab.haskell.org/ghc/ghc/-/issues/11214
-        filterJS $
-          -- see 'filterExtTH' comment below
-          filterExtTH $
-            extensions0
+        -- see 'filterExtTH' comment below
+        filterJS $ filterExtTH extensions0
 
       -- starting with GHC 8.0, `TemplateHaskell` will be omitted from
       -- `--supported-extensions` when it's not available.
@@ -933,9 +931,7 @@ installFLib verbosity lbi targetDir builtDir _pkg flib =
       -- Now install appropriate symlinks if library is versioned
       let (Platform _ os) = hostPlatform lbi
       when (not (null (foreignLibVersion flib os))) $ do
-        when (os /= Linux) $
-          dieWithException verbosity $
-            CantInstallForeignLib
+        when (os /= Linux) $ dieWithException verbosity CantInstallForeignLib
 #ifndef mingw32_HOST_OS
         -- 'createSymbolicLink file1 file2' creates a symbolic link
         -- named 'file2' which points to the file 'file1'.

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -398,7 +398,7 @@ linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg li
               then toFlag sharedLibInstallPath
               else mempty
         , ghcOptLinkLibs = extraLibs libBi
-        , ghcOptLinkLibPath = toNubListR $ cleanedExtraLibDirs
+        , ghcOptLinkLibPath = toNubListR cleanedExtraLibDirs
         , ghcOptLinkFrameworks = toNubListR $ map getSymbolicPath $ PD.frameworks libBi
         , ghcOptLinkFrameworkDirs =
             toNubListR $ PD.extraFrameworkDirs libBi
@@ -424,7 +424,7 @@ linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg li
               then toFlag profSharedLibInstallPath
               else mempty
         , ghcOptLinkLibs = extraLibs libBi
-        , ghcOptLinkLibPath = toNubListR $ cleanedExtraLibDirs
+        , ghcOptLinkLibPath = toNubListR cleanedExtraLibDirs
         , ghcOptLinkFrameworks = toNubListR $ map getSymbolicPath $ PD.frameworks libBi
         , ghcOptLinkFrameworkDirs =
             toNubListR $ PD.extraFrameworkDirs libBi
@@ -437,7 +437,7 @@ linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg li
         , ghcOptOutputFile = toFlag staticLibFilePath
         , ghcOptLinkLibs = extraLibs libBi
         , -- TODO: Shouldn't this use cleanedExtraLibDirsStatic instead?
-          ghcOptLinkLibPath = toNubListR $ cleanedExtraLibDirs
+          ghcOptLinkLibPath = toNubListR cleanedExtraLibDirs
         }
 
   staticObjectFiles <- getObjFiles StaticWay

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -571,8 +571,7 @@ componentGhcOptions verbosity lbi bi clbi odir =
         , ghcOptCppOptions = cppOptions bi
         , ghcOptJSppOptions = jsppOptions bi
         , ghcOptCppIncludes =
-            toNubListR $
-              [coerceSymbolicPath (autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName)]
+            toNubListR [coerceSymbolicPath (autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName)]
         , ghcOptFfiIncludes = toNubListR $ map getSymbolicPath $ includes bi
         , ghcOptObjDir = toFlag $ coerceSymbolicPath odir
         , ghcOptHiDir = toFlag $ coerceSymbolicPath odir
@@ -619,8 +618,7 @@ componentCmmGhcOptions verbosity lbi bi clbi odir filename =
     , ghcOptCppIncludePath = includePaths lbi bi clbi odir
     , ghcOptCppOptions = cppOptions bi
     , ghcOptCppIncludes =
-        toNubListR $
-          [autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName]
+        toNubListR [autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName]
     , ghcOptHideAllPackages = toFlag True
     , ghcOptPackageDBs = withPackageDB lbi
     , ghcOptPackages = toNubListR $ mkGhcOptPackages (promisedPkgs lbi) clbi

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -243,8 +243,7 @@ compilerProgramDb verbosity comp progdb1 hcPkgPath = do
       progdb3 =
         addKnownProgram haddockProgram' $
           addKnownProgram hsc2hsProgram' $
-            addKnownProgram hpcProgram' $
-              {- addKnownProgram runghcProgram' -} progdb2
+            addKnownProgram hpcProgram' {- addKnownProgram runghcProgram' -} progdb2
 
   return progdb3
 

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -554,7 +554,7 @@ createHaddockIndex
 createHaddockIndex verbosity programDb comp platform mbWorkDir flags = do
   let args = fromHaddockProjectFlags flags
       tmpFileOpts =
-        commonSetupTempFileOptions $ haddockProjectCommonFlags $ flags
+        commonSetupTempFileOptions $ haddockProjectCommonFlags flags
   (haddockProg, _version) <-
     getHaddockProg verbosity programDb comp args (Flag True)
   runHaddock verbosity mbWorkDir tmpFileOpts comp platform haddockProg False args
@@ -629,7 +629,7 @@ fromPackageDescription :: HaddockTarget -> PackageDescription -> HaddockArgs
 fromPackageDescription _haddockTarget pkg_descr =
   mempty
     { argInterfaceFile = Flag $ haddockPath pkg_descr
-    , argPackageName = Flag $ packageId $ pkg_descr
+    , argPackageName = Flag $ packageId pkg_descr
     , argOutputDir = Dir $ "doc" </> "html"
     , argPrologue =
         Flag $
@@ -1282,7 +1282,7 @@ renderPureArgs version comp platform args =
       | r <- argReexports args
       , isVersion 2 19
       ]
-    , argTargets $ args
+    , argTargets args
     , maybe [] ((: []) . (resourcesDirFlag ++)) . flagToMaybe . argResourcesDir $ args
     , -- Do not re-direct compilation output to a temporary directory (--no-tmp-comp-dir)
       -- We pass this option by default to haddock to avoid recompilation
@@ -1373,7 +1373,7 @@ haddockPackagePaths ipkgs mkHtmlPath = do
               Just htmlPath -> do
                 let hypSrcPath = htmlPath </> defaultHyperlinkedSourceDirectory
                 hypSrcExists <- doesDirectoryExist hypSrcPath
-                return $
+                return
                   ( Just (fixFileUrl htmlPath)
                   , if hypSrcExists
                       then Just (fixFileUrl hypSrcPath)

--- a/Cabal/src/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/src/Distribution/Simple/PackageIndex.hs
@@ -184,7 +184,7 @@ invariant (PackageIndex pids pnames) =
                 all
                   (\g -> length g == 1)
                   (groupBy (equating installedUnitId) pinsts')
-        , pinst <- assert pinstsOk $ pinsts'
+        , pinst <- assert pinstsOk pinsts'
         , let pinstOk =
                 packageName pinst == pname
                   && packageVersion pinst == pver

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -257,7 +257,7 @@ preprocessComponent pd comp lbi clbi isSrcDist verbosity handlers =
         (coerceSymbolicPath outputDir : hsSourceDirs bi)
         outputDir
         isSrcDist
-        (dropExtensionsSymbolicPath $ exePath)
+        (dropExtensionsSymbolicPath exePath)
         verbosity
         builtinSuffixes
         biHandlers
@@ -345,7 +345,7 @@ preprocessFile mbWorkDir searchLoc buildLoc forSDist baseFile verbosity builtinS
           createDirectoryIfMissingVerbose verbosity True destDir
           runPreProcessorWithHsBootHack
             pp
-            (psrcLoc, getSymbolicPath $ psrcRelFile)
+            (psrcLoc, getSymbolicPath psrcRelFile)
             (buildLoc, srcStem <.> "hs")
   where
     i = interpretSymbolicPath mbWorkDir -- See Note [Symbolic paths] in Distribution.Utils.Path
@@ -367,8 +367,8 @@ preprocessFile mbWorkDir searchLoc buildLoc forSDist baseFile verbosity builtinS
         -- Hence the use of 'getSymbolicPath' here.
         runPreProcessor
           pp
-          (getSymbolicPath $ inBaseDir, inRelativeFile)
-          (getSymbolicPath $ outBaseDir, outRelativeFile)
+          (getSymbolicPath inBaseDir, inRelativeFile)
+          (getSymbolicPath outBaseDir, outRelativeFile)
           verbosity
 
         -- Here we interact directly with the file system, so we must

--- a/Cabal/src/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/src/Distribution/Simple/Program/Builtin.hs
@@ -134,8 +134,7 @@ ghcProgram =
               -- Workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/8825
               -- (spurious warning on non-english locales)
               $
-                applyWhen (withinRange v affectedVersionRange) setLanguageEnv $
-                  ghcProg
+                applyWhen (withinRange v affectedVersionRange) setLanguageEnv ghcProg
           )
           (programVersion ghcProg)
 

--- a/Cabal/src/Distribution/Simple/Program/ResponseFile.hs
+++ b/Cabal/src/Distribution/Simple/Program/ResponseFile.hs
@@ -40,8 +40,7 @@ withResponseFile verbosity tmpFileOpts fileNameTemplate encoding arguments f =
     traverse_ (hSetEncoding hf) encoding
     let responseContents =
           unlines $
-            map escapeResponseFileArg $
-              arguments
+            map escapeResponseFileArg arguments
     hPutStr hf responseContents
     hClose hf
     debug verbosity $ responseFileName ++ " contents: <<<"

--- a/Cabal/src/Distribution/Simple/Setup/Build.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Build.hs
@@ -128,7 +128,8 @@ buildCommand progDb =
       --        ++ "  " ++ pname ++ " build foo:Foo.Bar\n"
       --        ++ "  " ++ pname ++ " build testsuite1:Foo/Bar.hs\n"
       commandUsage =
-        usageAlternatives "build" $
+        usageAlternatives
+          "build"
           [ "[FLAGS]"
           , "COMPONENTS [FLAGS]"
           ]

--- a/Cabal/src/Distribution/Simple/Setup/Copy.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Copy.hs
@@ -111,7 +111,8 @@ copyCommand =
           ++ " copy foo       "
           ++ "    A component (i.e. lib, exe, test suite)"
     , commandUsage =
-        usageAlternatives "copy" $
+        usageAlternatives
+          "copy"
           [ "[FLAGS]"
           , "COMPONENTS [FLAGS]"
           ]

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -178,7 +178,8 @@ haddockCommand =
         "Requires the program haddock, version 2.x.\n"
     , commandNotes = Nothing
     , commandUsage =
-        usageAlternatives "haddock" $
+        usageAlternatives
+          "haddock"
           [ "[FLAGS]"
           , "COMPONENTS [FLAGS]"
           ]
@@ -204,8 +205,7 @@ haddockCommand =
   where
     progDb =
       addKnownProgram haddockProgram $
-        addKnownProgram ghcProgram $
-          emptyProgramDb
+        addKnownProgram ghcProgram emptyProgramDb
 
 haddockOptions :: ShowOrParseArgs -> [OptionField HaddockFlags]
 haddockOptions showOrParseArgs =
@@ -473,7 +473,8 @@ haddockProjectCommand =
         "Requires the program haddock, version 2.26.\n"
     , commandNotes = Nothing
     , commandUsage =
-        usageAlternatives "haddock-project" $
+        usageAlternatives
+          "haddock-project"
           [ "[FLAGS]"
           , "COMPONENTS [FLAGS]"
           ]
@@ -499,8 +500,7 @@ haddockProjectCommand =
   where
     progDb =
       addKnownProgram haddockProgram $
-        addKnownProgram ghcProgram $
-          emptyProgramDb
+        addKnownProgram ghcProgram emptyProgramDb
 
 haddockProjectOptions :: ShowOrParseArgs -> [OptionField HaddockProjectFlags]
 haddockProjectOptions showOrParseArgs =

--- a/Cabal/src/Distribution/Simple/Setup/Register.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Register.hs
@@ -111,54 +111,54 @@ registerCommand =
           registerCommonFlags
           (\c f -> f{registerCommonFlags = c})
           showOrParseArgs
-          $ [ option
-                ""
-                ["packageDB"]
-                ""
-                regPackageDB
-                (\v flags -> flags{regPackageDB = v})
-                ( choiceOpt
-                    [
-                      ( Flag UserPackageDB
-                      , ([], ["user"])
-                      , "upon registration, register this package in the user's local package database"
-                      )
-                    ,
-                      ( Flag GlobalPackageDB
-                      , ([], ["global"])
-                      , "(default)upon registration, register this package in the system-wide package database"
-                      )
-                    ]
-                )
-            , option
-                ""
-                ["inplace"]
-                "register the package in the build location, so it can be used without being installed"
-                regInPlace
-                (\v flags -> flags{regInPlace = v})
-                trueArg
-            , option
-                ""
-                ["gen-script"]
-                "instead of registering, generate a script to register later"
-                regGenScript
-                (\v flags -> flags{regGenScript = v})
-                trueArg
-            , option
-                ""
-                ["gen-pkg-config"]
-                "instead of registering, generate a package registration file/directory"
-                regGenPkgConf
-                (\v flags -> flags{regGenPkgConf = v})
-                (optArg' "PKG" (Flag . fmap makeSymbolicPath) (flagToList . fmap (fmap getSymbolicPath)))
-            , option
-                ""
-                ["print-ipid"]
-                "print the installed package ID calculated for this package"
-                regPrintId
-                (\v flags -> flags{regPrintId = v})
-                trueArg
-            ]
+          [ option
+              ""
+              ["packageDB"]
+              ""
+              regPackageDB
+              (\v flags -> flags{regPackageDB = v})
+              ( choiceOpt
+                  [
+                    ( Flag UserPackageDB
+                    , ([], ["user"])
+                    , "upon registration, register this package in the user's local package database"
+                    )
+                  ,
+                    ( Flag GlobalPackageDB
+                    , ([], ["global"])
+                    , "(default)upon registration, register this package in the system-wide package database"
+                    )
+                  ]
+              )
+          , option
+              ""
+              ["inplace"]
+              "register the package in the build location, so it can be used without being installed"
+              regInPlace
+              (\v flags -> flags{regInPlace = v})
+              trueArg
+          , option
+              ""
+              ["gen-script"]
+              "instead of registering, generate a script to register later"
+              regGenScript
+              (\v flags -> flags{regGenScript = v})
+              trueArg
+          , option
+              ""
+              ["gen-pkg-config"]
+              "instead of registering, generate a package registration file/directory"
+              regGenPkgConf
+              (\v flags -> flags{regGenPkgConf = v})
+              (optArg' "PKG" (Flag . fmap makeSymbolicPath) (flagToList . fmap (fmap getSymbolicPath)))
+          , option
+              ""
+              ["print-ipid"]
+              "print the installed package ID calculated for this package"
+              regPrintId
+              (\v flags -> flags{regPrintId = v})
+              trueArg
+          ]
     }
 
 unregisterCommand :: CommandUI RegisterFlags
@@ -177,33 +177,33 @@ unregisterCommand =
           registerCommonFlags
           (\c f -> f{registerCommonFlags = c})
           showOrParseArgs
-          $ [ option
-                ""
-                ["user"]
-                ""
-                regPackageDB
-                (\v flags -> flags{regPackageDB = v})
-                ( choiceOpt
-                    [
-                      ( Flag UserPackageDB
-                      , ([], ["user"])
-                      , "unregister this package in the user's local package database"
-                      )
-                    ,
-                      ( Flag GlobalPackageDB
-                      , ([], ["global"])
-                      , "(default) unregister this package in the  system-wide package database"
-                      )
-                    ]
-                )
-            , option
-                ""
-                ["gen-script"]
-                "Instead of performing the unregister command, generate a script to unregister later"
-                regGenScript
-                (\v flags -> flags{regGenScript = v})
-                trueArg
-            ]
+          [ option
+              ""
+              ["user"]
+              ""
+              regPackageDB
+              (\v flags -> flags{regPackageDB = v})
+              ( choiceOpt
+                  [
+                    ( Flag UserPackageDB
+                    , ([], ["user"])
+                    , "unregister this package in the user's local package database"
+                    )
+                  ,
+                    ( Flag GlobalPackageDB
+                    , ([], ["global"])
+                    , "(default) unregister this package in the  system-wide package database"
+                    )
+                  ]
+              )
+          , option
+              ""
+              ["gen-script"]
+              "Instead of performing the unregister command, generate a script to unregister later"
+              regGenScript
+              (\v flags -> flags{regGenScript = v})
+              trueArg
+          ]
     }
 
 emptyRegisterFlags :: RegisterFlags

--- a/Cabal/src/Distribution/Simple/Setup/Test.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Test.hs
@@ -132,8 +132,8 @@ defaultTestFlags :: TestFlags
 defaultTestFlags =
   TestFlags
     { testCommonFlags = defaultCommonSetupFlags
-    , testHumanLog = toFlag $ toPathTemplate $ "$pkgid-$test-suite.log"
-    , testMachineLog = toFlag $ toPathTemplate $ "$pkgid.log"
+    , testHumanLog = toFlag $ toPathTemplate "$pkgid-$test-suite.log"
+    , testMachineLog = toFlag $ toPathTemplate "$pkgid.log"
     , testShowDetails = toFlag Direct
     , testKeepTix = toFlag False
     , testWrapper = NoFlag

--- a/Cabal/src/Distribution/Simple/SetupHooks/Errors.hs
+++ b/Cabal/src/Distribution/Simple/SetupHooks/Errors.hs
@@ -170,7 +170,7 @@ rulesExceptionMessage = \case
             "The index is too large."
       plural = if nbOutputs == 1 then "" else "s"
   DuplicateRuleId rId r1 r2 ->
-    unlines $
+    unlines
       [ "Duplicate pre-build rule (" <> show rId <> ")"
       , "  - " <> showRule (ruleBinary r1)
       , "  - " <> showRule (ruleBinary r2)

--- a/Cabal/src/Distribution/Simple/SetupHooks/Internal.hs
+++ b/Cabal/src/Distribution/Simple/SetupHooks/Internal.hs
@@ -994,7 +994,7 @@ resolveDependency verbosity rId allRules = \case
     case Map.lookup depId allRules of
       Nothing ->
         error $
-          unlines $
+          unlines
             [ "Internal error: missing rule dependency."
             , "Rule: " ++ show rId
             , "Dependency: " ++ show depId

--- a/Cabal/src/Distribution/Simple/SetupHooks/Rule.hs
+++ b/Cabal/src/Distribution/Simple/SetupHooks/Rule.hs
@@ -819,7 +819,7 @@ runRuleDynDepsCmd = \case
           Just $ do
             (deps, dynDeps) <- runCommand depsCmd
             -- See Note [Hooks Binary instances]
-            return $ (deps, Binary.encode $ ScopedArgument @User dynDeps)
+            return (deps, Binary.encode $ ScopedArgument @User dynDeps)
 
 -- | Project out the command for running the rule, passing in the result of
 -- the dependency computation if there was one.

--- a/Cabal/src/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/src/Distribution/Simple/Test/ExeV10.hs
@@ -82,7 +82,7 @@ runTest verbHandles pkg_descr lbi clbi hpcMarkupInfo flags suite = do
   createDirectoryIfMissing True tixDir_
 
   -- Write summary notices indicating start of test suite
-  notice verbosity $ summarizeSuiteStart $ testName'
+  notice verbosity $ summarizeSuiteStart testName'
 
   -- Run the test executable (with the appropriate environment set)
   let progDb = LBI.withPrograms lbi

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -131,8 +131,7 @@ getInstalledPackages verbosity comp mbWorkDir packagedbs progdb = do
   -- putStrLn $ "pkgs: " ++ show pkgs
   let iPkgs =
         map mkInstalledPackageInfo $
-          concatMap parsePackage $
-            pkgs
+          concatMap parsePackage pkgs
   -- putStrLn $ "installed pkgs: " ++ show iPkgs
   return (fromList iPkgs)
 
@@ -266,7 +265,7 @@ buildExe verbosity _pkg_descr lbi exe clbi = do
           -- output file
           ++ ["--output", u $ buildDir lbi </> makeRelativePathEx (prettyShow (exeName exe))]
           -- main source module
-          ++ [u $ srcMainPath]
+          ++ [u srcMainPath]
   runUhcProg uhcArgs
 
 constructUHCCmdLine

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -636,8 +636,7 @@ notice verbosity msg = withFrozenCallStack $ do
     ts <- getPOSIXTime
     hPutStr h $
       withMetadata ts NormalMark FlagTrace flags $
-        wrapTextVerbosity flags $
-          msg
+        wrapTextVerbosity flags msg
 
 -- | Display a message at 'normal' verbosity level, but without
 -- wrapping.
@@ -659,8 +658,7 @@ noticeDoc verbosity msg = withFrozenCallStack $ do
     ts <- getPOSIXTime
     hPutStr h $
       withMetadata ts NormalMark FlagTrace flags $
-        Disp.renderStyle defaultStyle $
-          msg
+        Disp.renderStyle defaultStyle msg
 
 -- | Display a "setup status message".  Prefer using setupMessage'
 -- if possible.
@@ -679,8 +677,7 @@ info verbosity msg = withFrozenCallStack $
     ts <- getPOSIXTime
     hPutStr h $
       withMetadata ts NeverMark FlagTrace flags $
-        wrapTextVerbosity flags $
-          msg
+        wrapTextVerbosity flags msg
 
 infoNoWrap :: Verbosity -> String -> IO ()
 infoNoWrap verbosity msg = withFrozenCallStack $
@@ -689,8 +686,7 @@ infoNoWrap verbosity msg = withFrozenCallStack $
         flags = verbosityFlags verbosity
     ts <- getPOSIXTime
     hPutStr h $
-      withMetadata ts NeverMark FlagTrace flags $
-        msg
+      withMetadata ts NeverMark FlagTrace flags msg
 
 -- | Detailed internal debugging information
 --
@@ -703,8 +699,7 @@ debug verbosity msg = withFrozenCallStack $
     ts <- getPOSIXTime
     hPutStr h $
       withMetadata ts NeverMark FlagTrace flags $
-        wrapTextVerbosity flags $
-          msg
+        wrapTextVerbosity flags msg
     -- ensure that we don't lose output if we segfault/infinite loop
     hFlush stdout
 
@@ -716,8 +711,7 @@ debugNoWrap verbosity msg = withFrozenCallStack $
     let h = verbosityChosenOutputHandle verbosity
     ts <- getPOSIXTime
     hPutStr h $
-      withMetadata ts NeverMark FlagTrace (verbosityFlags verbosity) $
-        msg
+      withMetadata ts NeverMark FlagTrace (verbosityFlags verbosity) msg
     -- ensure that we don't lose output if we segfault/infinite loop
     hFlush stdout
 
@@ -1909,8 +1903,7 @@ withTempFileEx opts template action = do
           hClose handle
           unless (optKeepTempFiles opts) $
             handleDoesNotExist () $
-              removeFile $
-                name
+              removeFile name
       )
       (withLexicalCallStack (\(fn, h) -> action (mkRelToPkg tmp fn) h))
   where

--- a/Cabal/src/Distribution/Types/LocalBuildConfig.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildConfig.hs
@@ -203,27 +203,27 @@ instance Structured BuildOptions
 buildOptionsConfigFlags :: BuildOptions -> ConfigFlags
 buildOptionsConfigFlags (BuildOptions{..}) =
   mempty
-    { configVanillaLib = toFlag $ withVanillaLib
-    , configSharedLib = toFlag $ withSharedLib
-    , configStaticLib = toFlag $ withStaticLib
-    , configDynExe = toFlag $ withDynExe
-    , configFullyStaticExe = toFlag $ withFullyStaticExe
-    , configGHCiLib = toFlag $ withGHCiLib
-    , configProfExe = toFlag $ withProfExe
-    , configProfLib = toFlag $ withProfLib
-    , configProfShared = toFlag $ withProfLibShared
+    { configVanillaLib = toFlag withVanillaLib
+    , configSharedLib = toFlag withSharedLib
+    , configStaticLib = toFlag withStaticLib
+    , configDynExe = toFlag withDynExe
+    , configFullyStaticExe = toFlag withFullyStaticExe
+    , configGHCiLib = toFlag withGHCiLib
+    , configProfExe = toFlag withProfExe
+    , configProfLib = toFlag withProfLib
+    , configProfShared = toFlag withProfLibShared
     , configProf = mempty
     , -- configProfDetail is for exe+lib, but overridden by configProfLibDetail
       -- so we specify both so we can specify independently
-      configProfDetail = toFlag $ withProfExeDetail
-    , configProfLibDetail = toFlag $ withProfLibDetail
-    , configCoverage = toFlag $ exeCoverage
+      configProfDetail = toFlag withProfExeDetail
+    , configProfLibDetail = toFlag withProfLibDetail
+    , configCoverage = toFlag exeCoverage
     , configLibCoverage = mempty
-    , configRelocatable = toFlag $ relocatable
-    , configOptimization = toFlag $ withOptimization
-    , configSplitSections = toFlag $ splitSections
-    , configSplitObjs = toFlag $ splitObjs
-    , configStripExes = toFlag $ stripExes
-    , configStripLibs = toFlag $ stripLibs
-    , configDebugInfo = toFlag $ withDebugInfo
+    , configRelocatable = toFlag relocatable
+    , configOptimization = toFlag withOptimization
+    , configSplitSections = toFlag splitSections
+    , configSplitObjs = toFlag splitObjs
+    , configStripExes = toFlag stripExes
+    , configStripLibs = toFlag stripLibs
+    , configDebugInfo = toFlag withDebugInfo
     }

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Assignment.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Assignment.hs
@@ -69,8 +69,7 @@ toCPs (A pa fa sa) rdm =
     fapp :: Map QPN FlagAssignment
     fapp = M.fromListWith mappend $
            L.map (\ ((FN qpn fn), b) -> (qpn, mkFlagAssignment [(fn, b)])) $
-           M.toList $
-           fa
+           M.toList fa
     -- Stanzas per package.
     sapp :: Map QPN OptionalStanzaSet
     sapp = M.fromListWith mappend

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
@@ -145,7 +145,7 @@ newtype UpdateState a = UpdateState {
   deriving (Functor, Applicative, Monad)
 
 instance MonadState ValidateState UpdateState where
-  get    = UpdateState $ get
+  get    = UpdateState get
   put st = UpdateState $ do
              expensiveAssert (lgInvariant $ vsLinks st) $ return ()
              put st

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -118,32 +118,32 @@ summarizeMessages = go 0
         goPSkip l qpn [i] conflicts ms
 
     go !l (Step (TryF qfn b) (Step Enter (Step (Failure c fr) (Step Leave ms)))) =
-        Step (SummarizedMsg $ AtLevel l $ (EntryRejectF qfn b c fr)) (go l ms)
+        Step (SummarizedMsg $ AtLevel l (EntryRejectF qfn b c fr)) (go l ms)
 
     go !l (Step (TryS qsn b) (Step Enter (Step (Failure c fr) (Step Leave ms)))) =
-        Step (SummarizedMsg $ AtLevel l $ (EntryRejectS qsn b c fr)) (go l ms)
+        Step (SummarizedMsg $ AtLevel l (EntryRejectS qsn b c fr)) (go l ms)
 
     -- "Trying ..." message when a new goal is started
     go !l (Step (Next (Goal (P _  ) gr)) (Step (TryP qpn' i) ms@(Step Enter (Step (Next _) _)))) =
-        Step (SummarizedMsg $ AtLevel l $ (EntryTryingNewP qpn' i gr)) (go l ms)
+        Step (SummarizedMsg $ AtLevel l (EntryTryingNewP qpn' i gr)) (go l ms)
 
     go !l (Step (Next (Goal (P qpn) gr)) (Step (Failure _c UnknownPackage) ms)) =
-        Step (SummarizedMsg $ AtLevel l $ (EntryUnknownPackage qpn gr)) (go l ms)
+        Step (SummarizedMsg $ AtLevel l (EntryUnknownPackage qpn gr)) (go l ms)
 
     -- standard display
     go !l (Step Enter                    ms) = go (l+1) ms
     go !l (Step Leave                    ms) = go (l-1) ms
 
-    go !l (Step (TryP qpn i)             ms) = Step (SummarizedMsg $ AtLevel l $ (EntryTryingP qpn i)) (go l ms)
-    go !l (Step (TryF qfn b)             ms) = Step (SummarizedMsg $ AtLevel l $ (EntryTryingF qfn b)) (go l ms)
-    go !l (Step (TryS qsn b)             ms) = Step (SummarizedMsg $ AtLevel l $ (EntryTryingS qsn b)) (go l ms)
-    go !l (Step (Next (Goal (P qpn) gr)) ms) = Step (SummarizedMsg $ AtLevel l $ (EntryPackageGoal qpn gr)) (go l ms)
+    go !l (Step (TryP qpn i)             ms) = Step (SummarizedMsg $ AtLevel l (EntryTryingP qpn i)) (go l ms)
+    go !l (Step (TryF qfn b)             ms) = Step (SummarizedMsg $ AtLevel l (EntryTryingF qfn b)) (go l ms)
+    go !l (Step (TryS qsn b)             ms) = Step (SummarizedMsg $ AtLevel l (EntryTryingS qsn b)) (go l ms)
+    go !l (Step (Next (Goal (P qpn) gr)) ms) = Step (SummarizedMsg $ AtLevel l (EntryPackageGoal qpn gr)) (go l ms)
     go !l (Step (Next _)                 ms) = go l ms -- ignore flag goals in the log
 
     -- 'Skip' should always be handled by 'goPSkip' in the case above.
-    go !l (Step (Skip conflicts)         ms) = Step (SummarizedMsg $ AtLevel l $ (EntrySkipping conflicts)) (go l ms)
-    go !l (Step (Success)                ms) = Step (SummarizedMsg $ AtLevel l $ EntrySuccess) (go l ms)
-    go !l (Step (Failure c fr)           ms) = Step (SummarizedMsg $ AtLevel l $ (EntryFailure c fr)) (go l ms)
+    go !l (Step (Skip conflicts)         ms) = Step (SummarizedMsg $ AtLevel l (EntrySkipping conflicts)) (go l ms)
+    go !l (Step (Success)                ms) = Step (SummarizedMsg $ AtLevel l EntrySuccess) (go l ms)
+    go !l (Step (Failure c fr)           ms) = Step (SummarizedMsg $ AtLevel l (EntryFailure c fr)) (go l ms)
 
     -- special handler for many subsequent package rejections
     goPReject :: Int
@@ -158,7 +158,7 @@ summarizeMessages = go 0
         -- By prepending (i : is) we reverse the order of the instances.
         goPReject l qpn (i : is) c fr ms
     goPReject l qpn is c fr ms =
-        Step (SummarizedMsg $ AtLevel l $ (EntryRejectMany qpn (reverse is) c fr)) (go l ms)
+        Step (SummarizedMsg $ AtLevel l (EntryRejectMany qpn (reverse is) c fr)) (go l ms)
 
     -- Handle many subsequent skipped package instances.
     goPSkip :: Int
@@ -172,7 +172,7 @@ summarizeMessages = go 0
         -- By prepending (i : is) we reverse the order of the instances.
         goPSkip l qpn (i : is) conflicts ms
     goPSkip l qpn is conflicts ms =
-       Step (SummarizedMsg $ AtLevel l $ (EntrySkipMany qpn (reverse is) conflicts)) (go l ms)
+       Step (SummarizedMsg $ AtLevel l (EntrySkipMany qpn (reverse is) conflicts)) (go l ms)
 
 -- | Display the set of 'Conflicts' for a skipped package version.
 showConflicts :: Set CS.Conflict -> String

--- a/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
@@ -120,7 +120,7 @@ componentNameToComponent (CN.CBenchName               s)  = ComponentBench  s
 -------------------------------------------------------------------------------}
 
 empty :: ComponentDeps a
-empty = ComponentDeps $ Map.empty
+empty = ComponentDeps Map.empty
 
 fromList :: Monoid a => [ComponentDep a] -> ComponentDeps a
 fromList = ComponentDeps . Map.fromListWith mappend

--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -359,7 +359,7 @@ showAsJson pathOutputs =
 
     pathsJson = Json.object $ map (\(k, v) -> k .= Json.String v) (pathOutputsConfigPaths pathOutputs)
    in
-    mergeJsonObjects $
+    mergeJsonObjects
       [ cabalInstallJson
       , compilerInfoJson
       , pathsJson

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -349,7 +349,7 @@ runAction flags targetAndArgs globalFlags =
             { progInvokePath = exePath
             , progInvokeArgs = args
             , progInvokeEnv =
-                ("PATH", Just $ progPath)
+                ("PATH", Just progPath)
                   : dataDirsEnvironmentForPlan
                     (distDirLayout baseCtx)
                     elaboratedPlan

--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -103,8 +103,7 @@ updateCommand =
     , commandSynopsis = "Updates list of known packages."
     , commandUsage = usageAlternatives "v2-update" ["[FLAGS] [REPOS]"]
     , commandDescription = Just $ \_ ->
-        wrapText $
-          "For all known remote repositories, download the package list."
+        wrapText "For all known remote repositories, download the package list."
     , commandNotes = Just $ \pname ->
         "REPO has the format <repo-id>[,<index-state>] where index-state follows\n"
           ++ "the same format and syntax that is supported by the --index-state flag.\n\n"

--- a/cabal-install/src/Distribution/Client/Errors.hs
+++ b/cabal-install/src/Distribution/Client/Errors.hs
@@ -835,7 +835,7 @@ exceptionMessageCabalInstall e = case e of
     "--enable-benchmarks was specified, but benchmarks can't "
       ++ "be enabled in a remote package"
   UnknownPackage hn name ->
-    concat $
+    concat
       [ "Unknown package \""
       , hn
       , "\". "

--- a/cabal-install/src/Distribution/Client/Get.hs
+++ b/cabal-install/src/Distribution/Client/Get.hs
@@ -132,8 +132,7 @@ get verbosity repoCtxt globalFlags getFlags userTargets = do
   if onlyPkgDescr
     then do
       when useSourceRepo $
-        warn verbosity $
-          "Ignoring --source-repository for --only-package-description"
+        warn verbosity "Ignoring --source-repository for --only-package-description"
 
       mapM_ (unpackOnlyPkgDescr verbosity prefix) pkgs
     else

--- a/cabal-install/src/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/src/Distribution/Client/InstallPlan.hs
@@ -689,8 +689,7 @@ ready
   => GenericInstallPlan ipkg srcpkg
   -> ([GenericReadyPackage srcpkg], Processing)
 ready plan =
-  assert (processingInvariant plan processing) $
-    (readyPackages, processing)
+  assert (processingInvariant plan processing) (readyPackages, processing)
   where
     !processing =
       Processing
@@ -720,7 +719,8 @@ completed
   -> ([GenericReadyPackage srcpkg], Processing)
 completed plan (Processing processingSet completedSet failedSet) pkgid =
   assert (pkgid `Set.member` processingSet) $
-    assert (processingInvariant plan processing') $
+    assert
+      (processingInvariant plan processing')
       ( map asReadyPackage newlyReady
       , processing'
       )
@@ -760,7 +760,8 @@ failed plan (Processing processingSet completedSet failedSet) pkgid =
         -- but note that some newlyFailed may already be in the failed set
         -- since one package can depend on two packages that both fail and
         -- so would be in the rev-dep closure for both.
-        assert (processingInvariant plan processing') $
+        assert
+          (processingInvariant plan processing')
           ( map asConfiguredPackage (drop 1 newlyFailed)
           , processing'
           )

--- a/cabal-install/src/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/src/Distribution/Client/InstallSymlink.hs
@@ -407,7 +407,7 @@ trySymlink verbosity = do
     let create :: IO Bool
         create = do
           createFileLink from to
-          info verbosity $ "Symlinking seems to work"
+          info verbosity "Symlinking seems to work"
           return True
 
     create `catchIO` \exc -> do

--- a/cabal-install/src/Distribution/Client/ParseUtils.hs
+++ b/cabal-install/src/Distribution/Client/ParseUtils.hs
@@ -321,12 +321,12 @@ parseFieldsAndSections fieldDescrs sectionDescrs fgSectionDescrs =
                 ++ show line'
           case runParseResult $ parseFieldGrammar cabalSpecLatest fields2 grammar of
             (warnings, Right b) -> do
-              for_ warnings $ \w -> warning $ showPWarningWithSource $ w
+              for_ warnings $ \w -> warning $ showPWarningWithSource w
               setter line param b a
             (warnings, Left (_, errs)) -> do
-              for_ warnings $ \w -> warning $ showPWarningWithSource $ w
+              for_ warnings $ \w -> warning $ showPWarningWithSource w
               case errs of
-                err :| _errs -> fail $ showPErrorWithSource $ err
+                err :| _errs -> fail $ showPErrorWithSource err
         Nothing -> do
           warning $
             "Unrecognized section '"

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -893,7 +893,7 @@ readProjectFileSkeleton option =
 readProjectFileSkeletonLegacy :: Verbosity -> HttpTransport -> DistDirLayout -> String -> String -> Rebuild ProjectConfigSkeleton
 readProjectFileSkeletonLegacy verbosity httpTransport distDirLayout extensionName extensionDescription = do
   readProjectFileSkeletonGen verbosity httpTransport distDirLayout extensionName extensionDescription $ \fp -> do
-    debug verbosity $ "Reading project file using the legacy parser"
+    debug verbosity "Reading project file using the legacy parser"
     parseProjectFileSkeletonLegacy verbosity httpTransport distDirLayout extensionName extensionDescription fp
       >>= liftIO . reportParseResult verbosity extensionDescription fp
 
@@ -901,7 +901,7 @@ readProjectFileSkeletonLegacy verbosity httpTransport distDirLayout extensionNam
 readProjectFileSkeletonFallback :: Verbosity -> HttpTransport -> DistDirLayout -> String -> String -> Rebuild ProjectConfigSkeleton
 readProjectFileSkeletonFallback verbosity httpTransport distDirLayout extensionName extensionDescription = do
   readProjectFileSkeletonGen verbosity httpTransport distDirLayout extensionName extensionDescription $ \fp -> do
-    debug verbosity $ "Reading project file using the fallback parser"
+    debug verbosity "Reading project file using the fallback parser"
     (res, bs) <- parseProjectFileSkeletonParsec verbosity httpTransport distDirLayout extensionName extensionDescription fp
     let (_, pres) = runParseResult res
     case pres of
@@ -914,7 +914,7 @@ readProjectFileSkeletonFallback verbosity httpTransport distDirLayout extensionN
           -- 3a. The legacy parser worked, but the parsec parser failed!
           -- Report a warning to the user that this happened.
           OldParser.ProjectParseOk{} -> do
-            warn verbosity $ "The new parsec parser failed, but the legacy parser worked. This is unexpected, please report this as a bug.\nThe legacy parser will be removed in the next major version."
+            warn verbosity "The new parsec parser failed, but the legacy parser worked. This is unexpected, please report this as a bug.\nThe legacy parser will be removed in the next major version."
             liftIO $ reportParseResult verbosity extensionDescription fp lres
           -- 3b. The legacy parser failed as well, report the original error.
           OldParser.ProjectParseFailed{} -> do
@@ -924,14 +924,14 @@ readProjectFileSkeletonFallback verbosity httpTransport distDirLayout extensionN
 readProjectFileSkeletonParsec :: Verbosity -> HttpTransport -> DistDirLayout -> String -> String -> Rebuild ProjectConfigSkeleton
 readProjectFileSkeletonParsec verbosity httpTransport distDirLayout extensionName extensionDescription = do
   readProjectFileSkeletonGen verbosity httpTransport distDirLayout extensionName extensionDescription $ \fp -> do
-    debug verbosity $ "Reading project file using the parsec parser"
+    debug verbosity "Reading project file using the parsec parser"
     (res, bs) <- parseProjectFileSkeletonParsec verbosity httpTransport distDirLayout extensionName extensionDescription fp
     liftIO $ reportParseResultParsec verbosity fp bs res
 
 readProjectFileSkeletonCompare :: Verbosity -> HttpTransport -> DistDirLayout -> String -> String -> Rebuild ProjectConfigSkeleton
 readProjectFileSkeletonCompare verbosity httpTransport distDirLayout extensionName extensionDescription = do
   readProjectFileSkeletonGen verbosity httpTransport distDirLayout extensionName extensionDescription $ \fp -> do
-    debug verbosity $ "Reading project file using the comparative parser"
+    debug verbosity "Reading project file using the comparative parser"
     (pres, bs) <- parseProjectFileSkeletonParsec verbosity httpTransport distDirLayout extensionName extensionDescription fp
     lres <- parseProjectFileSkeletonLegacy verbosity httpTransport distDirLayout extensionName extensionDescription fp
     let (_, ppres) = runParseResult pres
@@ -943,12 +943,12 @@ readProjectFileSkeletonCompare verbosity httpTransport distDirLayout extensionNa
       -- 2. The legacy parser failed, but the parsec parser succeeded.
       -- Report a warning to the user that this happened.
       (OldParser.ProjectParseFailed{}, Right{}) -> do
-        warn verbosity $ "The legacy parser failed, but the new parsec parser worked. This is unexpected, please report this as a bug.\nThe legacy parser will be removed in the next major version."
+        warn verbosity "The legacy parser failed, but the new parsec parser worked. This is unexpected, please report this as a bug.\nThe legacy parser will be removed in the next major version."
         liftIO $ reportParseResult verbosity extensionDescription fp lres
       -- 3. The legacy parser succeeded, but the parsec parser failed.
       -- Report a warning to the user that this happened.
       (OldParser.ProjectParseOk{}, Left{}) -> do
-        warn verbosity $ "The new parsec parser failed, but the legacy parser worked. This is unexpected, please report this as a bug.\nThe legacy parser will be removed in the next major version."
+        warn verbosity "The new parsec parser failed, but the legacy parser worked. This is unexpected, please report this as a bug.\nThe legacy parser will be removed in the next major version."
         liftIO $ reportParseResult verbosity extensionDescription fp lres
       (OldParser.ProjectParseFailed{}, Left{}) -> do
         -- 4. Both failed, report the original error. We don't check that the same errors are reported.

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1001,7 +1001,7 @@ convertToLegacySharedConfig
       commonFlags =
         mempty
           { setupVerbosity = projectConfigVerbosity
-          , setupDistPref = fmap makeSymbolicPath $ projectConfigDistDir
+          , setupDistPref = fmap makeSymbolicPath projectConfigDistDir
           , setupKeepTempFiles = projectConfigKeepTempFiles
           }
 
@@ -1200,13 +1200,13 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , configSplitObjs = packageConfigSplitObjs
         , configStripExes = packageConfigStripExes
         , configStripLibs = packageConfigStripLibs
-        , configExtraLibDirs = fmap makeSymbolicPath $ packageConfigExtraLibDirs
-        , configExtraLibDirsStatic = fmap makeSymbolicPath $ packageConfigExtraLibDirsStatic
-        , configExtraFrameworkDirs = fmap makeSymbolicPath $ packageConfigExtraFrameworkDirs
+        , configExtraLibDirs = fmap makeSymbolicPath packageConfigExtraLibDirs
+        , configExtraLibDirsStatic = fmap makeSymbolicPath packageConfigExtraLibDirsStatic
+        , configExtraFrameworkDirs = fmap makeSymbolicPath packageConfigExtraFrameworkDirs
         , configConstraints = mempty
         , configDependencies = mempty
         , configPromisedDependencies = mempty
-        , configExtraIncludeDirs = fmap makeSymbolicPath $ packageConfigExtraIncludeDirs
+        , configExtraIncludeDirs = fmap makeSymbolicPath packageConfigExtraIncludeDirs
         , configIPID = mempty
         , configCID = mempty
         , configDeterministic = mempty

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -1131,7 +1131,8 @@ printPlan
       showPkgAndReason :: ElaboratedReadyPackage -> String
       showPkgAndReason (ReadyPackage elab) =
         unwords $
-          filter (not . null) $
+          filter
+            (not . null)
             [ " -"
             , if verbosityLevel verbosity >= Deafening
                 then prettyShow (installedUnitId elab)
@@ -1188,7 +1189,7 @@ printPlan
                 (makeSymbolicPath "$builddir")
                 buildSettingKeepTempFiles
             fullConfigureFlags =
-              runIdentity $
+              runIdentity
                 ( setupHsConfigureFlags
                     (\_ -> return (error "unused"))
                     elaboratedPlan
@@ -1301,7 +1302,7 @@ writeBuildReports settings buildContext plan buildOutcomes = do
               Right br -> case buildResultTests br of
                 TestsNotTried -> BuildReports.NotTried
                 TestsOk -> BuildReports.Ok
-         in Just $ (BuildReports.BuildReport (packageId pkg) os arch (compilerId comp) cabalInstallID (elabFlagAssignment pkg) (map (packageId . fst) $ elabLibDependencies pkg) installOutcome docsOutcome testsOutcome, getRepo . elabPkgSourceLocation $ pkg) -- TODO handle failure log files?
+         in Just (BuildReports.BuildReport (packageId pkg) os arch (compilerId comp) cabalInstallID (elabFlagAssignment pkg) (map (packageId . fst) $ elabLibDependencies pkg) installOutcome docsOutcome testsOutcome, getRepo . elabPkgSourceLocation $ pkg) -- TODO handle failure log files?
       fromPlanPackage _ _ = Nothing
       buildReports = mapMaybe (\x -> fromPlanPackage x (InstallPlan.lookupBuildOutcome x buildOutcomes)) $ InstallPlan.toList plan
 

--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -285,7 +285,8 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
         sourceRepoToJ :: SourceRepoMaybe -> J.Value
         sourceRepoToJ SourceRepositoryPackage{..} =
           J.object $
-            filter ((/= J.Null) . snd) $
+            filter
+              ((/= J.Null) . snd)
               [ "type" J..= jdisplay srpType
               , "location" J..= J.String srpLocation
               , "branch" J..= fmap J.String srpBranch

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -371,7 +371,7 @@ rebuildProjectConfig
     , distProjectFile
     }
   cliConfig = do
-    progsearchpath <- liftIO $ getSystemSearchPath
+    progsearchpath <- liftIO getSystemSearchPath
 
     let fileMonitorProjectConfig = newFileMonitor (distProjectCacheFile "config")
 
@@ -404,7 +404,7 @@ rebuildProjectConfig
                 pure (os, arch, compiler)
 
           (projectConfig, compiler) <- instantiateProjectConfigSkeletonFetchingCompiler fetchCompiler mempty projectConfigSkeleton
-          when (projectConfigDistDir (projectConfigShared $ projectConfig) /= NoFlag) $
+          when (projectConfigDistDir (projectConfigShared projectConfig) /= NoFlag) $
             liftIO $
               warn verbosity "The builddir option is not supported in project and config files. It will be ignored."
           localPackages <- phaseReadLocalPackages compiler (projectConfig <> cliConfig)
@@ -526,7 +526,7 @@ configureCompiler
     } = do
     let fileMonitorCompiler = newFileMonitor $ distProjectCacheFile "compiler"
 
-    progsearchpath <- liftIO $ getSystemSearchPath
+    progsearchpath <- liftIO getSystemSearchPath
 
     (hc, plat, hcProgDb) <-
       rerunIfChanged
@@ -657,7 +657,7 @@ rebuildInstallPlan
     { cabalStoreDirLayout
     } = \projectConfig localPackages mbInstalledPackages ->
     runRebuild distProjectRootDirectory $ do
-      progsearchpath <- liftIO $ getSystemSearchPath
+      progsearchpath <- liftIO getSystemSearchPath
       let projectConfigMonitored = projectConfig{projectConfigBuildOnly = mempty}
 
       -- The overall improved plan is cached
@@ -1907,7 +1907,7 @@ elaborateInstallPlan
                 -- correctly.
                 let elab1 =
                       elab0
-                        { elabPkgOrComp = ElabComponent $ elab_comp
+                        { elabPkgOrComp = ElabComponent elab_comp
                         }
                     cid = case elabBuildStyle elab0 of
                       BuildInplaceOnly{} ->
@@ -4119,10 +4119,10 @@ setupHsConfigureFlags
 
       configConfigurationsFlags = elabFlagAssignment
       configConfigureArgs = elabConfigureScriptArgs
-      configExtraLibDirs = fmap makeSymbolicPath $ elabExtraLibDirs
-      configExtraLibDirsStatic = fmap makeSymbolicPath $ elabExtraLibDirsStatic
-      configExtraFrameworkDirs = fmap makeSymbolicPath $ elabExtraFrameworkDirs
-      configExtraIncludeDirs = fmap makeSymbolicPath $ elabExtraIncludeDirs
+      configExtraLibDirs = fmap makeSymbolicPath elabExtraLibDirs
+      configExtraLibDirsStatic = fmap makeSymbolicPath elabExtraLibDirsStatic
+      configExtraFrameworkDirs = fmap makeSymbolicPath elabExtraFrameworkDirs
+      configExtraIncludeDirs = fmap makeSymbolicPath elabExtraIncludeDirs
       configProgPrefix = maybe mempty toFlag elabProgPrefix
       configProgSuffix = maybe mempty toFlag elabProgSuffix
 

--- a/cabal-install/src/Distribution/Client/Security/HTTP.hs
+++ b/cabal-install/src/Distribution/Client/Security/HTTP.hs
@@ -197,7 +197,6 @@ wrapCustomEx
   -> (HC.Throws HC.SomeRemoteError => IO a)
 wrapCustomEx act =
   HC.handleChecked (\(ex :: UnexpectedResponse) -> go ex) $
-    HC.handleChecked (\(ex :: IOException) -> go ex) $
-      act
+    HC.handleChecked (\(ex :: IOException) -> go ex) act
   where
     go ex = HC.throwChecked (HC.SomeRemoteError ex)

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1062,7 +1062,7 @@ relaxDepsParser = do
 relaxDepsPrinter :: (Maybe RelaxDeps) -> [Maybe String]
 relaxDepsPrinter Nothing = []
 relaxDepsPrinter (Just RelaxDepsAll) = [Nothing]
-relaxDepsPrinter (Just (RelaxDepsSome pkgs)) = map (Just . prettyShow) $ pkgs
+relaxDepsPrinter (Just (RelaxDepsSome pkgs)) = map (Just . prettyShow) pkgs
 
 instance Monoid ConfigExFlags where
   mempty = gmempty
@@ -1117,8 +1117,7 @@ buildCommand =
             ++ "Affected by configuration options, see `v1-configure`.\n"
     , commandDefaultFlags = commandDefaultFlags parent
     , commandUsage =
-        usageAlternatives "v1-build" $
-          ["[FLAGS]", "COMPONENTS [FLAGS]"]
+        usageAlternatives "v1-build" ["[FLAGS]", "COMPONENTS [FLAGS]"]
     , commandOptions = commandOptions parent
     , commandNotes = Just $ \pname ->
         "Examples:\n"
@@ -2428,8 +2427,7 @@ haddockCommand :: CommandUI HaddockFlags
 haddockCommand =
   Cabal.haddockCommand
     { commandUsage =
-        usageAlternatives "v1-haddock" $
-          ["[FLAGS]", "COMPONENTS [FLAGS]"]
+        usageAlternatives "v1-haddock" ["[FLAGS]", "COMPONENTS [FLAGS]"]
     }
 
 filterHaddockArgs :: [String] -> Version -> [String]
@@ -3354,7 +3352,8 @@ copyCommand =
           ++ " v1-copy foo       "
           ++ "    A component (i.e. lib, exe, test suite)"
     , commandUsage =
-        usageAlternatives "v1-copy" $
+        usageAlternatives
+          "v1-copy"
           [ "[FLAGS]"
           , "COMPONENTS [FLAGS]"
           ]

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -1037,7 +1037,7 @@ getExternalSetupMethod verbosity options pkg bt = do
                 debug verbosity $
                   "Found cached setup executable: " ++ cachedSetupProgFile
               else do
-                debug verbosity $ "Setup executable not found in the cache."
+                debug verbosity "Setup executable not found in the cache."
                 src <-
                   compileSetupExecutable
                     options'
@@ -1122,9 +1122,9 @@ getExternalSetupMethod verbosity options pkg bt = do
                     ghcOptVerbosity = Flag (min (verbosityLevel verbosity) Normal)
                   , ghcOptMode = Flag GhcModeMake
                   , ghcOptInputFiles = toNubListR [setupHs]
-                  , ghcOptOutputFile = Flag $ setupProgFile
-                  , ghcOptObjDir = Flag $ setupDir
-                  , ghcOptHiDir = Flag $ setupDir
+                  , ghcOptOutputFile = Flag setupProgFile
+                  , ghcOptObjDir = Flag setupDir
+                  , ghcOptHiDir = Flag setupDir
                   , ghcOptSourcePathClear = Flag True
                   , ghcOptSourcePath = case bt of
                       Custom -> toNubListR [sameDirectory]

--- a/cabal-install/src/Distribution/Client/SourceFiles.hs
+++ b/cabal-install/src/Distribution/Client/SourceFiles.hs
@@ -186,7 +186,7 @@ needBuildInfo pkg_descr bi modules = do
       , map getSymbolicPath $ jsSources bi
       , map getSymbolicPath $ cmmSources bi
       , map getSymbolicPath $ asmSources bi
-      , map getSymbolicPath $ expandedExtraSrcFiles
+      , map getSymbolicPath expandedExtraSrcFiles
       ]
   for_ (fmap getSymbolicPath $ installIncludes bi) $ \f ->
     findFileMonitored ("." : fmap getSymbolicPath (includeDirs bi)) f

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -304,7 +304,7 @@ filePathToByteString p =
     conv :: Word32 -> [Word8] -> [Word8]
     conv w32 rest = b0 : b1 : b2 : b3 : rest
       where
-        b0 = fromIntegral $ w32
+        b0 = fromIntegral w32
         b1 = fromIntegral $ w32 `shiftR` 8
         b2 = fromIntegral $ w32 `shiftR` 16
         b3 = fromIntegral $ w32 `shiftR` 24

--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -600,7 +600,7 @@ vcsGit =
         git localDir $ ["submodule", "update", "--force", "--init", "--recursive"] ++ verboseArg
         git localDir $ ["submodule", "foreach", "--recursive"] ++ verboseArg ++ ["git clean -ffxdq"]
 
-      git localDir $ ["clean", "-ffxdq"]
+      git localDir ["clean", "-ffxdq"]
       where
         git :: FilePath -> [String] -> IO ()
         git cwd args =

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -144,12 +144,16 @@ tests config =
   -- TODO: tests for:
   -- \* normal success
   -- \* dry-run tests with changes
-  [ sequentialTestGroup "Discovery and planning" AllFinish $
+  [ sequentialTestGroup
+      "Discovery and planning"
+      AllFinish
       [ testCase "no package" (testExceptionInFindingPackage config)
       , testCase "no package2" (testExceptionInFindingPackage2 config)
       , testCase "proj conf1" (testExceptionInProjectConfig config)
       ]
-  , sequentialTestGroup "Target selectors" AllFinish $
+  , sequentialTestGroup
+      "Target selectors"
+      AllFinish
       [ testCaseSteps "valid" testTargetSelectors
       , testCase "bad syntax" testTargetSelectorBadSyntax
       , testCaseSteps "ambiguous syntax" testTargetSelectorAmbiguous
@@ -166,7 +170,9 @@ tests config =
       , testCaseSteps "problems (bench)" (testTargetProblemsBench config)
       , testCaseSteps "problems (haddock)" (testTargetProblemsHaddock config)
       ]
-  , sequentialTestGroup "Exceptions during building (local inplace)" AllFinish $
+  , sequentialTestGroup
+      "Exceptions during building (local inplace)"
+      AllFinish
       [ testCase "configure" (testExceptionInConfigureStep config)
       , testCase "build" (testExceptionInBuildStep config)
       --    , testCase "register"   testExceptionInRegisterStep
@@ -185,13 +191,17 @@ tests config =
           else
             [ testCase "local tarball" (testBuildLocalTarball config)
             ]
-  , sequentialTestGroup "Regression tests" AllFinish $
+  , sequentialTestGroup
+      "Regression tests"
+      AllFinish
       [ testCase "issue #3324" (testRegressionIssue3324 config)
       , testCase "program options scope all" (testProgramOptionsAll config)
       , testCase "program options scope local" (testProgramOptionsLocal config)
       , testCase "program options scope specific" (testProgramOptionsSpecific config)
       ]
-  , sequentialTestGroup "Flag tests" AllFinish $
+  , sequentialTestGroup
+      "Flag tests"
+      AllFinish
       [ testCase "Test Config options for commented options" testConfigOptionComments
       , testCase "Test Ignore Project Flag" testIgnoreProjectFlag
       ]

--- a/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
@@ -30,10 +30,10 @@ tests =
       [ testCase "handles an empty package list" testEmpty
       , testCase "passes an unpacked local package through" testPassLocalPackage
       , testCase "handles http" testHttp
-      , testCase "aborts on interrupt in GET" $ testGetInterrupt
-      , testCase "aborts on other exception in GET" $ testGetException
-      , testCase "aborts on interrupt in GET (uncollected download)" $ testUncollectedInterrupt
-      , testCase "continues on other exception in GET (uncollected download)" $ testUncollectedException
+      , testCase "aborts on interrupt in GET" testGetInterrupt
+      , testCase "aborts on other exception in GET" testGetException
+      , testCase "aborts on interrupt in GET (uncollected download)" testUncollectedInterrupt
+      , testCase "continues on other exception in GET (uncollected download)" testUncollectedException
       ]
   ]
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
@@ -40,7 +40,8 @@ tests =
       ]
   , askOption $ \(RunNetworkTests doRunNetTests) ->
       testGroup "forkPackages, network tests" $
-        includeTestsIf doRunNetTests $
+        includeTestsIf
+          doRunNetTests
           [ testCase "git clone" testNetworkGitClone
           ]
   ]

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
@@ -1427,7 +1427,7 @@ cliListParserTests =
         flags <- runParserTest ["--extra-doc-file", "README"]
         flags
           @?= emptyFlags
-            { extraDoc = Flag $ ["README"]
+            { extraDoc = Flag ["README"]
             }
     , testCase "Multiple extraDoc" $ do
         flags <-

--- a/cabal-install/tests/UnitTests/Distribution/Client/Tar.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Tar.hs
@@ -47,8 +47,7 @@ filterTest = do
           Next e2 Done
   assertEqual "Unexpected result for filter" "z" $
     entriesToString $
-      filterEntries p $
-        Done
+      filterEntries p Done
   assertEqual "Unexpected result for filter" "xf" $
     entriesToString $
       filterEntries p $
@@ -72,7 +71,7 @@ filterMTest = do
   assertEqual "Unexpected result for filterM" "xz" $ entriesToString r
   assertEqual "Unexpected result for filterM w" "tt" w
 
-  (r1, w1) <- runWriterT $ filterEntriesM p $ Done
+  (r1, w1) <- runWriterT $ filterEntriesM p Done
   assertEqual "Unexpected result for filterM" "z" $ entriesToString r1
   assertEqual "Unexpected result for filterM w" "" w1
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -1068,7 +1068,7 @@ vcsTestDriverPijul
       , vcsRepoRoot = repoRoot
       , vcsIgnoreFiles = Set.empty
       , vcsInit =
-          pijul $ ["init"]
+          pijul ["init"]
       , vcsAddFile = \_ filename ->
           pijul ["add", filename]
       , vcsSubmoduleDriver = \_ ->
@@ -1076,7 +1076,7 @@ vcsTestDriverPijul
       , vcsAddSubmodule = \_ _ _ ->
           fail "vcsAddSubmodule: pijul does not support submodules"
       , vcsCommitChanges = \_state -> do
-          pijul $
+          pijul
             [ "record"
             , "-a"
             , "-m 'a patch'"
@@ -1092,9 +1092,9 @@ vcsTestDriverPijul
       , vcsSwitchBranch = \_ branchname -> do
           --        unless (branchname `Map.member` allBranches) $
           --          pijul ["from-branch", branchname]
-          pijul $ ["checkout", branchname]
+          pijul ["checkout", branchname]
       , vcsCheckoutTag = Left $ \tagname ->
-          pijul $ ["checkout", tagname]
+          pijul ["checkout", tagname]
       }
     where
       gitInvocation args =

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -182,8 +182,8 @@ tests =
       , runTest $ mkTest db9 "setupDeps7" ["F", "G"] (solverSuccess [("A", 1), ("B", 1), ("B", 2), ("C", 1), ("D", 1), ("E", 1), ("E", 2), ("F", 1), ("G", 1)])
       , runTest $ mkTest db10 "setupDeps8" ["C"] (solverSuccess [("C", 1)])
       , runTest $ indep $ mkTest dbSetupDeps "setupDeps9" ["A", "B"] (solverSuccess [("A", 1), ("B", 1), ("C", 1), ("D", 1), ("D", 2)])
-      , runTest $ setupStanzaTest1
-      , runTest $ setupStanzaTest2
+      , runTest setupStanzaTest1
+      , runTest setupStanzaTest2
       ]
   , testGroup
       "Base shim"
@@ -434,8 +434,7 @@ tests =
          in runTest $
               mkTest db "reject package that is missing required sub-library" ["A"] $
                 solverFailure $
-                  isInfixOf $
-                    "rejecting: B-1.0.0 (does not contain library 'sub-lib', which is required by A)"
+                  isInfixOf "rejecting: B-1.0.0 (does not contain library 'sub-lib', which is required by A)"
       , let db =
               [ Right $ exAv "A" 1 [ExSubLibAny "B" "sub-lib"]
               , Right $ exAvNoLibrary "B" 1 `withSubLibrary` exSubLib "sub-lib" []
@@ -443,8 +442,7 @@ tests =
          in runTest $
               mkTest db "reject package with private but required sub-library" ["A"] $
                 solverFailure $
-                  isInfixOf $
-                    "rejecting: B-1.0.0 (library 'sub-lib' is private, but it is required by A)"
+                  isInfixOf "rejecting: B-1.0.0 (library 'sub-lib' is private, but it is required by A)"
       , let db =
               [ Right $ exAv "A" 1 [ExSubLibAny "B" "sub-lib"]
               , Right $
@@ -455,8 +453,7 @@ tests =
               constraints [ExFlagConstraint (ScopeAnyQualifier "B") "make-lib-private" True] $
                 mkTest db "reject package with sub-library made private by flag constraint" ["A"] $
                   solverFailure $
-                    isInfixOf $
-                      "rejecting: B-1.0.0 (library 'sub-lib' is private, but it is required by A)"
+                    isInfixOf "rejecting: B-1.0.0 (library 'sub-lib' is private, but it is required by A)"
       , let db =
               [ Right $ exAv "A" 1 [ExSubLibAny "B" "sub-lib"]
               , Right $
@@ -481,8 +478,7 @@ tests =
               goalOrder goals $
                 mkTest db "reject package that requires a private sub-library" ["A", "C"] $
                   solverFailure $
-                    isInfixOf $
-                      "rejecting: C-1.0.0 (requires library 'sub-lib' from B, but the component is private)"
+                    isInfixOf "rejecting: C-1.0.0 (requires library 'sub-lib' from B, but the component is private)"
       , let db =
               [ Right $ exAv "A" 1 [ExSubLibAny "B" "sub-lib-v1"]
               , Right $ exAv "B" 2 [] `withSubLibrary` ExSubLib "sub-lib-v2" publicDependencies
@@ -1782,8 +1778,7 @@ twoLevelDeepCommonDependencyLogMessage :: String -> SolverTest
 twoLevelDeepCommonDependencyLogMessage name =
   mkTest db name ["A"] $
     solverFailure $
-      isInfixOf $
-        "unknown package: B (dependency of A +/-flagA +/-flagB)"
+      isInfixOf "unknown package: B (dependency of A +/-flagA +/-flagB)"
   where
     db :: ExampleDb
     db =

--- a/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
@@ -28,9 +28,9 @@ main = setupAndCabalTest $ do
     withPackageDb $ do
         -- MULTI
         forM_ [False, True] $ \is_dynamic -> do
-            setup_install $ [ if is_dynamic then "--enable-executable-dynamic"
-                                            else "--disable-executable-dynamic"
-                            , "--enable-shared"]
+            setup_install [ if is_dynamic then "--enable-executable-dynamic"
+                                          else "--disable-executable-dynamic"
+                          , "--enable-shared"]
             dist_dir <- fmap testDistDir getTestEnv
             lbi <- liftIO $
                      getPersistBuildConfig

--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
@@ -75,7 +75,7 @@ main = cabalTest $ do
                             cabal "v2-install" $ "--force-reinstalls" : installOptions
                         let exIPID s = takeWhile (/= '\n') . head . filter (\t -> any (`isPrefixOf` t) ["basic-0.1-", "bsc-0.1-"]) $ tails s
                         hashedIpid <- exIPID <$> liftIO (readFile packageEnv)
-                        return $ ((idx, linking), hashedIpid)
+                        return ((idx, linking), hashedIpid)
         -- Phase 2: make sure we have different hashes iff we have different config flags.
         -- In particular make sure the dynamic config flags weren't silently
         -- dropped and ignored, since this is the bug that prompted this test.

--- a/cabal-testsuite/PackageTests/TestCodeGenerator/test-code-gen/app/Main.hs
+++ b/cabal-testsuite/PackageTests/TestCodeGenerator/test-code-gen/app/Main.hs
@@ -8,8 +8,8 @@ main = do
   let (srcDirs, ghcArgs) = splitArgs rest
   let isGood = srcDirs == ["."] && "-outputdir" `elem` ghcArgs
   if isGood
-   then writeFile (tgt </> "Main.hs") $ "module Main where main = pure ()"
-   else writeFile (tgt </> "Main.hs") $ "module Main where main = error \"failure\""
+   then writeFile (tgt </> "Main.hs") "module Main where main = pure ()"
+   else writeFile (tgt </> "Main.hs") "module Main where main = error \"failure\""
 
 splitArgs = go []
   where

--- a/cabal-testsuite/PackageTests/TestNameCollision/child/tests/Test.hs
+++ b/cabal-testsuite/PackageTests/TestNameCollision/child/tests/Test.hs
@@ -4,7 +4,7 @@ import Distribution.TestSuite
 import Child
 
 tests :: IO [Test]
-tests = return $ [Test $ TestInstance
+tests = return [Test $ TestInstance
           { run = return (Finished Pass)
           , name = "test"
           , tags = []

--- a/cabal-testsuite/PackageTests/UniqueIPID/setup.test.hs
+++ b/cabal-testsuite/PackageTests/UniqueIPID/setup.test.hs
@@ -12,5 +12,5 @@ main = setupAndCabalTest $ do
             withDirectory "P2" $ setup "build" []
             r2 <- withDirectory "P2" $ setup' "register" ["--print-ipid", "--inplace"]
             let exIPID s = takeWhile (/= '\n') $
-                     head . filter (isPrefixOf $ "UniqueIPID-0.1-") $ (tails s)
+                     head . filter (isPrefixOf "UniqueIPID-0.1-") $ (tails s)
             assertNotEqual "ipid match" (exIPID $ resultOutput r1) (exIPID $ resultOutput r2)

--- a/cabal-testsuite/PackageTests/WithRepl/WithExe/Main.hs
+++ b/cabal-testsuite/PackageTests/WithRepl/WithExe/Main.hs
@@ -1,4 +1,4 @@
 import ModuleA
 
 main :: IO ()
-main = print $ "My specific executable"
+main = print "My specific executable"

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -708,7 +708,7 @@ mkNormalizerEnv = do
         (programPath ghc_pkg_program)
         ["list", "--global", "--simple-output"]
         ""
-  tmpDir <- liftIO $ getTemporaryDirectory
+  tmpDir <- liftIO getTemporaryDirectory
 
   canonicalizedTestTmpDir <- liftIO $ canonicalizePath (testTmpDir env)
   canonicalizedGblDir <- liftIO $ canonicalizePath tmpDir

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -729,8 +729,8 @@ withRemoteRepo repoDir m = do
             archiveTo srcPath (destPath <.> "tar.gz")
 
   -- 3. Create keys and bootstrap repository
-  hackageRepoTool "create-keys" $ ["--keys", keysDir]
-  hackageRepoTool "bootstrap" $ ["--keys", keysDir, "--repo", workDir]
+  hackageRepoTool "create-keys" ["--keys", keysDir]
+  hackageRepoTool "bootstrap" ["--keys", keysDir, "--repo", workDir]
 
   -- 4. Wire it up in .cabal/config
   let package_cache = testCabalDir env </> "packages"

--- a/cabal-testsuite/src/Test/Cabal/Script.hs
+++ b/cabal-testsuite/src/Test/Cabal/Script.hs
@@ -93,7 +93,7 @@ runnerCommand
   -> IO (FilePath, [String])
 runnerCommand senv mb_cwd _env_overrides script_path args = do
   (prog, _) <- requireProgram verbosity runghcProgram (runnerProgramDb senv)
-  return $
+  return
     ( programPath prog
     , runghc_args ++ ["--"] ++ map ("--ghc-arg=" ++) ghc_args ++ [script_path] ++ args
     )

--- a/cabal-testsuite/src/Test/Cabal/Server.hs
+++ b/cabal-testsuite/src/Test/Cabal/Server.hs
@@ -168,14 +168,14 @@ runOnServer s mb_cwd env_overrides script_path args = do
       write s $ ":load " ++ script_path
       -- Create a ref which will record the exit status of the command
       -- NB: do this after :load so it doesn't get dropped
-      write s $ "ref <- Data.IORef.newIORef Test.Cabal.TestCode.TestCodeFail"
+      write s "ref <- Data.IORef.newIORef Test.Cabal.TestCode.TestCodeFail"
       -- TODO: What if an async exception gets raised here?  At the
       -- moment, there is no way to recover until we get to the top-level
       -- bracket; then stopServer which correctly handles this case.
       -- If you do want to be able to abort this computation but KEEP
       -- USING THE SERVER SESSION, you will need to have a lot more
       -- sophisticated logic.
-      write s $ "Test.Cabal.Server.runMain ref Main.main"
+      write s "Test.Cabal.Server.runMain ref Main.main"
       -- Output end sigil.
       -- NB: We're line-oriented, so we MUST add an extra newline
       -- to ensure that we see the end sigil.
@@ -303,7 +303,7 @@ stopServer s = do
 
   let hardKiller = do
         threadDelay 2000000 -- 2sec
-        log ServerMeta s $ "Terminating..."
+        log ServerMeta s "Terminating..."
         terminateProcess (serverProcessHandle s)
       softKiller = do
         -- Ask to quit.  If we're in the middle of a computation,
@@ -319,7 +319,7 @@ stopServer s = do
         -- flushed.
         interruptProcessGroupOf (serverProcessHandle s)
 
-        log ServerMeta s $ "Waiting..."
+        log ServerMeta s "Waiting..."
         -- Close input BEFORE waiting, close output AFTER waiting.
         -- If you get either order wrong, deadlock!
         ignoreSigPipe $ hClose (serverStdin s)
@@ -337,10 +337,10 @@ stopServer s = do
     withAsync (drain serverStderr) $ \a_err -> do
       r <- case mb_exit of
         Nothing -> do
-          log ServerMeta s $ "Terminating GHCi"
+          log ServerMeta s "Terminating GHCi"
           race hardKiller softKiller
         Just exit -> do
-          log ServerMeta s $ "GHCi died unexpectedly"
+          log ServerMeta s "GHCi died unexpectedly"
           return (Right exit)
 
       -- Drain the output buffers
@@ -365,7 +365,7 @@ stopServer s = do
                 else ""
         else log ServerOut s rest_out
 
-      log ServerMeta s $ "Done"
+      log ServerMeta s "Done"
       return ()
   where
     verbosity = runnerVerbosity (serverScriptEnv s)
@@ -400,7 +400,7 @@ info ctor s msg =
 -- | Write a string to the prompt of the GHCi server.
 write :: Server -> String -> IO ()
 write s msg = do
-  log ServerIn s $ msg
+  log ServerIn s msg
   hPutStrLn (serverStdin s) msg
   hFlush (serverStdin s) -- line buffering should get it, but just for good luck
 


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "redundant $" suggestion so that this will be suggested by our CI linting.

In `ParserTests`, I've been able to rearrange the `-XCPP` code to also remove the `{- FOURMOLU_DISABLE -}` comments.

> [!NOTE]
> There are a lot of changes (sorry about that) but these should be easy to review.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
