### PR TITLE
remove datestamp from bootstrap cache keys

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -32,6 +32,8 @@ jobs:
           rm -rf ~/.config/cabal
           rm -rf ~/.cache/cabal
 
+      - uses: actions/checkout@v6
+
       # runner.os isn't sufficient for binary compatible caches
       - name: Get runner OS/version for cache keys
         id: get-osver
@@ -42,10 +44,9 @@ jobs:
         id: bootstrap-cache
         with:
           path: "/home/runner/work/cabal/cabal/_build"
-          key: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-20221115-${{ github.sha }}
-          restore-keys: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-20221115-
+          key: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-${{ hashFiles(format('bootstrap/linux-{0}.json', matrix.ghc)) }}-${{ github.sha }}
+          restore-keys: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-${{ hashFiles(format('bootstrap/linux-{0}.json', matrix.ghc)) }}-
 
-      - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
The intent behind the datestamps was to avoid accumulating out of date source tarballs — which we've been doing since 2022, because nobody's been updating it.

Use a hash computed from the bootstrap JSONs instead, which will be self-updating.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
