### PR TITLE
Fix typo explitic

### DIFF
--- a/.typos-docs.toml
+++ b/.typos-docs.toml
@@ -2,6 +2,7 @@
 extend-exclude = [
     "changelog.d/pr-11501.md",
     "changelog.d/pr-11602.md",
+    "changelog.d/pr-11621.md",
 ]
 
 [default]

--- a/.typos-srcs.toml
+++ b/.typos-srcs.toml
@@ -58,4 +58,3 @@ fo = "fo"
 nto = "nto" # nto-qnx operating system
 dows = "dows" # win-dows
 bimap = "bimap"
-explitic = "explitic"

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -537,7 +537,7 @@ checkPackageDescription
       ( isNothing setupBuildInfo_
           && buildTypeRaw_ == Just Custom
       )
-      (PackageDistSuspiciousWarn CVExpliticDepsCustomSetup)
+      (PackageDistSuspiciousWarn CVExplicitDepsCustomSetup)
     checkP
       (isNothing buildTypeRaw_ && specVersion_ < CabalSpecV2_2)
       (PackageBuildWarning NoBuildType)

--- a/Cabal/src/Distribution/PackageDescription/Check/Warning.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Warning.hs
@@ -245,7 +245,7 @@ data CheckExplanation
   | CVSourceRepository
   | CVExtensions CabalSpecVersion [Extension]
   | CVCustomSetup
-  | CVExpliticDepsCustomSetup
+  | CVExplicitDepsCustomSetup
   | CVAutogenPaths
   | CVAutogenPackageInfo
   | CVAutogenPackageInfoGuard
@@ -413,7 +413,7 @@ data CheckExplanationID
   | CICVSourceRepository
   | CICVExtensions
   | CICVCustomSetup
-  | CICVExpliticDepsCustomSetup
+  | CICVExplicitDepsCustomSetup
   | CICVAutogenPaths
   | CICVAutogenPackageInfo
   | CICVAutogenPackageInfoGuard
@@ -560,7 +560,7 @@ checkExplanationId (CVVirtualModules{}) = CICVVirtualModules
 checkExplanationId (CVSourceRepository{}) = CICVSourceRepository
 checkExplanationId (CVExtensions{}) = CICVExtensions
 checkExplanationId (CVCustomSetup{}) = CICVCustomSetup
-checkExplanationId (CVExpliticDepsCustomSetup{}) = CICVExpliticDepsCustomSetup
+checkExplanationId (CVExplicitDepsCustomSetup{}) = CICVExplicitDepsCustomSetup
 checkExplanationId (CVAutogenPaths{}) = CICVAutogenPaths
 checkExplanationId (CVAutogenPackageInfo{}) = CICVAutogenPackageInfo
 checkExplanationId (CVAutogenPackageInfoGuard{}) = CICVAutogenPackageInfoGuard
@@ -714,7 +714,7 @@ ppCheckExplanationId CICVVirtualModules = "virtual-modules"
 ppCheckExplanationId CICVSourceRepository = "source-repository"
 ppCheckExplanationId CICVExtensions = "incompatible-extension"
 ppCheckExplanationId CICVCustomSetup = "no-setup-depends"
-ppCheckExplanationId CICVExpliticDepsCustomSetup = "dependencies-setup"
+ppCheckExplanationId CICVExplicitDepsCustomSetup = "dependencies-setup"
 ppCheckExplanationId CICVAutogenPaths = "no-autogen-paths"
 ppCheckExplanationId CICVAutogenPackageInfo = "no-autogen-pinfo"
 ppCheckExplanationId CICVAutogenPackageInfoGuard = "autogen-guard"
@@ -1258,7 +1258,7 @@ ppExplanation CVCustomSetup =
     ++ "that specifies the dependencies of the Setup.hs script itself. "
     ++ "The 'setup-depends' field uses the same syntax as 'build-depends', "
     ++ "so a simple example would be 'setup-depends: base, Cabal'."
-ppExplanation CVExpliticDepsCustomSetup =
+ppExplanation CVExplicitDepsCustomSetup =
   "From version 1.24 cabal supports specifying explicit dependencies "
     ++ "for Custom setup scripts. Consider using 'cabal-version: 1.24' or "
     ++ "higher and adding a 'custom-setup' section with a 'setup-depends' "

--- a/changelog.d/pr-11621.md
+++ b/changelog.d/pr-11621.md
@@ -1,0 +1,8 @@
+---
+synopsis: Fix typos explitic
+packages: [Cabal]
+prs: 11621
+---
+
+Changes `CheckExplanation` constructor `CVExpliticDepsCustomSetup` and
+`CheckExplanationID` constructor `CICVExpliticDepsCustomSetup`.


### PR DESCRIPTION
A follow on from #11501. This changes a couple of data constructors in `Cabal`.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)