### PR TITLE
Update semaphore-compat to 2.0.0.0 to fix #9993

### DIFF
--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -86,6 +86,7 @@ module Distribution.Simple.Compiler
   , libraryDynDirSupported
   , libraryVisibilitySupported
   , jsemSupported
+  , jsemVersion
   , reexportedAsSupported
 
     -- * Support for profiling detail levels
@@ -479,6 +480,15 @@ jsemSupported comp = case compilerFlavor comp of
   _ -> False
   where
     v = compilerVersion comp
+
+-- | What semaphore protocol version does this compiler use?
+--
+-- Returns @Nothing@ for compilers that don't report a "Semaphore version"
+-- field in @ghc --info@ (i.e. GHC 9.8–9.14, which use v1).
+jsemVersion :: Compiler -> Maybe Int
+jsemVersion comp = case compilerFlavor comp of
+  GHC -> Map.lookup "Semaphore version" (compilerProperties comp) >>= readMaybe
+  _ -> Nothing
 
 -- | Does the compiler support the -reexported-modules "A as B" syntax
 reexportedAsSupported :: Compiler -> Bool

--- a/bootstrap/linux-9.10.3.json
+++ b/bootstrap/linux-9.10.3.json
@@ -95,22 +95,18 @@
         {
             "package": "parsec",
             "version": "3.1.18.0"
-        },
-        {
-            "package": "semaphore-compat",
-            "version": "1.0.0"
         }
     ],
     "dependencies": [
         {
-            "cabal_sha256": "f6fde8ff59e7e38f9e95eca8f5154fb611c9789d1d9538aa9745c6c3cd9495b4",
+            "cabal_sha256": "8db1ce2ae03edd217c408206980e8b3fce7f00b9d4b99f3e3e83b35525d94074",
             "component": "exe:alex",
             "flags": [],
             "package": "alex",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a5cd52e2dd2837138523e2e24ec3435b8cf2624afd50725105e644226e0b9ec6",
-            "version": "3.5.3.0"
+            "src_sha256": "df481dc960e2c59a30395f7335031fd4ef8773b8a42894a4f2320e00ff474418",
+            "version": "3.5.4.2"
         },
         {
             "cabal_sha256": null,
@@ -123,7 +119,7 @@
             "version": "3.17.0.0"
         },
         {
-            "cabal_sha256": "9e9590572cc6bdb0d7ccb8835f7f9302f1c11a36c972a4c4a97aeb789be42cd9",
+            "cabal_sha256": "8526e690c91e9ef812d49f84f7f41c79bb4b692a55e399e4b8464687017f0342",
             "component": "lib:process",
             "flags": [
                 "+os-string"
@@ -131,8 +127,8 @@
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "da03911abf6bbdc68342f8f25698b0d3780964ed591f1c7d7f9b688c1097fda1",
-            "version": "1.6.26.0"
+            "src_sha256": "579d57cf0c7bceb3104c13ec452114a1e479cc718684ca018b322742b79e4cb4",
+            "version": "1.6.29.0"
         },
         {
             "cabal_sha256": null,
@@ -169,7 +165,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "e3a1ec8b8dd32f1d5a541679a67de60d6626487a95f20c6bc245268ae7142ab7",
+            "cabal_sha256": "c6f02f2626d1d83b3e3521fc2a9832c366e31dd391cb8478bd2d83528459e786",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -177,18 +173,18 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "68548e660632a3c09b230c33fe08cc880273372b485e65cbe7a717936de9728b",
-            "version": "3.2.7.0"
+            "src_sha256": "51788e5eeb7d77264f260acd48df8055a4dbc2477e8d634a8493677bb15c5fc8",
+            "version": "3.2.8.0"
         },
         {
-            "cabal_sha256": "e83d97946f84fe492762ceb3b4753b4770c78b0b70e594078700baa91a5106c2",
+            "cabal_sha256": "449be09a4e3f46ea4645700c026624c4b6f066f508187326c284dbdea8884bc9",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b781a0c059872bc95406d00e98f6fa7d9e81e744730f75186583cb4dcea0a4eb",
-            "version": "0.1.6"
+            "src_sha256": "9e26f12230d38ae56dcf94f8c139799dc3b7376f3434d35ce74847a0a24fd5ff",
+            "version": "0.1.7"
         },
         {
             "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
@@ -201,47 +197,59 @@
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "ad36c6a1b3bc203b02751c8bffae8a684cc755661a2a567362cd4a0da1193c5e",
+            "cabal_sha256": "4cf03628597ffc2f3760e3da25dee116a64cfea26013d75dc386c98aecea5f6e",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
-                "+network-uri",
                 "-warn-as-error",
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 6,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
+            "src_sha256": "d2a33bc281327d8f20afee18287c2e3f923f0cd86bac40dcba120ca3d2014f9b",
+            "version": "4000.5.0"
         },
         {
-            "cabal_sha256": "2f23146cbe0325029927b221647695a4c7d6e97548ff731110979e34361f58ef",
+            "cabal_sha256": "140fc5adad166f7b527567cbd26ff481e8da4a66bdfc84be3ddf28dbeb66f275",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
                 "-random-initial-seed"
             ],
             "package": "hashable",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
-            "version": "1.5.0.0"
+            "src_sha256": "ed0b7c10ce92c9ffe45420dadc38c6d39db486ff3633ff13567cc9f75f79b112",
+            "version": "1.5.1.0"
         },
         {
-            "cabal_sha256": "e2a877717968edf1e2c91312fefd4fd53f4e49b27a421f98452b29a9256cad2a",
+            "cabal_sha256": "c5de1fb3377ed3c5f4cd851a771d1acc5c37d2f6bef0a499295c0e8857da5605",
+            "component": "lib:unordered-containers",
+            "flags": [
+                "-debug"
+            ],
+            "package": "unordered-containers",
+            "revision": 2,
+            "source": "hackage",
+            "src_sha256": "3b2ad1522b546e61960153257d1e5d239eeec5e83da847d5cb4d896a5bb7f9c0",
+            "version": "0.2.21"
+        },
+        {
+            "cabal_sha256": "45d5587d8a348a7e2b3f04de963fe633db49b49cde10ca1e6f834bef3baecee9",
             "component": "lib:async",
             "flags": [
-                "-bench"
+                "-bench",
+                "-debug-auto-label"
             ],
             "package": "async",
-            "revision": 4,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
+            "src_sha256": "148571bc188003101241da6c49131d07324e63a88ed283a84def2e9694599619",
+            "version": "2.2.6"
         },
         {
-            "cabal_sha256": "81a105aed2ee2f5e479448e44252b24cdfacf81a5a2106aabdd217bad94b6f40",
+            "cabal_sha256": "51c0178c727ef4ccd694514c0a44369eb8593ae83dde42bc5fb5c89d5b4c60b5",
             "component": "lib:atomic-counter",
             "flags": [
                 "-dev",
@@ -250,8 +258,8 @@
             "package": "atomic-counter",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "ce4b63391b3c0d426cbe32af89f483222602a5b43aa5379aa720bf6f45f4cf04",
-            "version": "0.1.2.3"
+            "src_sha256": "b101e8dedc66da051a16022287d9b05c2dcb2f54f973fb09298b3486cd63ec2f",
+            "version": "0.1.2.4"
         },
         {
             "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
@@ -274,7 +282,7 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "d0002f3fb16a2cc5ba8afd47a6657726386edccfe8853d310e3479fe3b45201b",
+            "cabal_sha256": "a557cff65eed1f70f3a3b468423cd58e7a9a9564c5cc00c76a13de64dec9bcbd",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
@@ -282,8 +290,8 @@
             "package": "splitmix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b6bcd0d79bd4fe40975c8ebe803be2f3bfbf6006069a59745a325a0df3f86270",
-            "version": "0.1.3.1"
+            "src_sha256": "a61d4e8b30f5a16526d7d31171b674ae7924d2207f378060d13363bd8794de8c",
+            "version": "0.1.3.2"
         },
         {
             "cabal_sha256": "0b4f649c3e78713b2ccad1535251ee34b148237fb2229d7058c2b1d9ccc324b8",
@@ -359,7 +367,7 @@
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "b24ec42ce02c42a76732323c4e59414d9b5439ac5fa99304412719ba7f4c6a3f",
+            "cabal_sha256": "6dbfaeade84d388e9b75cdaa6ffe452a44b7f89321bd691350f41b223e2b1898",
             "component": "lib:directory-ospath-streaming",
             "flags": [
                 "+os-string"
@@ -367,43 +375,44 @@
             "package": "directory-ospath-streaming",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1ade8fbee13db15e8d22a1ecdca54794617cabc69911b51d46a65e12f4554ef7",
-            "version": "0.2.2"
+            "src_sha256": "7e86ee4f4d17c98f4943ea3e224448563870123e19a5d0d2ab4b874ef5f10f42",
+            "version": "0.3"
         },
         {
-            "cabal_sha256": "1d68a81fa684d006b1ec73836cebe3de9a54688836915fe3e56a20389846bb4e",
+            "cabal_sha256": "e896ca0207a70f04a1d4357bb031a703f79317ff973efc62817fa237c2964e5c",
             "component": "lib:file-io",
             "flags": [
+                "+long-paths",
                 "+os-string"
             ],
             "package": "file-io",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "310a19e4c792de4d30c912bc71ff3becb40818d7c796b9999bcd0979dab87d5b",
-            "version": "0.1.5"
+            "src_sha256": "8e75f8905d7c9f114e6164779e7a19ff0e2968015ecf686934e38250575dabe7",
+            "version": "0.2.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
+            "cabal_sha256": "cf2f8f91b10b635bdaa2c3010f40a5562a06ede24b92d819758e7f1b7d04f9f2",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -411,23 +420,23 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
-            "version": "0.7.1.0"
+            "src_sha256": "bf95ab01ed924be800addea195fba5ca97ec69f378368f6ff466bdc29666c1c1",
+            "version": "0.7.1.1"
         },
         {
-            "cabal_sha256": "e7289d17ca709d1acfb9bb43402ebcfe6c126eff9e0bda26beb3c687d8ac26ea",
+            "cabal_sha256": "c026577b7110184bcd8596040dd109ff815124d47bfc08be195d13ed6f1a72c0",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "-lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1def1a524cc894351e28e86a91cf2d043f18eeaba79070e1cc1304c9f79e4c17",
-            "version": "0.6.3.1"
+            "src_sha256": "bf8f97868ed5219d0a13a90fcbfad819bbeba4ab368c5cb590b57202c98768f9",
+            "version": "0.6.3.2"
         },
         {
             "cabal_sha256": null,
@@ -474,14 +483,14 @@
             "version": "0.96.0.2"
         },
         {
-            "cabal_sha256": "58a8c6f17dece62891e7534c6f033e1fb1d0685e68dbe5d4fbb71256d45c6132",
+            "cabal_sha256": "36de637c17bb3a37c8b9c1a66d5c37caa11ed8e7cb42284f0372f3d7d6cf684b",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 5,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
+            "src_sha256": "7702a48ab88b2ccbb78d4c4748f70a0bca2347b603daa2eb8ab014439d577103",
+            "version": "0.2.0.3"
         },
         {
             "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
@@ -492,6 +501,18 @@
             "source": "hackage",
             "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
             "version": "0.1.7.4"
+        },
+        {
+            "cabal_sha256": "e2eee36b01e7f686cb3d5467e649466272207be2107b19e2c781c7f17862906d",
+            "component": "lib:semaphore-compat",
+            "flags": [
+                "-build-testing"
+            ],
+            "package": "semaphore-compat",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "eaf00de15ff13e890d7d39181e5edf13dd12ae7d956b6a97df713097d89c4d62",
+            "version": "2.0.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-9.12.2.json
+++ b/bootstrap/linux-9.12.2.json
@@ -99,22 +99,18 @@
         {
             "package": "parsec",
             "version": "3.1.18.0"
-        },
-        {
-            "package": "semaphore-compat",
-            "version": "1.0.0"
         }
     ],
     "dependencies": [
         {
-            "cabal_sha256": "f6fde8ff59e7e38f9e95eca8f5154fb611c9789d1d9538aa9745c6c3cd9495b4",
+            "cabal_sha256": "8db1ce2ae03edd217c408206980e8b3fce7f00b9d4b99f3e3e83b35525d94074",
             "component": "exe:alex",
             "flags": [],
             "package": "alex",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a5cd52e2dd2837138523e2e24ec3435b8cf2624afd50725105e644226e0b9ec6",
-            "version": "3.5.3.0"
+            "src_sha256": "df481dc960e2c59a30395f7335031fd4ef8773b8a42894a4f2320e00ff474418",
+            "version": "3.5.4.2"
         },
         {
             "cabal_sha256": null,
@@ -127,7 +123,7 @@
             "version": "3.17.0.0"
         },
         {
-            "cabal_sha256": "9e9590572cc6bdb0d7ccb8835f7f9302f1c11a36c972a4c4a97aeb789be42cd9",
+            "cabal_sha256": "8526e690c91e9ef812d49f84f7f41c79bb4b692a55e399e4b8464687017f0342",
             "component": "lib:process",
             "flags": [
                 "+os-string"
@@ -135,8 +131,8 @@
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "da03911abf6bbdc68342f8f25698b0d3780964ed591f1c7d7f9b688c1097fda1",
-            "version": "1.6.26.0"
+            "src_sha256": "579d57cf0c7bceb3104c13ec452114a1e479cc718684ca018b322742b79e4cb4",
+            "version": "1.6.29.0"
         },
         {
             "cabal_sha256": null,
@@ -173,7 +169,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "e3a1ec8b8dd32f1d5a541679a67de60d6626487a95f20c6bc245268ae7142ab7",
+            "cabal_sha256": "c6f02f2626d1d83b3e3521fc2a9832c366e31dd391cb8478bd2d83528459e786",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -181,18 +177,18 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "68548e660632a3c09b230c33fe08cc880273372b485e65cbe7a717936de9728b",
-            "version": "3.2.7.0"
+            "src_sha256": "51788e5eeb7d77264f260acd48df8055a4dbc2477e8d634a8493677bb15c5fc8",
+            "version": "3.2.8.0"
         },
         {
-            "cabal_sha256": "e83d97946f84fe492762ceb3b4753b4770c78b0b70e594078700baa91a5106c2",
+            "cabal_sha256": "449be09a4e3f46ea4645700c026624c4b6f066f508187326c284dbdea8884bc9",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b781a0c059872bc95406d00e98f6fa7d9e81e744730f75186583cb4dcea0a4eb",
-            "version": "0.1.6"
+            "src_sha256": "9e26f12230d38ae56dcf94f8c139799dc3b7376f3434d35ce74847a0a24fd5ff",
+            "version": "0.1.7"
         },
         {
             "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
@@ -205,47 +201,59 @@
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "ad36c6a1b3bc203b02751c8bffae8a684cc755661a2a567362cd4a0da1193c5e",
+            "cabal_sha256": "4cf03628597ffc2f3760e3da25dee116a64cfea26013d75dc386c98aecea5f6e",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
-                "+network-uri",
                 "-warn-as-error",
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 6,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
+            "src_sha256": "d2a33bc281327d8f20afee18287c2e3f923f0cd86bac40dcba120ca3d2014f9b",
+            "version": "4000.5.0"
         },
         {
-            "cabal_sha256": "2f23146cbe0325029927b221647695a4c7d6e97548ff731110979e34361f58ef",
+            "cabal_sha256": "140fc5adad166f7b527567cbd26ff481e8da4a66bdfc84be3ddf28dbeb66f275",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
                 "-random-initial-seed"
             ],
             "package": "hashable",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
-            "version": "1.5.0.0"
+            "src_sha256": "ed0b7c10ce92c9ffe45420dadc38c6d39db486ff3633ff13567cc9f75f79b112",
+            "version": "1.5.1.0"
         },
         {
-            "cabal_sha256": "e2a877717968edf1e2c91312fefd4fd53f4e49b27a421f98452b29a9256cad2a",
+            "cabal_sha256": "c5de1fb3377ed3c5f4cd851a771d1acc5c37d2f6bef0a499295c0e8857da5605",
+            "component": "lib:unordered-containers",
+            "flags": [
+                "-debug"
+            ],
+            "package": "unordered-containers",
+            "revision": 2,
+            "source": "hackage",
+            "src_sha256": "3b2ad1522b546e61960153257d1e5d239eeec5e83da847d5cb4d896a5bb7f9c0",
+            "version": "0.2.21"
+        },
+        {
+            "cabal_sha256": "45d5587d8a348a7e2b3f04de963fe633db49b49cde10ca1e6f834bef3baecee9",
             "component": "lib:async",
             "flags": [
-                "-bench"
+                "-bench",
+                "-debug-auto-label"
             ],
             "package": "async",
-            "revision": 4,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
+            "src_sha256": "148571bc188003101241da6c49131d07324e63a88ed283a84def2e9694599619",
+            "version": "2.2.6"
         },
         {
-            "cabal_sha256": "81a105aed2ee2f5e479448e44252b24cdfacf81a5a2106aabdd217bad94b6f40",
+            "cabal_sha256": "51c0178c727ef4ccd694514c0a44369eb8593ae83dde42bc5fb5c89d5b4c60b5",
             "component": "lib:atomic-counter",
             "flags": [
                 "-dev",
@@ -254,8 +262,8 @@
             "package": "atomic-counter",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "ce4b63391b3c0d426cbe32af89f483222602a5b43aa5379aa720bf6f45f4cf04",
-            "version": "0.1.2.3"
+            "src_sha256": "b101e8dedc66da051a16022287d9b05c2dcb2f54f973fb09298b3486cd63ec2f",
+            "version": "0.1.2.4"
         },
         {
             "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
@@ -278,7 +286,7 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "d0002f3fb16a2cc5ba8afd47a6657726386edccfe8853d310e3479fe3b45201b",
+            "cabal_sha256": "a557cff65eed1f70f3a3b468423cd58e7a9a9564c5cc00c76a13de64dec9bcbd",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
@@ -286,8 +294,8 @@
             "package": "splitmix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b6bcd0d79bd4fe40975c8ebe803be2f3bfbf6006069a59745a325a0df3f86270",
-            "version": "0.1.3.1"
+            "src_sha256": "a61d4e8b30f5a16526d7d31171b674ae7924d2207f378060d13363bd8794de8c",
+            "version": "0.1.3.2"
         },
         {
             "cabal_sha256": "0b4f649c3e78713b2ccad1535251ee34b148237fb2229d7058c2b1d9ccc324b8",
@@ -363,7 +371,7 @@
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "b24ec42ce02c42a76732323c4e59414d9b5439ac5fa99304412719ba7f4c6a3f",
+            "cabal_sha256": "6dbfaeade84d388e9b75cdaa6ffe452a44b7f89321bd691350f41b223e2b1898",
             "component": "lib:directory-ospath-streaming",
             "flags": [
                 "+os-string"
@@ -371,31 +379,31 @@
             "package": "directory-ospath-streaming",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1ade8fbee13db15e8d22a1ecdca54794617cabc69911b51d46a65e12f4554ef7",
-            "version": "0.2.2"
+            "src_sha256": "7e86ee4f4d17c98f4943ea3e224448563870123e19a5d0d2ab4b874ef5f10f42",
+            "version": "0.3"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
+            "cabal_sha256": "cf2f8f91b10b635bdaa2c3010f40a5562a06ede24b92d819758e7f1b7d04f9f2",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -403,23 +411,23 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
-            "version": "0.7.1.0"
+            "src_sha256": "bf95ab01ed924be800addea195fba5ca97ec69f378368f6ff466bdc29666c1c1",
+            "version": "0.7.1.1"
         },
         {
-            "cabal_sha256": "e7289d17ca709d1acfb9bb43402ebcfe6c126eff9e0bda26beb3c687d8ac26ea",
+            "cabal_sha256": "c026577b7110184bcd8596040dd109ff815124d47bfc08be195d13ed6f1a72c0",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "-lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1def1a524cc894351e28e86a91cf2d043f18eeaba79070e1cc1304c9f79e4c17",
-            "version": "0.6.3.1"
+            "src_sha256": "bf8f97868ed5219d0a13a90fcbfad819bbeba4ab368c5cb590b57202c98768f9",
+            "version": "0.6.3.2"
         },
         {
             "cabal_sha256": null,
@@ -466,14 +474,14 @@
             "version": "0.96.0.2"
         },
         {
-            "cabal_sha256": "58a8c6f17dece62891e7534c6f033e1fb1d0685e68dbe5d4fbb71256d45c6132",
+            "cabal_sha256": "36de637c17bb3a37c8b9c1a66d5c37caa11ed8e7cb42284f0372f3d7d6cf684b",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 5,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
+            "src_sha256": "7702a48ab88b2ccbb78d4c4748f70a0bca2347b603daa2eb8ab014439d577103",
+            "version": "0.2.0.3"
         },
         {
             "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
@@ -484,6 +492,18 @@
             "source": "hackage",
             "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
             "version": "0.1.7.4"
+        },
+        {
+            "cabal_sha256": "e2eee36b01e7f686cb3d5467e649466272207be2107b19e2c781c7f17862906d",
+            "component": "lib:semaphore-compat",
+            "flags": [
+                "-build-testing"
+            ],
+            "package": "semaphore-compat",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "eaf00de15ff13e890d7d39181e5edf13dd12ae7d956b6a97df713097d89c4d62",
+            "version": "2.0.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-9.2.8.json
+++ b/bootstrap/linux-9.2.8.json
@@ -71,85 +71,87 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "cb5408281cb0e7cea41885611e06ee6208e3dae90c98f6901a9f20c58f930414",
+            "cabal_sha256": "7c2be4d5333786c0e1f6ed7b856c9424c03965013e161bbab07f94bf9a095196",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
-            "version": "2.0.7"
+            "src_sha256": "f682b8a6121a09fc820ce69d99e33bfa9b1a959505663ef2fedebe7b95c75aa5",
+            "version": "2.0.10"
         },
         {
-            "cabal_sha256": "1497c2630af2dd41397905ff0dff79f842bd80a139d7c5bfba3789fc3caef02c",
+            "cabal_sha256": "c6ec08084ffc90838ad36d03c3792be70fa171942a3677ec68e9be8b437754fe",
             "component": "lib:filepath",
             "flags": [
                 "-cpphs"
             ],
             "package": "filepath",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "54aa86c432f593273d7b9f607c5b5e0a1628c2674c6f4e3b5a54eb0c83db5caf",
-            "version": "1.5.4.0"
+            "src_sha256": "87e6f50f43ffce293fd431184d321ff11a480d28369dde306aaae450ba4a7d1e",
+            "version": "1.5.5.0"
         },
         {
-            "cabal_sha256": "da731114a8ec7106c76c7d96c2b02f1b4963cb12e360a2029f4248e22a327375",
+            "cabal_sha256": "9456ccdbeeb1818983f0d25f25999adb5fca07d149474d2f82de956b2eb03a7e",
             "component": "lib:unix",
             "flags": [
+                "-non-portable-tests",
                 "+os-string"
             ],
             "package": "unix",
-            "revision": 2,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "cbdd879d5aaf0755eeeedc95e3c4adde74edb8dbb7164aa1297b0b84d916fb83",
-            "version": "2.8.7.0"
+            "src_sha256": "a128dea3bfeb731a562f22d376fa606e902154d95321363f7ec1ea6b787a5a3e",
+            "version": "2.8.8.0"
         },
         {
-            "cabal_sha256": "1d68a81fa684d006b1ec73836cebe3de9a54688836915fe3e56a20389846bb4e",
+            "cabal_sha256": "5e3466f15993e499db47d79d09c519d6d37c143cfe94fb46dd218bf2f6f3fd39",
             "component": "lib:file-io",
             "flags": [
+                "+long-paths",
                 "+os-string"
             ],
             "package": "file-io",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "310a19e4c792de4d30c912bc71ff3becb40818d7c796b9999bcd0979dab87d5b",
-            "version": "0.1.5"
+            "src_sha256": "0ae9986dc1df9a87d17a16c6c0afb2bfc72dcd2a2ec7a40faf1257bf1fa4d710",
+            "version": "0.1.6"
         },
         {
-            "cabal_sha256": "ed6784601c6a800d4c1e40efbc9f20cf33ae2f25cac301fc239f9c91947b816b",
+            "cabal_sha256": "bf029d8163ccae567cc6a5aa8f654016f58dfc066d15f8a8f7c74b8ca855562c",
             "component": "lib:directory",
             "flags": [
                 "+os-string"
             ],
             "package": "directory",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "20a24846117fc5f8751d974b7de07210a161989410467e9adca525381b8e64cc",
-            "version": "1.3.9.0"
+            "src_sha256": "d8f718851aa25a357ca4a6d0204eb357a69383b9b69528d18e2bca463e94c259",
+            "version": "1.3.10.1"
         },
         {
-            "cabal_sha256": "f6fde8ff59e7e38f9e95eca8f5154fb611c9789d1d9538aa9745c6c3cd9495b4",
+            "cabal_sha256": "8db1ce2ae03edd217c408206980e8b3fce7f00b9d4b99f3e3e83b35525d94074",
             "component": "exe:alex",
             "flags": [],
             "package": "alex",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a5cd52e2dd2837138523e2e24ec3435b8cf2624afd50725105e644226e0b9ec6",
-            "version": "3.5.3.0"
+            "src_sha256": "df481dc960e2c59a30395f7335031fd4ef8773b8a42894a4f2320e00ff474418",
+            "version": "3.5.4.2"
         },
         {
-            "cabal_sha256": "0cf2a0543fb7003e0389c92840ee6326cadf762266da9cb13d67dff7c189ae1b",
+            "cabal_sha256": "2560d90e419cd359563a691fce6398dc42bb8bff87e68446636581ed3362e19a",
             "component": "lib:data-array-byte",
             "flags": [],
             "package": "data-array-byte",
-            "revision": 5,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
-            "version": "0.1.0.1"
+            "src_sha256": "55f5d970aae27f45455e5766d073bbf0d0e617a8f8d42dc9966e68ea855834bd",
+            "version": "0.1.0.2"
         },
         {
-            "cabal_sha256": "457c3b7a8bc7d8290793d152d6077efdde33c21ba300635e824bf0df38b9edfb",
+            "cabal_sha256": "32823fd40b02db9b4ef4c527c9c3e6c1dcd365b8a79521f9d78d2c0a0a8d64f1",
             "component": "lib:text",
             "flags": [
                 "-developer",
@@ -158,10 +160,10 @@
                 "+simdutf"
             ],
             "package": "text",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "84a60cf59287d38e9a25910f90e9cb818e18656532034e60c9c5aaaddeceacb6",
-            "version": "2.1.2"
+            "src_sha256": "162e8f77c2e7b0c46457a044573bc489fdd624cdc40bdde9b70b47924c081074",
+            "version": "2.1.4"
         },
         {
             "cabal_sha256": "dfbb9835b8abc966b6bbd34340ef5122227b4cf4480062b85ca4c4704f054f98",
@@ -184,7 +186,7 @@
             "version": "3.17.0.0"
         },
         {
-            "cabal_sha256": "9e9590572cc6bdb0d7ccb8835f7f9302f1c11a36c972a4c4a97aeb789be42cd9",
+            "cabal_sha256": "8526e690c91e9ef812d49f84f7f41c79bb4b692a55e399e4b8464687017f0342",
             "component": "lib:process",
             "flags": [
                 "+os-string"
@@ -192,8 +194,8 @@
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "da03911abf6bbdc68342f8f25698b0d3780964ed591f1c7d7f9b688c1097fda1",
-            "version": "1.6.26.0"
+            "src_sha256": "579d57cf0c7bceb3104c13ec452114a1e479cc718684ca018b322742b79e4cb4",
+            "version": "1.6.29.0"
         },
         {
             "cabal_sha256": null,
@@ -230,7 +232,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "e3a1ec8b8dd32f1d5a541679a67de60d6626487a95f20c6bc245268ae7142ab7",
+            "cabal_sha256": "c6f02f2626d1d83b3e3521fc2a9832c366e31dd391cb8478bd2d83528459e786",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -238,18 +240,18 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "68548e660632a3c09b230c33fe08cc880273372b485e65cbe7a717936de9728b",
-            "version": "3.2.7.0"
+            "src_sha256": "51788e5eeb7d77264f260acd48df8055a4dbc2477e8d634a8493677bb15c5fc8",
+            "version": "3.2.8.0"
         },
         {
-            "cabal_sha256": "e83d97946f84fe492762ceb3b4753b4770c78b0b70e594078700baa91a5106c2",
+            "cabal_sha256": "449be09a4e3f46ea4645700c026624c4b6f066f508187326c284dbdea8884bc9",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b781a0c059872bc95406d00e98f6fa7d9e81e744730f75186583cb4dcea0a4eb",
-            "version": "0.1.6"
+            "src_sha256": "9e26f12230d38ae56dcf94f8c139799dc3b7376f3434d35ce74847a0a24fd5ff",
+            "version": "0.1.7"
         },
         {
             "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
@@ -262,19 +264,18 @@
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "ad36c6a1b3bc203b02751c8bffae8a684cc755661a2a567362cd4a0da1193c5e",
+            "cabal_sha256": "4cf03628597ffc2f3760e3da25dee116a64cfea26013d75dc386c98aecea5f6e",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
-                "+network-uri",
                 "-warn-as-error",
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 6,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
+            "src_sha256": "d2a33bc281327d8f20afee18287c2e3f923f0cd86bac40dcba120ca3d2014f9b",
+            "version": "4000.5.0"
         },
         {
             "cabal_sha256": "573f3ab242f75465a0d67ce9d84202650a1606575e6dbd6d31ffcf4767a9a379",
@@ -291,19 +292,32 @@
             "version": "1.4.7.0"
         },
         {
-            "cabal_sha256": "e2a877717968edf1e2c91312fefd4fd53f4e49b27a421f98452b29a9256cad2a",
-            "component": "lib:async",
+            "cabal_sha256": "c5de1fb3377ed3c5f4cd851a771d1acc5c37d2f6bef0a499295c0e8857da5605",
+            "component": "lib:unordered-containers",
             "flags": [
-                "-bench"
+                "-debug"
             ],
-            "package": "async",
-            "revision": 4,
+            "package": "unordered-containers",
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
+            "src_sha256": "3b2ad1522b546e61960153257d1e5d239eeec5e83da847d5cb4d896a5bb7f9c0",
+            "version": "0.2.21"
         },
         {
-            "cabal_sha256": "81a105aed2ee2f5e479448e44252b24cdfacf81a5a2106aabdd217bad94b6f40",
+            "cabal_sha256": "45d5587d8a348a7e2b3f04de963fe633db49b49cde10ca1e6f834bef3baecee9",
+            "component": "lib:async",
+            "flags": [
+                "-bench",
+                "-debug-auto-label"
+            ],
+            "package": "async",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "148571bc188003101241da6c49131d07324e63a88ed283a84def2e9694599619",
+            "version": "2.2.6"
+        },
+        {
+            "cabal_sha256": "51c0178c727ef4ccd694514c0a44369eb8593ae83dde42bc5fb5c89d5b4c60b5",
             "component": "lib:atomic-counter",
             "flags": [
                 "-dev",
@@ -312,8 +326,8 @@
             "package": "atomic-counter",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "ce4b63391b3c0d426cbe32af89f483222602a5b43aa5379aa720bf6f45f4cf04",
-            "version": "0.1.2.3"
+            "src_sha256": "b101e8dedc66da051a16022287d9b05c2dcb2f54f973fb09298b3486cd63ec2f",
+            "version": "0.1.2.4"
         },
         {
             "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
@@ -336,7 +350,7 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "d0002f3fb16a2cc5ba8afd47a6657726386edccfe8853d310e3479fe3b45201b",
+            "cabal_sha256": "a557cff65eed1f70f3a3b468423cd58e7a9a9564c5cc00c76a13de64dec9bcbd",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
@@ -344,8 +358,8 @@
             "package": "splitmix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b6bcd0d79bd4fe40975c8ebe803be2f3bfbf6006069a59745a325a0df3f86270",
-            "version": "0.1.3.1"
+            "src_sha256": "a61d4e8b30f5a16526d7d31171b674ae7924d2207f378060d13363bd8794de8c",
+            "version": "0.1.3.2"
         },
         {
             "cabal_sha256": "0b4f649c3e78713b2ccad1535251ee34b148237fb2229d7058c2b1d9ccc324b8",
@@ -421,7 +435,7 @@
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "b24ec42ce02c42a76732323c4e59414d9b5439ac5fa99304412719ba7f4c6a3f",
+            "cabal_sha256": "6dbfaeade84d388e9b75cdaa6ffe452a44b7f89321bd691350f41b223e2b1898",
             "component": "lib:directory-ospath-streaming",
             "flags": [
                 "+os-string"
@@ -429,31 +443,31 @@
             "package": "directory-ospath-streaming",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1ade8fbee13db15e8d22a1ecdca54794617cabc69911b51d46a65e12f4554ef7",
-            "version": "0.2.2"
+            "src_sha256": "7e86ee4f4d17c98f4943ea3e224448563870123e19a5d0d2ab4b874ef5f10f42",
+            "version": "0.3"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
+            "cabal_sha256": "cf2f8f91b10b635bdaa2c3010f40a5562a06ede24b92d819758e7f1b7d04f9f2",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -461,23 +475,23 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
-            "version": "0.7.1.0"
+            "src_sha256": "bf95ab01ed924be800addea195fba5ca97ec69f378368f6ff466bdc29666c1c1",
+            "version": "0.7.1.1"
         },
         {
-            "cabal_sha256": "e7289d17ca709d1acfb9bb43402ebcfe6c126eff9e0bda26beb3c687d8ac26ea",
+            "cabal_sha256": "c026577b7110184bcd8596040dd109ff815124d47bfc08be195d13ed6f1a72c0",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "-lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1def1a524cc894351e28e86a91cf2d043f18eeaba79070e1cc1304c9f79e4c17",
-            "version": "0.6.3.1"
+            "src_sha256": "bf8f97868ed5219d0a13a90fcbfad819bbeba4ab368c5cb590b57202c98768f9",
+            "version": "0.6.3.2"
         },
         {
             "cabal_sha256": null,
@@ -524,14 +538,14 @@
             "version": "0.96.0.2"
         },
         {
-            "cabal_sha256": "58a8c6f17dece62891e7534c6f033e1fb1d0685e68dbe5d4fbb71256d45c6132",
+            "cabal_sha256": "36de637c17bb3a37c8b9c1a66d5c37caa11ed8e7cb42284f0372f3d7d6cf684b",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 5,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
+            "src_sha256": "7702a48ab88b2ccbb78d4c4748f70a0bca2347b603daa2eb8ab014439d577103",
+            "version": "0.2.0.3"
         },
         {
             "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
@@ -544,14 +558,16 @@
             "version": "0.1.7.4"
         },
         {
-            "cabal_sha256": "2dff81c2c0ec9bac9f8bae364db497188654d2e1e4330f4a0e2f12310149f3e9",
+            "cabal_sha256": "e2eee36b01e7f686cb3d5467e649466272207be2107b19e2c781c7f17862906d",
             "component": "lib:semaphore-compat",
-            "flags": [],
+            "flags": [
+                "-build-testing"
+            ],
             "package": "semaphore-compat",
-            "revision": 4,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
+            "src_sha256": "eaf00de15ff13e890d7d39181e5edf13dd12ae7d956b6a97df713097d89c4d62",
+            "version": "2.0.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-9.4.8.json
+++ b/bootstrap/linux-9.4.8.json
@@ -79,72 +79,74 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "cb5408281cb0e7cea41885611e06ee6208e3dae90c98f6901a9f20c58f930414",
+            "cabal_sha256": "7c2be4d5333786c0e1f6ed7b856c9424c03965013e161bbab07f94bf9a095196",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
-            "version": "2.0.7"
+            "src_sha256": "f682b8a6121a09fc820ce69d99e33bfa9b1a959505663ef2fedebe7b95c75aa5",
+            "version": "2.0.10"
         },
         {
-            "cabal_sha256": "1497c2630af2dd41397905ff0dff79f842bd80a139d7c5bfba3789fc3caef02c",
+            "cabal_sha256": "c6ec08084ffc90838ad36d03c3792be70fa171942a3677ec68e9be8b437754fe",
             "component": "lib:filepath",
             "flags": [
                 "-cpphs"
             ],
             "package": "filepath",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "54aa86c432f593273d7b9f607c5b5e0a1628c2674c6f4e3b5a54eb0c83db5caf",
-            "version": "1.5.4.0"
+            "src_sha256": "87e6f50f43ffce293fd431184d321ff11a480d28369dde306aaae450ba4a7d1e",
+            "version": "1.5.5.0"
         },
         {
-            "cabal_sha256": "da731114a8ec7106c76c7d96c2b02f1b4963cb12e360a2029f4248e22a327375",
+            "cabal_sha256": "9456ccdbeeb1818983f0d25f25999adb5fca07d149474d2f82de956b2eb03a7e",
             "component": "lib:unix",
             "flags": [
+                "-non-portable-tests",
                 "+os-string"
             ],
             "package": "unix",
-            "revision": 2,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "cbdd879d5aaf0755eeeedc95e3c4adde74edb8dbb7164aa1297b0b84d916fb83",
-            "version": "2.8.7.0"
+            "src_sha256": "a128dea3bfeb731a562f22d376fa606e902154d95321363f7ec1ea6b787a5a3e",
+            "version": "2.8.8.0"
         },
         {
-            "cabal_sha256": "1d68a81fa684d006b1ec73836cebe3de9a54688836915fe3e56a20389846bb4e",
+            "cabal_sha256": "5e3466f15993e499db47d79d09c519d6d37c143cfe94fb46dd218bf2f6f3fd39",
             "component": "lib:file-io",
             "flags": [
+                "+long-paths",
                 "+os-string"
             ],
             "package": "file-io",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "310a19e4c792de4d30c912bc71ff3becb40818d7c796b9999bcd0979dab87d5b",
-            "version": "0.1.5"
+            "src_sha256": "0ae9986dc1df9a87d17a16c6c0afb2bfc72dcd2a2ec7a40faf1257bf1fa4d710",
+            "version": "0.1.6"
         },
         {
-            "cabal_sha256": "ed6784601c6a800d4c1e40efbc9f20cf33ae2f25cac301fc239f9c91947b816b",
+            "cabal_sha256": "bf029d8163ccae567cc6a5aa8f654016f58dfc066d15f8a8f7c74b8ca855562c",
             "component": "lib:directory",
             "flags": [
                 "+os-string"
             ],
             "package": "directory",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "20a24846117fc5f8751d974b7de07210a161989410467e9adca525381b8e64cc",
-            "version": "1.3.9.0"
+            "src_sha256": "d8f718851aa25a357ca4a6d0204eb357a69383b9b69528d18e2bca463e94c259",
+            "version": "1.3.10.1"
         },
         {
-            "cabal_sha256": "f6fde8ff59e7e38f9e95eca8f5154fb611c9789d1d9538aa9745c6c3cd9495b4",
+            "cabal_sha256": "8db1ce2ae03edd217c408206980e8b3fce7f00b9d4b99f3e3e83b35525d94074",
             "component": "exe:alex",
             "flags": [],
             "package": "alex",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a5cd52e2dd2837138523e2e24ec3435b8cf2624afd50725105e644226e0b9ec6",
-            "version": "3.5.3.0"
+            "src_sha256": "df481dc960e2c59a30395f7335031fd4ef8773b8a42894a4f2320e00ff474418",
+            "version": "3.5.4.2"
         },
         {
             "cabal_sha256": null,
@@ -157,7 +159,7 @@
             "version": "3.17.0.0"
         },
         {
-            "cabal_sha256": "9e9590572cc6bdb0d7ccb8835f7f9302f1c11a36c972a4c4a97aeb789be42cd9",
+            "cabal_sha256": "8526e690c91e9ef812d49f84f7f41c79bb4b692a55e399e4b8464687017f0342",
             "component": "lib:process",
             "flags": [
                 "+os-string"
@@ -165,8 +167,8 @@
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "da03911abf6bbdc68342f8f25698b0d3780964ed591f1c7d7f9b688c1097fda1",
-            "version": "1.6.26.0"
+            "src_sha256": "579d57cf0c7bceb3104c13ec452114a1e479cc718684ca018b322742b79e4cb4",
+            "version": "1.6.29.0"
         },
         {
             "cabal_sha256": null,
@@ -203,7 +205,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "e3a1ec8b8dd32f1d5a541679a67de60d6626487a95f20c6bc245268ae7142ab7",
+            "cabal_sha256": "c6f02f2626d1d83b3e3521fc2a9832c366e31dd391cb8478bd2d83528459e786",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -211,18 +213,18 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "68548e660632a3c09b230c33fe08cc880273372b485e65cbe7a717936de9728b",
-            "version": "3.2.7.0"
+            "src_sha256": "51788e5eeb7d77264f260acd48df8055a4dbc2477e8d634a8493677bb15c5fc8",
+            "version": "3.2.8.0"
         },
         {
-            "cabal_sha256": "e83d97946f84fe492762ceb3b4753b4770c78b0b70e594078700baa91a5106c2",
+            "cabal_sha256": "449be09a4e3f46ea4645700c026624c4b6f066f508187326c284dbdea8884bc9",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b781a0c059872bc95406d00e98f6fa7d9e81e744730f75186583cb4dcea0a4eb",
-            "version": "0.1.6"
+            "src_sha256": "9e26f12230d38ae56dcf94f8c139799dc3b7376f3434d35ce74847a0a24fd5ff",
+            "version": "0.1.7"
         },
         {
             "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
@@ -235,19 +237,18 @@
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "ad36c6a1b3bc203b02751c8bffae8a684cc755661a2a567362cd4a0da1193c5e",
+            "cabal_sha256": "4cf03628597ffc2f3760e3da25dee116a64cfea26013d75dc386c98aecea5f6e",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
-                "+network-uri",
                 "-warn-as-error",
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 6,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
+            "src_sha256": "d2a33bc281327d8f20afee18287c2e3f923f0cd86bac40dcba120ca3d2014f9b",
+            "version": "4000.5.0"
         },
         {
             "cabal_sha256": "573f3ab242f75465a0d67ce9d84202650a1606575e6dbd6d31ffcf4767a9a379",
@@ -264,19 +265,32 @@
             "version": "1.4.7.0"
         },
         {
-            "cabal_sha256": "e2a877717968edf1e2c91312fefd4fd53f4e49b27a421f98452b29a9256cad2a",
-            "component": "lib:async",
+            "cabal_sha256": "c5de1fb3377ed3c5f4cd851a771d1acc5c37d2f6bef0a499295c0e8857da5605",
+            "component": "lib:unordered-containers",
             "flags": [
-                "-bench"
+                "-debug"
             ],
-            "package": "async",
-            "revision": 4,
+            "package": "unordered-containers",
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
+            "src_sha256": "3b2ad1522b546e61960153257d1e5d239eeec5e83da847d5cb4d896a5bb7f9c0",
+            "version": "0.2.21"
         },
         {
-            "cabal_sha256": "81a105aed2ee2f5e479448e44252b24cdfacf81a5a2106aabdd217bad94b6f40",
+            "cabal_sha256": "45d5587d8a348a7e2b3f04de963fe633db49b49cde10ca1e6f834bef3baecee9",
+            "component": "lib:async",
+            "flags": [
+                "-bench",
+                "-debug-auto-label"
+            ],
+            "package": "async",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "148571bc188003101241da6c49131d07324e63a88ed283a84def2e9694599619",
+            "version": "2.2.6"
+        },
+        {
+            "cabal_sha256": "51c0178c727ef4ccd694514c0a44369eb8593ae83dde42bc5fb5c89d5b4c60b5",
             "component": "lib:atomic-counter",
             "flags": [
                 "-dev",
@@ -285,8 +299,8 @@
             "package": "atomic-counter",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "ce4b63391b3c0d426cbe32af89f483222602a5b43aa5379aa720bf6f45f4cf04",
-            "version": "0.1.2.3"
+            "src_sha256": "b101e8dedc66da051a16022287d9b05c2dcb2f54f973fb09298b3486cd63ec2f",
+            "version": "0.1.2.4"
         },
         {
             "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
@@ -309,7 +323,7 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "d0002f3fb16a2cc5ba8afd47a6657726386edccfe8853d310e3479fe3b45201b",
+            "cabal_sha256": "a557cff65eed1f70f3a3b468423cd58e7a9a9564c5cc00c76a13de64dec9bcbd",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
@@ -317,8 +331,8 @@
             "package": "splitmix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b6bcd0d79bd4fe40975c8ebe803be2f3bfbf6006069a59745a325a0df3f86270",
-            "version": "0.1.3.1"
+            "src_sha256": "a61d4e8b30f5a16526d7d31171b674ae7924d2207f378060d13363bd8794de8c",
+            "version": "0.1.3.2"
         },
         {
             "cabal_sha256": "0b4f649c3e78713b2ccad1535251ee34b148237fb2229d7058c2b1d9ccc324b8",
@@ -394,7 +408,7 @@
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "b24ec42ce02c42a76732323c4e59414d9b5439ac5fa99304412719ba7f4c6a3f",
+            "cabal_sha256": "6dbfaeade84d388e9b75cdaa6ffe452a44b7f89321bd691350f41b223e2b1898",
             "component": "lib:directory-ospath-streaming",
             "flags": [
                 "+os-string"
@@ -402,31 +416,31 @@
             "package": "directory-ospath-streaming",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1ade8fbee13db15e8d22a1ecdca54794617cabc69911b51d46a65e12f4554ef7",
-            "version": "0.2.2"
+            "src_sha256": "7e86ee4f4d17c98f4943ea3e224448563870123e19a5d0d2ab4b874ef5f10f42",
+            "version": "0.3"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
+            "cabal_sha256": "cf2f8f91b10b635bdaa2c3010f40a5562a06ede24b92d819758e7f1b7d04f9f2",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -434,23 +448,23 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
-            "version": "0.7.1.0"
+            "src_sha256": "bf95ab01ed924be800addea195fba5ca97ec69f378368f6ff466bdc29666c1c1",
+            "version": "0.7.1.1"
         },
         {
-            "cabal_sha256": "e7289d17ca709d1acfb9bb43402ebcfe6c126eff9e0bda26beb3c687d8ac26ea",
+            "cabal_sha256": "c026577b7110184bcd8596040dd109ff815124d47bfc08be195d13ed6f1a72c0",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "-lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1def1a524cc894351e28e86a91cf2d043f18eeaba79070e1cc1304c9f79e4c17",
-            "version": "0.6.3.1"
+            "src_sha256": "bf8f97868ed5219d0a13a90fcbfad819bbeba4ab368c5cb590b57202c98768f9",
+            "version": "0.6.3.2"
         },
         {
             "cabal_sha256": null,
@@ -497,14 +511,14 @@
             "version": "0.96.0.2"
         },
         {
-            "cabal_sha256": "58a8c6f17dece62891e7534c6f033e1fb1d0685e68dbe5d4fbb71256d45c6132",
+            "cabal_sha256": "36de637c17bb3a37c8b9c1a66d5c37caa11ed8e7cb42284f0372f3d7d6cf684b",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 5,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
+            "src_sha256": "7702a48ab88b2ccbb78d4c4748f70a0bca2347b603daa2eb8ab014439d577103",
+            "version": "0.2.0.3"
         },
         {
             "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
@@ -517,14 +531,16 @@
             "version": "0.1.7.4"
         },
         {
-            "cabal_sha256": "2dff81c2c0ec9bac9f8bae364db497188654d2e1e4330f4a0e2f12310149f3e9",
+            "cabal_sha256": "e2eee36b01e7f686cb3d5467e649466272207be2107b19e2c781c7f17862906d",
             "component": "lib:semaphore-compat",
-            "flags": [],
+            "flags": [
+                "-build-testing"
+            ],
             "package": "semaphore-compat",
-            "revision": 4,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
+            "src_sha256": "eaf00de15ff13e890d7d39181e5edf13dd12ae7d956b6a97df713097d89c4d62",
+            "version": "2.0.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-9.6.7.json
+++ b/bootstrap/linux-9.6.7.json
@@ -87,22 +87,18 @@
         {
             "package": "parsec",
             "version": "3.1.16.1"
-        },
-        {
-            "package": "process",
-            "version": "1.6.19.0"
         }
     ],
     "dependencies": [
         {
-            "cabal_sha256": "f6fde8ff59e7e38f9e95eca8f5154fb611c9789d1d9538aa9745c6c3cd9495b4",
+            "cabal_sha256": "8db1ce2ae03edd217c408206980e8b3fce7f00b9d4b99f3e3e83b35525d94074",
             "component": "exe:alex",
             "flags": [],
             "package": "alex",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a5cd52e2dd2837138523e2e24ec3435b8cf2624afd50725105e644226e0b9ec6",
-            "version": "3.5.3.0"
+            "src_sha256": "df481dc960e2c59a30395f7335031fd4ef8773b8a42894a4f2320e00ff474418",
+            "version": "3.5.4.2"
         },
         {
             "cabal_sha256": null,
@@ -115,7 +111,7 @@
             "version": "3.17.0.0"
         },
         {
-            "cabal_sha256": "9e9590572cc6bdb0d7ccb8835f7f9302f1c11a36c972a4c4a97aeb789be42cd9",
+            "cabal_sha256": "8526e690c91e9ef812d49f84f7f41c79bb4b692a55e399e4b8464687017f0342",
             "component": "lib:process",
             "flags": [
                 "-os-string"
@@ -123,8 +119,8 @@
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "da03911abf6bbdc68342f8f25698b0d3780964ed591f1c7d7f9b688c1097fda1",
-            "version": "1.6.26.0"
+            "src_sha256": "579d57cf0c7bceb3104c13ec452114a1e479cc718684ca018b322742b79e4cb4",
+            "version": "1.6.29.0"
         },
         {
             "cabal_sha256": null,
@@ -161,7 +157,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "e3a1ec8b8dd32f1d5a541679a67de60d6626487a95f20c6bc245268ae7142ab7",
+            "cabal_sha256": "c6f02f2626d1d83b3e3521fc2a9832c366e31dd391cb8478bd2d83528459e786",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -169,18 +165,18 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "68548e660632a3c09b230c33fe08cc880273372b485e65cbe7a717936de9728b",
-            "version": "3.2.7.0"
+            "src_sha256": "51788e5eeb7d77264f260acd48df8055a4dbc2477e8d634a8493677bb15c5fc8",
+            "version": "3.2.8.0"
         },
         {
-            "cabal_sha256": "e83d97946f84fe492762ceb3b4753b4770c78b0b70e594078700baa91a5106c2",
+            "cabal_sha256": "449be09a4e3f46ea4645700c026624c4b6f066f508187326c284dbdea8884bc9",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b781a0c059872bc95406d00e98f6fa7d9e81e744730f75186583cb4dcea0a4eb",
-            "version": "0.1.6"
+            "src_sha256": "9e26f12230d38ae56dcf94f8c139799dc3b7376f3434d35ce74847a0a24fd5ff",
+            "version": "0.1.7"
         },
         {
             "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
@@ -193,57 +189,69 @@
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "ad36c6a1b3bc203b02751c8bffae8a684cc755661a2a567362cd4a0da1193c5e",
+            "cabal_sha256": "4cf03628597ffc2f3760e3da25dee116a64cfea26013d75dc386c98aecea5f6e",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
-                "+network-uri",
                 "-warn-as-error",
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 6,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
+            "src_sha256": "d2a33bc281327d8f20afee18287c2e3f923f0cd86bac40dcba120ca3d2014f9b",
+            "version": "4000.5.0"
         },
         {
-            "cabal_sha256": "cb5408281cb0e7cea41885611e06ee6208e3dae90c98f6901a9f20c58f930414",
+            "cabal_sha256": "7c2be4d5333786c0e1f6ed7b856c9424c03965013e161bbab07f94bf9a095196",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
-            "version": "2.0.7"
+            "src_sha256": "f682b8a6121a09fc820ce69d99e33bfa9b1a959505663ef2fedebe7b95c75aa5",
+            "version": "2.0.10"
         },
         {
-            "cabal_sha256": "2f23146cbe0325029927b221647695a4c7d6e97548ff731110979e34361f58ef",
+            "cabal_sha256": "140fc5adad166f7b527567cbd26ff481e8da4a66bdfc84be3ddf28dbeb66f275",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
                 "-random-initial-seed"
             ],
             "package": "hashable",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
-            "version": "1.5.0.0"
+            "src_sha256": "ed0b7c10ce92c9ffe45420dadc38c6d39db486ff3633ff13567cc9f75f79b112",
+            "version": "1.5.1.0"
         },
         {
-            "cabal_sha256": "e2a877717968edf1e2c91312fefd4fd53f4e49b27a421f98452b29a9256cad2a",
+            "cabal_sha256": "c5de1fb3377ed3c5f4cd851a771d1acc5c37d2f6bef0a499295c0e8857da5605",
+            "component": "lib:unordered-containers",
+            "flags": [
+                "-debug"
+            ],
+            "package": "unordered-containers",
+            "revision": 2,
+            "source": "hackage",
+            "src_sha256": "3b2ad1522b546e61960153257d1e5d239eeec5e83da847d5cb4d896a5bb7f9c0",
+            "version": "0.2.21"
+        },
+        {
+            "cabal_sha256": "45d5587d8a348a7e2b3f04de963fe633db49b49cde10ca1e6f834bef3baecee9",
             "component": "lib:async",
             "flags": [
-                "-bench"
+                "-bench",
+                "-debug-auto-label"
             ],
             "package": "async",
-            "revision": 4,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
+            "src_sha256": "148571bc188003101241da6c49131d07324e63a88ed283a84def2e9694599619",
+            "version": "2.2.6"
         },
         {
-            "cabal_sha256": "81a105aed2ee2f5e479448e44252b24cdfacf81a5a2106aabdd217bad94b6f40",
+            "cabal_sha256": "51c0178c727ef4ccd694514c0a44369eb8593ae83dde42bc5fb5c89d5b4c60b5",
             "component": "lib:atomic-counter",
             "flags": [
                 "-dev",
@@ -252,8 +260,8 @@
             "package": "atomic-counter",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "ce4b63391b3c0d426cbe32af89f483222602a5b43aa5379aa720bf6f45f4cf04",
-            "version": "0.1.2.3"
+            "src_sha256": "b101e8dedc66da051a16022287d9b05c2dcb2f54f973fb09298b3486cd63ec2f",
+            "version": "0.1.2.4"
         },
         {
             "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
@@ -276,7 +284,7 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "d0002f3fb16a2cc5ba8afd47a6657726386edccfe8853d310e3479fe3b45201b",
+            "cabal_sha256": "a557cff65eed1f70f3a3b468423cd58e7a9a9564c5cc00c76a13de64dec9bcbd",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
@@ -284,8 +292,8 @@
             "package": "splitmix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b6bcd0d79bd4fe40975c8ebe803be2f3bfbf6006069a59745a325a0df3f86270",
-            "version": "0.1.3.1"
+            "src_sha256": "a61d4e8b30f5a16526d7d31171b674ae7924d2207f378060d13363bd8794de8c",
+            "version": "0.1.3.2"
         },
         {
             "cabal_sha256": "0b4f649c3e78713b2ccad1535251ee34b148237fb2229d7058c2b1d9ccc324b8",
@@ -361,7 +369,7 @@
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "b24ec42ce02c42a76732323c4e59414d9b5439ac5fa99304412719ba7f4c6a3f",
+            "cabal_sha256": "6dbfaeade84d388e9b75cdaa6ffe452a44b7f89321bd691350f41b223e2b1898",
             "component": "lib:directory-ospath-streaming",
             "flags": [
                 "-os-string"
@@ -369,43 +377,44 @@
             "package": "directory-ospath-streaming",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1ade8fbee13db15e8d22a1ecdca54794617cabc69911b51d46a65e12f4554ef7",
-            "version": "0.2.2"
+            "src_sha256": "7e86ee4f4d17c98f4943ea3e224448563870123e19a5d0d2ab4b874ef5f10f42",
+            "version": "0.3"
         },
         {
-            "cabal_sha256": "1d68a81fa684d006b1ec73836cebe3de9a54688836915fe3e56a20389846bb4e",
+            "cabal_sha256": "e896ca0207a70f04a1d4357bb031a703f79317ff973efc62817fa237c2964e5c",
             "component": "lib:file-io",
             "flags": [
+                "+long-paths",
                 "-os-string"
             ],
             "package": "file-io",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "310a19e4c792de4d30c912bc71ff3becb40818d7c796b9999bcd0979dab87d5b",
-            "version": "0.1.5"
+            "src_sha256": "8e75f8905d7c9f114e6164779e7a19ff0e2968015ecf686934e38250575dabe7",
+            "version": "0.2.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
+            "cabal_sha256": "cf2f8f91b10b635bdaa2c3010f40a5562a06ede24b92d819758e7f1b7d04f9f2",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -413,23 +422,23 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
-            "version": "0.7.1.0"
+            "src_sha256": "bf95ab01ed924be800addea195fba5ca97ec69f378368f6ff466bdc29666c1c1",
+            "version": "0.7.1.1"
         },
         {
-            "cabal_sha256": "e7289d17ca709d1acfb9bb43402ebcfe6c126eff9e0bda26beb3c687d8ac26ea",
+            "cabal_sha256": "c026577b7110184bcd8596040dd109ff815124d47bfc08be195d13ed6f1a72c0",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "-lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1def1a524cc894351e28e86a91cf2d043f18eeaba79070e1cc1304c9f79e4c17",
-            "version": "0.6.3.1"
+            "src_sha256": "bf8f97868ed5219d0a13a90fcbfad819bbeba4ab368c5cb590b57202c98768f9",
+            "version": "0.6.3.2"
         },
         {
             "cabal_sha256": null,
@@ -476,14 +485,14 @@
             "version": "0.96.0.2"
         },
         {
-            "cabal_sha256": "58a8c6f17dece62891e7534c6f033e1fb1d0685e68dbe5d4fbb71256d45c6132",
+            "cabal_sha256": "36de637c17bb3a37c8b9c1a66d5c37caa11ed8e7cb42284f0372f3d7d6cf684b",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 5,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
+            "src_sha256": "7702a48ab88b2ccbb78d4c4748f70a0bca2347b603daa2eb8ab014439d577103",
+            "version": "0.2.0.3"
         },
         {
             "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
@@ -496,14 +505,16 @@
             "version": "0.1.7.4"
         },
         {
-            "cabal_sha256": "2dff81c2c0ec9bac9f8bae364db497188654d2e1e4330f4a0e2f12310149f3e9",
+            "cabal_sha256": "e2eee36b01e7f686cb3d5467e649466272207be2107b19e2c781c7f17862906d",
             "component": "lib:semaphore-compat",
-            "flags": [],
+            "flags": [
+                "-build-testing"
+            ],
             "package": "semaphore-compat",
-            "revision": 4,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
+            "src_sha256": "eaf00de15ff13e890d7d39181e5edf13dd12ae7d956b6a97df713097d89c4d62",
+            "version": "2.0.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-9.8.4.json
+++ b/bootstrap/linux-9.8.4.json
@@ -87,22 +87,18 @@
         {
             "package": "parsec",
             "version": "3.1.17.0"
-        },
-        {
-            "package": "semaphore-compat",
-            "version": "1.0.0"
         }
     ],
     "dependencies": [
         {
-            "cabal_sha256": "f6fde8ff59e7e38f9e95eca8f5154fb611c9789d1d9538aa9745c6c3cd9495b4",
+            "cabal_sha256": "8db1ce2ae03edd217c408206980e8b3fce7f00b9d4b99f3e3e83b35525d94074",
             "component": "exe:alex",
             "flags": [],
             "package": "alex",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a5cd52e2dd2837138523e2e24ec3435b8cf2624afd50725105e644226e0b9ec6",
-            "version": "3.5.3.0"
+            "src_sha256": "df481dc960e2c59a30395f7335031fd4ef8773b8a42894a4f2320e00ff474418",
+            "version": "3.5.4.2"
         },
         {
             "cabal_sha256": null,
@@ -115,7 +111,7 @@
             "version": "3.17.0.0"
         },
         {
-            "cabal_sha256": "9e9590572cc6bdb0d7ccb8835f7f9302f1c11a36c972a4c4a97aeb789be42cd9",
+            "cabal_sha256": "8526e690c91e9ef812d49f84f7f41c79bb4b692a55e399e4b8464687017f0342",
             "component": "lib:process",
             "flags": [
                 "-os-string"
@@ -123,8 +119,8 @@
             "package": "process",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "da03911abf6bbdc68342f8f25698b0d3780964ed591f1c7d7f9b688c1097fda1",
-            "version": "1.6.26.0"
+            "src_sha256": "579d57cf0c7bceb3104c13ec452114a1e479cc718684ca018b322742b79e4cb4",
+            "version": "1.6.29.0"
         },
         {
             "cabal_sha256": null,
@@ -161,7 +157,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "e3a1ec8b8dd32f1d5a541679a67de60d6626487a95f20c6bc245268ae7142ab7",
+            "cabal_sha256": "c6f02f2626d1d83b3e3521fc2a9832c366e31dd391cb8478bd2d83528459e786",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -169,18 +165,18 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "68548e660632a3c09b230c33fe08cc880273372b485e65cbe7a717936de9728b",
-            "version": "3.2.7.0"
+            "src_sha256": "51788e5eeb7d77264f260acd48df8055a4dbc2477e8d634a8493677bb15c5fc8",
+            "version": "3.2.8.0"
         },
         {
-            "cabal_sha256": "e83d97946f84fe492762ceb3b4753b4770c78b0b70e594078700baa91a5106c2",
+            "cabal_sha256": "449be09a4e3f46ea4645700c026624c4b6f066f508187326c284dbdea8884bc9",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b781a0c059872bc95406d00e98f6fa7d9e81e744730f75186583cb4dcea0a4eb",
-            "version": "0.1.6"
+            "src_sha256": "9e26f12230d38ae56dcf94f8c139799dc3b7376f3434d35ce74847a0a24fd5ff",
+            "version": "0.1.7"
         },
         {
             "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
@@ -193,57 +189,69 @@
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "ad36c6a1b3bc203b02751c8bffae8a684cc755661a2a567362cd4a0da1193c5e",
+            "cabal_sha256": "4cf03628597ffc2f3760e3da25dee116a64cfea26013d75dc386c98aecea5f6e",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
-                "+network-uri",
                 "-warn-as-error",
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 6,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
+            "src_sha256": "d2a33bc281327d8f20afee18287c2e3f923f0cd86bac40dcba120ca3d2014f9b",
+            "version": "4000.5.0"
         },
         {
-            "cabal_sha256": "cb5408281cb0e7cea41885611e06ee6208e3dae90c98f6901a9f20c58f930414",
+            "cabal_sha256": "7c2be4d5333786c0e1f6ed7b856c9424c03965013e161bbab07f94bf9a095196",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "339c35fd3a290522f23de4e33528423cfd0b0a8f22946b0b9816a817b926cba0",
-            "version": "2.0.7"
+            "src_sha256": "f682b8a6121a09fc820ce69d99e33bfa9b1a959505663ef2fedebe7b95c75aa5",
+            "version": "2.0.10"
         },
         {
-            "cabal_sha256": "2f23146cbe0325029927b221647695a4c7d6e97548ff731110979e34361f58ef",
+            "cabal_sha256": "140fc5adad166f7b527567cbd26ff481e8da4a66bdfc84be3ddf28dbeb66f275",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
                 "-random-initial-seed"
             ],
             "package": "hashable",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
-            "version": "1.5.0.0"
+            "src_sha256": "ed0b7c10ce92c9ffe45420dadc38c6d39db486ff3633ff13567cc9f75f79b112",
+            "version": "1.5.1.0"
         },
         {
-            "cabal_sha256": "e2a877717968edf1e2c91312fefd4fd53f4e49b27a421f98452b29a9256cad2a",
+            "cabal_sha256": "c5de1fb3377ed3c5f4cd851a771d1acc5c37d2f6bef0a499295c0e8857da5605",
+            "component": "lib:unordered-containers",
+            "flags": [
+                "-debug"
+            ],
+            "package": "unordered-containers",
+            "revision": 2,
+            "source": "hackage",
+            "src_sha256": "3b2ad1522b546e61960153257d1e5d239eeec5e83da847d5cb4d896a5bb7f9c0",
+            "version": "0.2.21"
+        },
+        {
+            "cabal_sha256": "45d5587d8a348a7e2b3f04de963fe633db49b49cde10ca1e6f834bef3baecee9",
             "component": "lib:async",
             "flags": [
-                "-bench"
+                "-bench",
+                "-debug-auto-label"
             ],
             "package": "async",
-            "revision": 4,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
+            "src_sha256": "148571bc188003101241da6c49131d07324e63a88ed283a84def2e9694599619",
+            "version": "2.2.6"
         },
         {
-            "cabal_sha256": "81a105aed2ee2f5e479448e44252b24cdfacf81a5a2106aabdd217bad94b6f40",
+            "cabal_sha256": "51c0178c727ef4ccd694514c0a44369eb8593ae83dde42bc5fb5c89d5b4c60b5",
             "component": "lib:atomic-counter",
             "flags": [
                 "-dev",
@@ -252,8 +260,8 @@
             "package": "atomic-counter",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "ce4b63391b3c0d426cbe32af89f483222602a5b43aa5379aa720bf6f45f4cf04",
-            "version": "0.1.2.3"
+            "src_sha256": "b101e8dedc66da051a16022287d9b05c2dcb2f54f973fb09298b3486cd63ec2f",
+            "version": "0.1.2.4"
         },
         {
             "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
@@ -276,7 +284,7 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "d0002f3fb16a2cc5ba8afd47a6657726386edccfe8853d310e3479fe3b45201b",
+            "cabal_sha256": "a557cff65eed1f70f3a3b468423cd58e7a9a9564c5cc00c76a13de64dec9bcbd",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
@@ -284,8 +292,8 @@
             "package": "splitmix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "b6bcd0d79bd4fe40975c8ebe803be2f3bfbf6006069a59745a325a0df3f86270",
-            "version": "0.1.3.1"
+            "src_sha256": "a61d4e8b30f5a16526d7d31171b674ae7924d2207f378060d13363bd8794de8c",
+            "version": "0.1.3.2"
         },
         {
             "cabal_sha256": "0b4f649c3e78713b2ccad1535251ee34b148237fb2229d7058c2b1d9ccc324b8",
@@ -361,7 +369,7 @@
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "b24ec42ce02c42a76732323c4e59414d9b5439ac5fa99304412719ba7f4c6a3f",
+            "cabal_sha256": "6dbfaeade84d388e9b75cdaa6ffe452a44b7f89321bd691350f41b223e2b1898",
             "component": "lib:directory-ospath-streaming",
             "flags": [
                 "-os-string"
@@ -369,43 +377,44 @@
             "package": "directory-ospath-streaming",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1ade8fbee13db15e8d22a1ecdca54794617cabc69911b51d46a65e12f4554ef7",
-            "version": "0.2.2"
+            "src_sha256": "7e86ee4f4d17c98f4943ea3e224448563870123e19a5d0d2ab4b874ef5f10f42",
+            "version": "0.3"
         },
         {
-            "cabal_sha256": "1d68a81fa684d006b1ec73836cebe3de9a54688836915fe3e56a20389846bb4e",
+            "cabal_sha256": "e896ca0207a70f04a1d4357bb031a703f79317ff973efc62817fa237c2964e5c",
             "component": "lib:file-io",
             "flags": [
+                "+long-paths",
                 "-os-string"
             ],
             "package": "file-io",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "310a19e4c792de4d30c912bc71ff3becb40818d7c796b9999bcd0979dab87d5b",
-            "version": "0.1.5"
+            "src_sha256": "8e75f8905d7c9f114e6164779e7a19ff0e2968015ecf686934e38250575dabe7",
+            "version": "0.2.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "1a5ff2b64cd1bac53ea68d057631818cab6edf7108dc86e7be8ad020b2bf2580",
+            "cabal_sha256": "6754dab008f513734cf78a8a2eb80b60f3952ce18fd874a88b42edcefc9030dd",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 4,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "7949a50004a80993000512079bc03ebcad4872414fc181f45b3883d743c0f3aa",
-            "version": "0.6.4.0"
+            "src_sha256": "d5d18a784ea37ac37853503abf3c5c95bd8cc50f42a1ada6285ce76e25b0b6cc",
+            "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "85e64a75c0b490506a7edaa2d54950c668e66b65758bb08bb14cd31faf53a206",
+            "cabal_sha256": "cf2f8f91b10b635bdaa2c3010f40a5562a06ede24b92d819758e7f1b7d04f9f2",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -413,23 +422,23 @@
                 "+pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
-            "version": "0.7.1.0"
+            "src_sha256": "bf95ab01ed924be800addea195fba5ca97ec69f378368f6ff466bdc29666c1c1",
+            "version": "0.7.1.1"
         },
         {
-            "cabal_sha256": "e7289d17ca709d1acfb9bb43402ebcfe6c126eff9e0bda26beb3c687d8ac26ea",
+            "cabal_sha256": "c026577b7110184bcd8596040dd109ff815124d47bfc08be195d13ed6f1a72c0",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "-lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
-            "src_sha256": "1def1a524cc894351e28e86a91cf2d043f18eeaba79070e1cc1304c9f79e4c17",
-            "version": "0.6.3.1"
+            "src_sha256": "bf8f97868ed5219d0a13a90fcbfad819bbeba4ab368c5cb590b57202c98768f9",
+            "version": "0.6.3.2"
         },
         {
             "cabal_sha256": null,
@@ -476,14 +485,14 @@
             "version": "0.96.0.2"
         },
         {
-            "cabal_sha256": "58a8c6f17dece62891e7534c6f033e1fb1d0685e68dbe5d4fbb71256d45c6132",
+            "cabal_sha256": "36de637c17bb3a37c8b9c1a66d5c37caa11ed8e7cb42284f0372f3d7d6cf684b",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 5,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
+            "src_sha256": "7702a48ab88b2ccbb78d4c4748f70a0bca2347b603daa2eb8ab014439d577103",
+            "version": "0.2.0.3"
         },
         {
             "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
@@ -494,6 +503,18 @@
             "source": "hackage",
             "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
             "version": "0.1.7.4"
+        },
+        {
+            "cabal_sha256": "e2eee36b01e7f686cb3d5467e649466272207be2107b19e2c781c7f17862906d",
+            "component": "lib:semaphore-compat",
+            "flags": [
+                "-build-testing"
+            ],
+            "package": "semaphore-compat",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "eaf00de15ff13e890d7d39181e5edf13dd12ae7d956b6a97df713097d89c4d62",
+            "version": "2.0.0"
         },
         {
             "cabal_sha256": null,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -273,7 +273,7 @@ library
       , regex-base  >= 0.94.0.0 && <0.95
       , regex-posix >= 0.96.0.0 && <0.97
       , safe-exceptions >= 0.1.7.0 && < 0.2
-      , semaphore-compat >= 1.0.0 && < 1.1
+      , semaphore-compat >= 2.0.0 && < 2.1
 
     if flag(native-dns)
       if os(windows)

--- a/cabal-install/src/Distribution/Client/JobControl.hs
+++ b/cabal-install/src/Distribution/Client/JobControl.hs
@@ -45,7 +45,7 @@ import Control.Concurrent (forkIO, forkIOWithUnmask, threadDelay)
 import Control.Concurrent.MVar
 import Control.Concurrent.STM (STM, TVar, atomically, modifyTVar', newTVarIO, readTVar)
 import Control.Concurrent.STM.TChan
-import Control.Exception (bracket, bracket_, mask_, try)
+import Control.Exception (bracket, bracket_, finally, mask_, try)
 import Control.Monad (forever, replicateM_)
 import Distribution.Client.Compat.Semaphore
 import Distribution.Client.Utils (numberOfProcessors)
@@ -72,9 +72,9 @@ data JobControl m a = JobControl
   , cleanupJobControl :: m ()
   -- ^ cleanup any resources created by the JobControl, intended to be used
   -- as the finaliser for `bracket`.
-  , jobControlSemaphore :: Maybe SemaphoreName
-  -- ^ Name of the semaphore which can be used to control parallelism, if one
-  -- is available for that job control type.
+  , jobControlSemaphore :: Maybe SemaphoreIdentifier
+  -- ^ Identifier of the semaphore which can be used to control parallelism,
+  -- if one is available for that job control type.
   }
 
 -- | Make a 'JobControl' that executes all jobs serially and in order.
@@ -183,40 +183,48 @@ newSemaphoreJobControl _ n
   | n < 1 || n > 1000 =
       error $ "newParallelJobControl: not a sensible number of jobs: " ++ show n
 newSemaphoreJobControl verbosity maxJobLimit = do
-  sem <- freshSemaphore "cabal_semaphore" maxJobLimit
-  info verbosity $
-    "Created semaphore called "
-      ++ getSemaphoreName (semaphoreName sem)
-      ++ " with "
-      ++ show maxJobLimit
-      ++ " slots."
-  outqVar <- newTChanIO
-  inqVar <- newTChanIO
-  countVar <- newTVarIO 0
-  void (forkIO (worker sem inqVar outqVar))
-  return
-    JobControl
-      { spawnJob = spawn inqVar countVar
-      , collectJob = collect outqVar countVar
-      , remainingJobs = remaining countVar
-      , cancelJobs = cancel inqVar countVar
-      , cleanupJobControl = destroySemaphore sem
-      , jobControlSemaphore = Just (semaphoreName sem)
-      }
+  mbServer <- freshSemaphore "cabal_semaphore" maxJobLimit
+  case mbServer of
+    Left err -> do
+      warn verbosity $
+        "Failed to create semaphore: "
+          ++ show err
+          ++ "; falling back to -j"
+          ++ show maxJobLimit
+          ++ "."
+      newParallelJobControl maxJobLimit
+    Right server -> do
+      let sem = serverClientSemaphore server
+      info verbosity $
+        "Created semaphore called "
+          ++ semaphoreIdentifier (clientSemaphoreName sem)
+          ++ " with "
+          ++ show maxJobLimit
+          ++ " slots."
+      outqVar <- newTChanIO
+      inqVar <- newTChanIO
+      countVar <- newTVarIO 0
+      void (forkIO (worker sem inqVar outqVar))
+      return
+        JobControl
+          { spawnJob = spawn inqVar countVar
+          , collectJob = collect outqVar countVar
+          , remainingJobs = remaining countVar
+          , cancelJobs = cancel inqVar countVar
+          , cleanupJobControl = destroyServerSemaphore server
+          , jobControlSemaphore = Just (semaphoreIdentifier (clientSemaphoreName sem))
+          }
   where
-    worker :: Semaphore -> TChan (IO a) -> TChan (Either SomeException a) -> IO ()
+    worker :: ClientSemaphore -> TChan (IO a) -> TChan (Either SomeException a) -> IO ()
     worker sem inqVar outqVar =
       forever $ do
         job <- atomically $ readTChan inqVar
-        -- mask here, as we need to ensure that the thread which contains the
-        -- release action is spawned. Otherwise, there is the chance that an
-        -- async exception is thrown between the semaphore being taken and the
-        -- thread being spawned.
+        -- mask so that the fork happens atomically with the acquire.
         mask_ $ do
-          waitOnSemaphore sem
+          -- waitOnSemaphore is interruptible under mask_
+          tok <- waitOnSemaphore sem
           void $ forkIOWithUnmask $ \unmask -> do
-            res <- try (unmask job)
-            releaseSemaphore sem 1
+            res <- try (unmask job) `finally` releaseSemaphoreToken tok
             atomically $ writeTChan outqVar res
         -- Try to give GHC enough time to compute the module graph and then
         -- request some additional capabilities if it can make use of them. The
@@ -291,17 +299,39 @@ newJobControlFromParStrat verbosity mcompiler parStrat numJobsCap = case parStra
   UseSem n ->
     case mcompiler of
       Just compiler
-        | jsemSupported compiler ->
+        | jsemSupported compiler
+        , isJsemCompatible compiler ->
             newSemaphoreJobControl verbosity (capJobs n)
+        | jsemSupported compiler ->
+            do
+              warn verbosity $
+                "Semaphore version mismatch (cabal-install uses v"
+                  ++ show (getSemaphoreProtocolVersion semaphoreVersion)
+                  ++ ", but the selected GHC reports "
+                  ++ maybe "no version (assumed v1)" (\v -> "v" ++ show v) (jsemVersion compiler)
+                  ++ "); not using -jsem, GHC will be invoked without semaphore-based parallelism."
+              newParallelJobControl (capJobs n)
         | otherwise ->
             do
-              warn verbosity "-jsem is not supported by the selected compiler, falling back to normal parallelism control."
+              warn verbosity $
+                "-jsem is not supported by the selected compiler; falling back to -j"
+                  ++ show (capJobs n)
+                  ++ "."
               newParallelJobControl (capJobs n)
       Nothing ->
         -- Don't warn in the Nothing case, as there isn't really a "selected" compiler.
         newParallelJobControl (capJobs n)
   where
     capJobs n = min (fromMaybe maxBound numJobsCap) n
+
+-- | Check if the compiler's semaphore version is compatible with ours,
+-- per 'versionsAreCompatible'. A compiler that doesn't report a
+-- @"Semaphore version"@ field is treated as v1.
+isJsemCompatible :: Compiler -> Bool
+isJsemCompatible compiler =
+  versionsAreCompatible (SemaphoreProtocolVersion v) semaphoreVersion
+  where
+    v = fromMaybe 1 (jsemVersion compiler)
 
 withJobControl :: IO (JobControl IO a) -> (JobControl IO a -> IO b) -> IO b
 withJobControl mkJC = bracket mkJC cleanupJobControl

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -90,7 +90,7 @@ import qualified Text.PrettyPrint as Disp
 import Control.Exception (assert, handle)
 import System.Directory (doesDirectoryExist, doesFileExist, renameDirectory)
 import System.FilePath (makeRelative, normalise, takeDirectory, (<.>), (</>))
-import System.Semaphore (SemaphoreName (..))
+import System.Semaphore (SemaphoreIdentifier)
 
 import Distribution.Client.Errors
 import Distribution.Simple.Flag (fromFlagOrDefault)
@@ -481,7 +481,7 @@ rebuildTarget
   :: Verbosity
   -> DistDirLayout
   -> StoreDirLayout
-  -> Maybe SemaphoreName
+  -> Maybe SemaphoreIdentifier
   -> BuildTimeSettings
   -> AsyncFetchMap
   -> Lock

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -117,7 +117,7 @@ import Control.Exception (ErrorCall, Handler (..), SomeAsyncException, assert, c
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, listDirectory)
 import System.FilePath (dropDrive, normalise, takeDirectory, (<.>), (</>))
 import System.IO (Handle, IOMode (AppendMode), withFile)
-import System.Semaphore (SemaphoreName (..))
+import System.Semaphore (SemaphoreIdentifier)
 
 import GHC.Stack
 import Web.Browser (openBrowser)
@@ -159,7 +159,7 @@ data PackageBuildingPhase r where
 buildAndRegisterUnpackedPackage
   :: Verbosity
   -> DistDirLayout
-  -> Maybe SemaphoreName
+  -> Maybe SemaphoreIdentifier
   -- ^ Whether to pass a semaphore to build process
   -- this is different to BuildTimeSettings because the
   -- name of the semaphore is created freshly each time.
@@ -298,7 +298,7 @@ buildAndRegisterUnpackedPackage
       uid = installedUnitId rpkg
 
       comp_par_strat = case maybe_semaphore of
-        Just sem_name -> Cabal.toFlag (getSemaphoreName sem_name)
+        Just sem_ident -> Cabal.toFlag sem_ident
         _ -> Cabal.NoFlag
 
       whenTest action
@@ -476,7 +476,7 @@ buildAndRegisterUnpackedPackage
 buildInplaceUnpackedPackage
   :: Verbosity
   -> DistDirLayout
-  -> Maybe SemaphoreName
+  -> Maybe SemaphoreIdentifier
   -> BuildTimeSettings
   -> Lock
   -> Lock
@@ -687,7 +687,7 @@ buildAndInstallUnpackedPackage
   :: Verbosity
   -> DistDirLayout
   -> StoreDirLayout
-  -> Maybe SemaphoreName
+  -> Maybe SemaphoreIdentifier
   -- ^ Whether to pass a semaphore to build process
   -- this is different to BuildTimeSettings because the
   -- name of the semaphore is created freshly each time.

--- a/cabal.bootstrap.project
+++ b/cabal.bootstrap.project
@@ -12,4 +12,4 @@ packages:
 tests: False
 benchmarks: False
 
-index-state: hackage.haskell.org 2025-06-27T20:43:14Z
+index-state: hackage.haskell.org 2026-05-25T10:36:08Z

--- a/cabal.project
+++ b/cabal.project
@@ -12,3 +12,6 @@ package cabal-install
 
 package Cabal
   flags: +git-rev
+
+package semaphore-compat
+  flags: -build-testing

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -3,7 +3,7 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
-index-state: hackage.haskell.org 2026-05-22T20:43:14Z
+index-state: hackage.haskell.org 2026-05-25T10:36:08Z
 
 -- never include this or its TH dependency in a release!
 package cabal-install

--- a/changelog.d/semaphore-v2-Cabal.md
+++ b/changelog.d/semaphore-v2-Cabal.md
@@ -1,0 +1,16 @@
+---
+synopsis: Expose `jsemVersion` to detect `-jsem` protocol mismatches
+packages: [Cabal]
+prs: 11628
+issues: 9993
+---
+
+The `Compiler` record now exposes a `jsemVersion :: Compiler -> Maybe Int`
+accessor that reads the `"Semaphore version"` field of `ghc --info`.
+Returns `Just v` when GHC reports a value, `Nothing` for compilers
+that don't report the field (older GHCs, or non-GHC compilers).
+
+cabal-install consumes this to detect a protocol mismatch with the
+selected GHC before invoking `ghc -jsem`, so it can fall back to
+its in-process coordinator and warn the user rather than handing GHC
+a name it can't speak.

--- a/changelog.d/semaphore-v2-cabal-install.md
+++ b/changelog.d/semaphore-v2-cabal-install.md
@@ -1,0 +1,39 @@
+---
+synopsis: Update to semaphore-compat 2.0.0 (`-jsem` protocol v2)
+packages: [cabal-install]
+prs: 11628
+issues: 9993
+---
+
+On Linux and other POSIX platforms, cabal-install's `--semaphore`
+jobserver now speaks v2 of the semaphore-compat protocol, which uses
+Unix domain sockets in place of POSIX named semaphores. The v1
+implementation used POSIX named semaphores via `sem_open(3)`, whose
+ABI varies between C standard libraries; a `cabal-install` and `ghc`
+built against different libc could not share a semaphore, breaking
+`-jsem` whenever the toolchain wasn't homogeneous (see
+[cabal #9993](https://github.com/haskell/cabal/issues/9993) and
+[GHC #25087](https://gitlab.haskell.org/ghc/ghc/-/issues/25087)).
+The v2 wire format is independent of libc. Windows is unaffected
+and continues to use the v1 protocol (Win32 named semaphores).
+
+cabal-install now inspects the selected GHC's `"Semaphore version"`
+entry in `ghc --info` (via the new `jsemVersion` field on the `Cabal`
+library's `Compiler` type) to detect a protocol mismatch ahead of
+time. If GHC's reported version is incompatible with the version
+cabal-install supports, cabal-install emits a warning of the form
+
+    Semaphore version mismatch (cabal-install uses vN, but the
+    selected GHC reports vM); not using -jsem, GHC will be invoked
+    without semaphore-based parallelism.
+
+and falls back to its in-process `NumJobs` coordinator instead of
+passing `-jsem` to GHC. The build still succeeds, but loses the
+cross-process module-level parallelism. Upgrading GHC to one that
+supports protocol v2 restores full parallelism.
+
+See also:
+
+- the [GHC proposal amendment](https://github.com/ghc-proposals/ghc-proposals/pull/673)
+- the [GHC patch](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/15729)
+- the [semaphore-compat library MR](https://gitlab.haskell.org/ghc/semaphore-compat/-/merge_requests/8)


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)


Update to semaphore-compat 2.0.0 fixing https://github.com/haskell/cabal/issues/9993 and https://gitlab.haskell.org/ghc/ghc/-/issues/25087
    
semaphore-compat now uses a unix sockets based implementation.

Semaphore identifiers are now versioned, and we can really on the versioning
scheme to detect semaphore version mismatch with GHC and fallback gracefully if
possible.

GHC patch: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/15729

After the GHC patch lands, it will include a "Semaphore version" field in its
settings file/`--info` output that we can use to guide Cabal behaviour.

If this field does not exist (and ghc is 9.8+), then we assume it uses version v1 of the protocol
and this triggers a graceful degradation of behaviour to `-jN` without semaphore based coordination.

See also

semaphore-compat MR: https://gitlab.haskell.org/ghc/semaphore-compat/-/merge_requests/8
ghc-proposals change: https://github.com/ghc-proposals/ghc-proposals/pull/673
