### PR TITLE
Drop support for anything below GHC 8.0.0, base 4.9.0.0, Cabal 1.24.0.0

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -52,9 +52,8 @@ library
     -Wincomplete-uni-patterns
     -Wincomplete-record-updates
     -Wno-unticked-promoted-constructors
-
-  if impl(ghc >= 8.0)
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+    -Wcompat
+    -Wnoncanonical-monad-instances
 
   if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances

--- a/Cabal/src/Distribution/Simple/Build.hs
+++ b/Cabal/src/Distribution/Simple/Build.hs
@@ -920,7 +920,7 @@ createInternalPackageDB
 createInternalPackageDB verbosity lbi distPref = do
   existsAlready <- doesPackageDBExist dbPath
   when existsAlready $ deletePackageDB dbPath
-  createPackageDB verbosity (compiler lbi) (withPrograms lbi) False dbPath
+  createPackageDB verbosity (compiler lbi) (withPrograms lbi) dbPath
   return (SpecificPackageDB dbRelPath)
   where
     dbRelPath = internalPackageDBPath lbi distPref
@@ -1188,7 +1188,7 @@ builtinAutogenFiles pkg lbi clbi =
     pathsFile = AutogenModule (autogenPathsModuleName pkg) (Suffix "hs")
     pathsContents = toUTF8LBS $ generatePathsModule pkg lbi clbi
     packageInfoFile = AutogenModule (autogenPackageInfoModuleName pkg) (Suffix "hs")
-    packageInfoContents = toUTF8LBS $ generatePackageInfoModule pkg lbi
+    packageInfoContents = toUTF8LBS $ generatePackageInfoModule pkg
     cppHeaderFile = AutogenFile $ toShortText cppHeaderName
     cppHeaderContents = toUTF8LBS $ generateCabalMacrosHeader pkg lbi clbi
 

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
@@ -19,11 +19,14 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 import Distribution.Package
-import Distribution.PackageDescription
-import Distribution.Simple.Compiler
-import Distribution.Simple.LocalBuildInfo
-import Distribution.Utils.ShortText
-import Distribution.Version
+  ( PackageName
+  , packageName
+  , packageVersion
+  , unPackageName
+  )
+import Distribution.Types.PackageDescription (PackageDescription (..))
+import Distribution.Types.Version (versionNumbers)
+import Distribution.Utils.ShortText (fromShortText)
 
 import qualified Distribution.Simple.Build.PackageInfoModule.Z as Z
 
@@ -33,8 +36,8 @@ import qualified Distribution.Simple.Build.PackageInfoModule.Z as Z
 
 -- ------------------------------------------------------------
 
-generatePackageInfoModule :: PackageDescription -> LocalBuildInfo -> String
-generatePackageInfoModule pkg_descr lbi =
+generatePackageInfoModule :: PackageDescription -> String
+generatePackageInfoModule pkg_descr =
   Z.render
     Z.Z
       { Z.zPackageName = showPkgName $ packageName pkg_descr
@@ -42,15 +45,7 @@ generatePackageInfoModule pkg_descr lbi =
       , Z.zSynopsis = fromShortText $ synopsis pkg_descr
       , Z.zCopyright = fromShortText $ copyright pkg_descr
       , Z.zHomepage = fromShortText $ homepage pkg_descr
-      , Z.zSupportsNoRebindableSyntax = supports_rebindable_syntax
       }
-  where
-    supports_rebindable_syntax = ghc_newer_than (mkVersion [7, 0, 1])
-
-    ghc_newer_than minVersion =
-      case compilerCompatVersion GHC (compiler lbi) of
-        Nothing -> False
-        Just version -> version `withinRange` orLaterVersion minVersion
 
 showPkgName :: PackageName -> String
 showPkgName = map fixchar . unPackageName

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
@@ -2,7 +2,7 @@
 
 module Distribution.Simple.Build.PackageInfoModule.Z (render, Z (..)) where
 
-import Distribution.ZinzaPrelude
+import Distribution.ZinzaPrelude (Generic, execWriter, tell)
 
 data Z = Z
   { zPackageName :: String
@@ -10,18 +10,12 @@ data Z = Z
   , zSynopsis :: String
   , zCopyright :: String
   , zHomepage :: String
-  , zSupportsNoRebindableSyntax :: Bool
   }
   deriving (Generic)
 
 render :: Z -> String
 render z_root = execWriter $ do
-  if (zSupportsNoRebindableSyntax z_root)
-    then do
-      tell "{-# LANGUAGE NoRebindableSyntax #-}\n"
-      return ()
-    else do
-      return ()
+  tell "{-# LANGUAGE NoRebindableSyntax #-}\n"
   tell "{-# OPTIONS_GHC -w #-}\n"
   tell "\n"
   tell "{-|\n"

--- a/Cabal/src/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule.hs
@@ -44,8 +44,6 @@ generatePathsModule pkg_descr lbi clbi =
     Z.Z
       { Z.zPackageName = packageName pkg_descr
       , Z.zVersionDigits = show $ versionNumbers $ packageVersion pkg_descr
-      , Z.zSupportsCpp = supports_cpp
-      , Z.zSupportsNoRebindableSyntax = supports_rebindable_syntax
       , Z.zAbsolute = absolute
       , Z.zRelocatable = relocatable lbi
       , Z.zIsWindows = isWindows
@@ -63,15 +61,6 @@ generatePathsModule pkg_descr lbi clbi =
       , Z.zSysconfdir = zSysconfdir
       }
   where
-    supports_cpp = supports_language_pragma
-    supports_rebindable_syntax = ghc_newer_than (mkVersion [7, 0, 1])
-    supports_language_pragma = ghc_newer_than (mkVersion [6, 6, 1])
-
-    ghc_newer_than minVersion =
-      case compilerCompatVersion GHC (compiler lbi) of
-        Nothing -> False
-        Just version -> version `withinRange` orLaterVersion minVersion
-
     -- In several cases we cannot make relocatable installations
     absolute =
       hasLibs pkg_descr -- we can only make progs relocatable

--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -5,8 +5,6 @@ import Distribution.ZinzaPrelude
 data Z
     = Z {zPackageName :: PackageName,
          zVersionDigits :: String,
-         zSupportsCpp :: Bool,
-         zSupportsNoRebindableSyntax :: Bool,
          zAbsolute :: Bool,
          zRelocatable :: Bool,
          zIsWindows :: Bool,
@@ -25,18 +23,8 @@ data Z
     deriving Generic
 render :: Z -> String
 render z_root = execWriter $ do
-  if (zSupportsCpp z_root)
-  then do
-    tell "{-# LANGUAGE CPP #-}\n"
-    return ()
-  else do
-    return ()
-  if (zSupportsNoRebindableSyntax z_root)
-  then do
-    tell "{-# LANGUAGE NoRebindableSyntax #-}\n"
-    return ()
-  else do
-    return ()
+  tell "{-# LANGUAGE CPP #-}\n"
+  tell "{-# LANGUAGE NoRebindableSyntax #-}\n"
   if (zNot z_root (zAbsolute z_root))
   then do
     tell "{-# LANGUAGE ForeignFunctionInterface #-}\n"
@@ -91,25 +79,8 @@ render z_root = execWriter $ do
   else do
     return ()
   tell "\n"
-  if (zSupportsCpp z_root)
-  then do
-    tell "#if defined(VERSION_base)\n"
-    tell "\n"
-    tell "#if MIN_VERSION_base(4,0,0)\n"
-    tell "catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a\n"
-    tell "#else\n"
-    tell "catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a\n"
-    tell "#endif\n"
-    tell "\n"
-    tell "#else\n"
-    tell "catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a\n"
-    tell "#endif\n"
-    tell "catchIO = Exception.catch\n"
-    return ()
-  else do
-    tell "catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a\n"
-    tell "catchIO = Exception.catch\n"
-    return ()
+  tell "catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a\n"
+  tell "catchIO = Exception.catch\n"
   tell "\n"
   tell "-- |The package version.\n"
   tell "version :: Version\n"

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -492,15 +492,8 @@ reexportedAsSupported comp = case compilerFlavor comp of
 -- "dynamic-library-dirs"?
 libraryDynDirSupported :: Compiler -> Bool
 libraryDynDirSupported comp = case compilerFlavor comp of
-  GHC ->
-    -- Not just v >= mkVersion [8,0,1,20161022], as there
-    -- are many GHC 8.1 nightlies which don't support this.
-    ( (v >= mkVersion [8, 0, 1, 20161022] && v < mkVersion [8, 1])
-        || v >= mkVersion [8, 1, 20161021]
-    )
+  GHC -> True
   _ -> False
-  where
-    v = compilerVersion comp
 
 -- | Does this compiler's "ar" command supports response file
 -- arguments (i.e. @file-style arguments).

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -2922,12 +2922,7 @@ checkForeignLibSupported :: Compiler -> Platform -> ForeignLib -> Maybe String
 checkForeignLibSupported comp platform flib = go (compilerFlavor comp)
   where
     go :: CompilerFlavor -> Maybe String
-    go GHC
-      | compilerVersion comp < mkVersion [7, 8] =
-          unsupported
-            [ "Building foreign libraries is only supported with GHC >= 7.8"
-            ]
-      | otherwise = goGhcPlatform platform
+    go GHC = goGhcPlatform platform
     go _ =
       unsupported
         [ "Building foreign libraries is currently only supported with ghc"

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -199,8 +199,8 @@ configureCompiler verbosity hcPath conf0 = do
         ++ prettyShow ghcVersion
 
   let implInfo = ghcVersionImplInfo ghcVersion
-  languages <- Internal.getLanguages verbosity implInfo ghcProg
-  extensions0 <- Internal.getExtensions verbosity implInfo ghcProg
+  languages <- Internal.getLanguages implInfo
+  extensions0 <- Internal.getExtensions verbosity ghcProg
 
   ghcInfo <- Internal.getGhcInfo verbosity implInfo ghcProg
 
@@ -1106,23 +1106,9 @@ installLib verbosity lbi targetDir dynlibTargetDir bytecodeTargetDir _builtDir p
 -- -----------------------------------------------------------------------------
 -- Registering
 
-hcPkgInfo :: ProgramDb -> HcPkg.HcPkgInfo
+hcPkgInfo :: ProgramDb -> HcPkg.ConfiguredProgram
 hcPkgInfo progdb =
-  HcPkg.HcPkgInfo
-    { HcPkg.hcPkgProgram = ghcPkgProg
-    , HcPkg.noPkgDbStack = v < [6, 9]
-    , HcPkg.noVerboseFlag = v < [6, 11]
-    , HcPkg.flagPackageConf = v < [7, 5]
-    , HcPkg.supportsDirDbs = v >= [6, 8]
-    , HcPkg.requiresDirDbs = v >= [7, 10]
-    , HcPkg.nativeMultiInstance = v >= [7, 10]
-    , HcPkg.recacheMultiInstance = v >= [6, 12]
-    , HcPkg.suppressFilesCheck = v >= [6, 6]
-    }
-  where
-    v = versionNumbers ver
-    ghcPkgProg = fromMaybe (error "GHC.hcPkgInfo: no ghc program") $ lookupProgram ghcPkgProgram progdb
-    ver = fromMaybe (error "GHC.hcPkgInfo: no ghc version") $ programVersion ghcPkgProg
+  fromMaybe (error "GHC.hcPkgInfo: no ghc program") $ lookupProgram ghcPkgProgram progdb
 
 registerPackage
   :: Verbosity

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -17,7 +17,6 @@ import Distribution.Compat.ResponseFile
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import qualified Distribution.InstalledPackageInfo as IPI
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-import qualified Distribution.ModuleName as ModuleName
 import Distribution.Package
 import Distribution.PackageDescription as PD
 import Distribution.PackageDescription.Utils (cabalBug)
@@ -32,7 +31,6 @@ import Distribution.Simple.GHC.ImplInfo
 import qualified Distribution.Simple.GHC.Internal as Internal
 import Distribution.Simple.LocalBuildInfo
 import qualified Distribution.Simple.PackageIndex as PackageIndex
-import Distribution.Simple.PreProcess.Types
 import Distribution.Simple.Program
 import qualified Distribution.Simple.Program.Ar as Ar
 import Distribution.Simple.Program.GHC
@@ -228,7 +226,7 @@ linkOrLoadComponent
                 CLib lib -> do
                   let libWays = wantedLibWays isIndef
                   rpaths <- get_rpaths (Set.fromList libWays)
-                  linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg lib lbi clbi extraSources rpaths libWays
+                  linkLibrary buildTargetDir cleanedExtraLibDirs verbosity runGhcProg lib lbi clbi extraSources rpaths libWays
                 CFLib flib -> do
                   let flib_way = wantedFLibWay (withDynFLib flib)
                   rpaths <- get_rpaths (Set.singleton flib_way)
@@ -243,8 +241,6 @@ linkLibrary
   -- ^ The library target build directory
   -> [SymbolicPath Pkg (Dir Lib)]
   -- ^ The list of extra lib dirs that exist (aka "cleaned")
-  -> PackageDescription
-  -- ^ The package description containing this library
   -> Verbosity
   -> (GhcOptions -> IO ())
   -- ^ Run the configured Ghc program
@@ -258,18 +254,13 @@ linkLibrary
   -> [BuildWay]
   -- ^ Wanted build ways and corresponding build options
   -> IO ()
-linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg lib lbi clbi extraSources rpaths wantedWays = do
+linkLibrary buildTargetDir cleanedExtraLibDirs verbosity runGhcProg lib lbi clbi extraSources rpaths wantedWays = do
   let
-    common = configCommonFlags $ configFlags lbi
-    mbWorkDir = flagToMaybe $ setupWorkingDir common
-
     compiler_id = compilerId comp
     comp = compiler lbi
-    ghcVersion = compilerVersion comp
     implInfo = getImplInfo comp
     uid = componentUnitId clbi
     libBi = libBuildInfo lib
-    Platform _hostArch hostOS = hostPlatform lbi
     vanillaLibFilePath = buildTargetDir </> makeRelativePathEx (mkLibName uid)
     profileLibFilePath = buildTargetDir </> makeRelativePathEx (mkProfLibName uid)
     sharedLibFilePath =
@@ -286,19 +277,6 @@ linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg li
         </> makeRelativePathEx (mkBytecodeLibName compiler_id uid)
     ghciLibFilePath = buildTargetDir </> makeRelativePathEx (Internal.mkGHCiLibName uid)
     ghciProfLibFilePath = buildTargetDir </> makeRelativePathEx (Internal.mkGHCiProfLibName uid)
-    libInstallPath =
-      libdir $
-        absoluteComponentInstallDirs
-          pkg_descr
-          lbi
-          uid
-          NoCopyDest
-    sharedLibInstallPath =
-      libInstallPath
-        </> mkSharedLibName (hostPlatform lbi) compiler_id uid
-    profSharedLibInstallPath =
-      libInstallPath
-        </> mkProfSharedLibName (hostPlatform lbi) compiler_id uid
 
     getObjWayFiles :: BuildWay -> IO [SymbolicPath Pkg File]
     getObjWayFiles w = getObjFiles (buildWayObjectExtension objExtension w) (buildWayObjectExtension objExtension w)
@@ -318,18 +296,6 @@ linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg li
             hs_ext
             True
         , pure $ map (srcObjPath obj_ext) extraSources
-        , catMaybes
-            <$> sequenceA
-              [ findFileCwdWithExtension
-                mbWorkDir
-                [Suffix obj_ext]
-                [buildTargetDir]
-                xPath
-              | ghcVersion < mkVersion [7, 2] -- ghc-7.2+ does not make _stub.o files
-              , x <- allLibModules lib clbi
-              , let xPath :: RelativePath Artifacts File
-                    xPath = makeRelativePathEx $ ModuleName.toFilePath x ++ "_stub"
-              ]
         ]
 
     -- Get the @.o@ path from a source path (e.g. @.hs@),
@@ -397,14 +363,7 @@ linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg li
         , ghcOptDynLinkMode = toFlag GhcDynamicOnly
         , ghcOptInputFiles = toNubListR $ map coerceSymbolicPath dynObjectFiles
         , ghcOptOutputFile = toFlag sharedLibFilePath
-        , -- For dynamic libs, Mac OS/X needs to know the install location
-          -- at build time. This only applies to GHC < 7.8 - see the
-          -- discussion in #1660.
-          ghcOptDylibName =
-            if hostOS == OSX
-              && ghcVersion < mkVersion [7, 8]
-              then toFlag sharedLibInstallPath
-              else mempty
+        , ghcOptDylibName = mempty
         , ghcOptLinkLibs = extraLibs libBi
         , ghcOptLinkLibPath = toNubListR cleanedExtraLibDirs
         , ghcOptLinkFrameworks = toNubListR $ map getSymbolicPath $ PD.frameworks libBi
@@ -423,14 +382,7 @@ linkLibrary buildTargetDir cleanedExtraLibDirs pkg_descr verbosity runGhcProg li
         , ghcOptDynLinkMode = toFlag GhcDynamicOnly
         , ghcOptInputFiles = toNubListR pdynObjectFiles
         , ghcOptOutputFile = toFlag profSharedLibFilePath
-        , -- For dynamic libs, Mac OS/X needs to know the install location
-          -- at build time. This only applies to GHC < 7.8 - see the
-          -- discussion in #1660.
-          ghcOptDylibName =
-            if hostOS == OSX
-              && ghcVersion < mkVersion [7, 8]
-              then toFlag profSharedLibInstallPath
-              else mempty
+        , ghcOptDylibName = mempty
         , ghcOptLinkLibs = extraLibs libBi
         , ghcOptLinkLibPath = toNubListR cleanedExtraLibDirs
         , ghcOptLinkFrameworks = toNubListR $ map getSymbolicPath $ PD.frameworks libBi
@@ -543,14 +495,11 @@ linkExecutable linkerOpts (way, buildOpts) targetDir targetName runGhcProg lbi =
               -- assume there is a main function in another non-haskell object
               ghcOptLinkNoHsMain = toFlag (ghcOptInputFiles baseOpts == mempty && ghcOptInputScripts baseOpts == mempty)
             }
-      comp = compiler lbi
 
   -- Work around old GHCs not relinking in this
   -- situation, see #3294
   let target =
         targetDir </> makeRelativePathEx (exeTargetName (hostPlatform lbi) targetName)
-  when (compilerVersion comp < mkVersion [7, 7]) $
-    removeFileForcibly (interpretSymbolicPathLBI lbi target)
   runGhcProg linkOpts{ghcOptOutputFile = toFlag target}
 
 -- | Link a foreign library component
@@ -657,7 +606,7 @@ getRPaths pbci = do
     supportRPaths OSX = True
     supportRPaths FreeBSD =
       case compid of
-        CompilerId GHC ver | ver >= mkVersion [7, 10, 2] -> True
+        CompilerId GHC _ -> True
         _ -> False
     supportRPaths OpenBSD = False
     supportRPaths NetBSD = False

--- a/Cabal/src/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/src/Distribution/Simple/GHC/ImplInfo.hs
@@ -20,7 +20,13 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 import Distribution.Simple.Compiler
-import Distribution.Version
+  ( Compiler
+  , CompilerFlavor (..)
+  , compilerCompatVersion
+  , compilerFlavor
+  , compilerVersion
+  )
+import Distribution.Types.Version (Version, versionNumbers)
 
 -- |
 --      Information about features and quirks of a GHC-based implementation.
@@ -34,30 +40,14 @@ import Distribution.Version
 --      module) should use implementation info rather than version numbers
 --      to test for supported features.
 data GhcImplInfo = GhcImplInfo
-  { supportsHaskell2010 :: Bool
-  -- ^ -XHaskell2010 and -XHaskell98 flags
-  , supportsGHC2021 :: Bool
+  { supportsGHC2021 :: Bool
   -- ^ -XGHC2021 flag
   , supportsGHC2024 :: Bool
   -- ^ -XGHC2024 flag
-  , reportsNoExt :: Bool
-  -- ^ --supported-languages gives Ext and NoExt
-  , alwaysNondecIndent :: Bool
-  -- ^ NondecreasingIndentation is always on
-  , flagGhciScript :: Bool
-  -- ^ -ghci-script flag supported
-  , flagProfAuto :: Bool
-  -- ^ new style -fprof-auto* flags
   , flagProfLate :: Bool
   -- ^ fprof-late flag
-  , flagPackageConf :: Bool
-  -- ^ use package-conf instead of package-db
-  , flagDebugInfo :: Bool
-  -- ^ -g flag supported
   , flagHie :: Bool
   -- ^ -hiedir flag supported
-  , supportsDebugLevels :: Bool
-  -- ^ supports numeric @-g@ levels
   , supportsPkgEnvFiles :: Bool
   -- ^ picks up @.ghc.environment@ files
   , flagWarnMissingHomeModules :: Bool
@@ -88,18 +78,10 @@ getImplInfo comp =
 ghcVersionImplInfo :: Version -> GhcImplInfo
 ghcVersionImplInfo ver =
   GhcImplInfo
-    { supportsHaskell2010 = v >= [7]
-    , supportsGHC2021 = v >= [9, 1]
+    { supportsGHC2021 = v >= [9, 1]
     , supportsGHC2024 = v >= [9, 9]
-    , reportsNoExt = v >= [7]
-    , alwaysNondecIndent = v < [7, 1]
-    , flagGhciScript = v >= [7, 2]
-    , flagProfAuto = v >= [7, 4]
     , flagProfLate = v >= [9, 4]
-    , flagPackageConf = v < [7, 5]
-    , flagDebugInfo = v >= [7, 10]
     , flagHie = v >= [8, 8]
-    , supportsDebugLevels = v >= [8, 0]
     , supportsPkgEnvFiles = v >= [8, 0, 1, 20160901] -- broken in 8.0.1, fixed in 8.0.2
     , flagWarnMissingHomeModules = v >= [8, 2]
     , unitIdForExes = v >= [9, 2]
@@ -115,18 +97,10 @@ ghcjsVersionImplInfo
   -> GhcImplInfo
 ghcjsVersionImplInfo _ghcjsver ghcver =
   GhcImplInfo
-    { supportsHaskell2010 = True
-    , supportsGHC2021 = True
+    { supportsGHC2021 = ghcv >= [9, 1]
     , supportsGHC2024 = ghcv >= [9, 9]
-    , reportsNoExt = True
-    , alwaysNondecIndent = False
-    , flagGhciScript = True
-    , flagProfAuto = True
-    , flagProfLate = True
-    , flagPackageConf = False
-    , flagDebugInfo = False
+    , flagProfLate = ghcv >= [9, 4]
     , flagHie = ghcv >= [8, 8]
-    , supportsDebugLevels = ghcv >= [8, 0]
     , supportsPkgEnvFiles = ghcv >= [8, 0, 2] -- TODO: check this works in ghcjs
     , flagWarnMissingHomeModules = ghcv >= [8, 2]
     , unitIdForExes = ghcv >= [9, 2]

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -192,10 +192,8 @@ configureToolchain _implInfo ghcProg ghcInfo =
 
     ccFlags = getFlags "C compiler flags"
     cxxFlags = getFlags "C++ compiler flags"
-    -- GHC 7.8 renamed "Gcc Linker flags" to "C compiler link flags"
-    -- and "Ld Linker flags" to "ld flags" (GHC #4862).
-    gccLinkerFlags = getFlags "Gcc Linker flags" ++ getFlags "C compiler link flags"
-    ldLinkerFlags = getFlags "Ld Linker flags" ++ getFlags "ld flags"
+    gccLinkerFlags = getFlags "C compiler link flags"
+    ldLinkerFlags = getFlags "ld flags"
 
     -- It appears that GHC 7.6 and earlier encode the tokenized flags as a
     -- [String] in these settings whereas later versions just encode the flags as
@@ -271,11 +269,9 @@ configureToolchain _implInfo ghcProg ghcInfo =
         else return ldProg
 
 getLanguages
-  :: Verbosity
-  -> GhcImplInfo
-  -> ConfiguredProgram
+  :: GhcImplInfo
   -> IO [(Language, String)]
-getLanguages _ implInfo _
+getLanguages implInfo
   -- TODO: should be using --supported-languages rather than hard coding
   | supportsGHC2024 implInfo =
       return
@@ -290,12 +286,11 @@ getLanguages _ implInfo _
         , (Haskell2010, "-XHaskell2010")
         , (Haskell98, "-XHaskell98")
         ]
-  | supportsHaskell2010 implInfo =
+  | otherwise =
       return
         [ (Haskell98, "-XHaskell98")
         , (Haskell2010, "-XHaskell2010")
         ]
-  | otherwise = return [(Haskell98, "")]
 
 getGhcInfo
   :: Verbosity
@@ -317,45 +312,18 @@ getGhcInfo verbosity _implInfo ghcProg = do
 
 getExtensions
   :: Verbosity
-  -> GhcImplInfo
   -> ConfiguredProgram
   -> IO [(Extension, Maybe String)]
-getExtensions verbosity implInfo ghcProg = do
+getExtensions verbosity ghcProg = do
   str <-
     getProgramOutput
       verbosity
       (suppressOverrideArgs ghcProg)
       ["--supported-languages"]
-  let extStrs =
-        if reportsNoExt implInfo
-          then lines str
-          else -- Older GHCs only gave us either Foo or NoFoo,
-          -- so we have to work out the other one ourselves
-
-            [ extStr''
-            | extStr <- lines str
-            , let extStr' = case extStr of
-                    'N' : 'o' : xs -> xs
-                    _ -> "No" ++ extStr
-            , extStr'' <- [extStr, extStr']
-            ]
-  let extensions0 =
-        [ (ext, Just $ "-X" ++ prettyShow ext)
-        | Just ext <- map simpleParsec extStrs
-        ]
-      extensions1 =
-        if alwaysNondecIndent implInfo
-          then -- ghc-7.2 split NondecreasingIndentation off
-          -- into a proper extension. Before that it
-          -- was always on.
-          -- Since it was not a proper extension, it could
-          -- not be turned off, hence we omit a
-          -- DisableExtension entry here.
-
-            (EnableExtension NondecreasingIndentation, Nothing)
-              : extensions0
-          else extensions0
-  return extensions1
+  return
+    [ (ext, Just $ "-X" ++ prettyShow ext)
+    | Just ext <- map simpleParsec $ lines str
+    ]
 
 includePaths
   :: LocalBuildInfo

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -153,8 +153,8 @@ configureCompiler verbosity hcPath conf0 = do
 
   let implInfo = ghcjsVersionImplInfo ghcjsVersion ghcjsGhcVersion
 
-  languages <- Internal.getLanguages verbosity implInfo ghcjsProg
-  extensions <- Internal.getExtensions verbosity implInfo ghcjsProg
+  languages <- Internal.getLanguages implInfo
+  extensions <- Internal.getExtensions verbosity ghcjsProg
 
   ghcjsInfo <- Internal.getGhcInfo verbosity implInfo ghcjsProg
   let ghcInfoMap = Map.fromList ghcjsInfo
@@ -793,15 +793,7 @@ buildOrReplLib mReplFlags verbosity numJobs _pkg_descr lbi lib clbi = do
               , ghcOptInputFiles = toNubListR dynamicObjectFiles
               , ghcOptOutputFile = toFlag sharedLibFilePath
               , ghcOptExtra = hcOptions GHC libBi ++ hcSharedOptions GHC libBi
-              , -- For dynamic libs, Mac OS/X needs to know the install location
-                -- at build time. This only applies to GHC < 7.8 - see the
-                -- discussion in #1660.
-                {-
-                    ghcOptDylibName          = if hostOS == OSX
-                                                  && ghcVersion < mkVersion [7,8]
-                                                then toFlag sharedLibInstallPath
-                                                else mempty, -}
-                ghcOptHideAllPackages = toFlag True
+              , ghcOptHideAllPackages = toFlag True
               , ghcOptNoAutoLinkPackages = toFlag True
               , ghcOptPackageDBs = withPackageDB lbi
               , ghcOptThisUnitId = case clbi of
@@ -1552,8 +1544,6 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
       -- Work around old GHCs not relinking in this
       -- situation, see #3294
       let target = targetDir </> makeRelativePathEx targetName
-      when (compilerVersion comp < mkVersion [7, 7]) $
-        removeFileForcibly (i target)
       runGhcProg linkOpts{ghcOptOutputFile = toFlag target}
     GBuildFLib flib -> do
       let rtsInfo = extractRtsInfo lbi
@@ -1722,7 +1712,7 @@ getRPaths lbi clbi | supportRPaths hostOS = do
     supportRPaths OSX = True
     supportRPaths FreeBSD =
       case compid of
-        CompilerId GHC ver | ver >= mkVersion [7, 10, 2] -> True
+        CompilerId GHC _ -> True
         _ -> False
     supportRPaths OpenBSD = False
     supportRPaths NetBSD = False
@@ -2015,23 +2005,9 @@ findGhcjsPkgGhcjsVersion verbosity pgm =
 -- -----------------------------------------------------------------------------
 -- Registering
 
-hcPkgInfo :: ProgramDb -> HcPkg.HcPkgInfo
+hcPkgInfo :: ProgramDb -> HcPkg.ConfiguredProgram
 hcPkgInfo progdb =
-  HcPkg.HcPkgInfo
-    { HcPkg.hcPkgProgram = ghcjsPkgProg
-    , HcPkg.noPkgDbStack = False
-    , HcPkg.noVerboseFlag = False
-    , HcPkg.flagPackageConf = False
-    , HcPkg.supportsDirDbs = True
-    , HcPkg.requiresDirDbs = ver >= v7_10
-    , HcPkg.nativeMultiInstance = ver >= v7_10
-    , HcPkg.recacheMultiInstance = True
-    , HcPkg.suppressFilesCheck = True
-    }
-  where
-    v7_10 = mkVersion [7, 10]
-    ghcjsPkgProg = fromMaybe (error "GHCJS.hcPkgInfo no ghcjs program") $ lookupProgram ghcjsPkgProgram progdb
-    ver = fromMaybe (error "GHCJS.hcPkgInfo no ghcjs version") $ programVersion ghcjsPkgProg
+  fromMaybe (error "GHCJS.hcPkgInfo no ghcjs program") $ lookupProgram ghcjsPkgProgram progdb
 
 registerPackage
   :: Verbosity

--- a/Cabal/src/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/src/Distribution/Simple/Program/Builtin.hs
@@ -105,20 +105,7 @@ ghcProgram =
     }
   where
     ghcPostConf _verbosity ghcProg = do
-      let setLanguageEnv prog =
-            prog
-              { programOverrideEnv =
-                  ("LANGUAGE", Just "en")
-                    : programOverrideEnv ghcProg
-              }
-
-          ignorePackageEnv prog = prog{programDefaultArgs = "-package-env=-" : programDefaultArgs prog}
-
-          -- Only the 7.8 branch seems to be affected. Fixed in 7.8.4.
-          affectedVersionRange =
-            intersectVersionRanges
-              (laterVersion $ mkVersion [7, 8, 0])
-              (earlierVersion $ mkVersion [7, 8, 4])
+      let ignorePackageEnv prog = prog{programDefaultArgs = "-package-env=-" : programDefaultArgs prog}
 
           canIgnorePackageEnv = orLaterVersion $ mkVersion [8, 4, 4]
 
@@ -130,11 +117,7 @@ ghcProgram =
           ( \v ->
               -- By default, ignore GHC_ENVIRONMENT variable of any package environment
               -- files. See #10759
-              applyWhen (withinRange v canIgnorePackageEnv) ignorePackageEnv
-              -- Workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/8825
-              -- (spurious warning on non-english locales)
-              $
-                applyWhen (withinRange v affectedVersionRange) setLanguageEnv ghcProg
+              applyWhen (withinRange v canIgnorePackageEnv) ignorePackageEnv ghcProg
           )
           (programVersion ghcProg)
 

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -797,18 +797,12 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
               | not (flagBool ghcOptProfilingMode) ->
                   []
             Nothing -> []
-            Just GhcProfAutoAll
-              | flagProfAuto implInfo -> ["-fprof-auto"]
-              | otherwise -> ["-auto-all"] -- not the same, but close
+            Just GhcProfAutoAll -> ["-fprof-auto"]
             Just GhcProfLate
               | flagProfLate implInfo -> ["-fprof-late"]
               | otherwise -> ["-fprof-auto-top"] -- not the same, not very close, but what we have.
-            Just GhcProfAutoToplevel
-              | flagProfAuto implInfo -> ["-fprof-auto-top"]
-              | otherwise -> ["-auto-all"]
-            Just GhcProfAutoExported
-              | flagProfAuto implInfo -> ["-fprof-auto-exported"]
-              | otherwise -> ["-auto"]
+            Just GhcProfAutoToplevel -> ["-fprof-auto-top"]
+            Just GhcProfAutoExported -> ["-fprof-auto-exported"]
         , ["-split-sections" | flagBool ghcOptSplitSections]
         , case compilerCompatVersion GHC comp of
             -- the -split-objs flag was removed in GHC 9.8
@@ -949,9 +943,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
         , ----------------------------
           -- Language and extensions
 
-          if supportsHaskell2010 implInfo
-            then ["-X" ++ prettyShow lang | lang <- flag ghcOptLanguage]
-            else []
+          ["-X" ++ prettyShow lang | lang <- flag ghcOptLanguage]
         , [ ext'
           | ext <- flags ghcOptExtensions
           , ext' <- case Map.lookup ext (ghcOptExtensionMap opts) of
@@ -966,7 +958,9 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
         , ----------------
           -- GHCi
 
-          concat [["-ghci-script", script] | flagGhciScript implInfo, script <- ghcOptGHCiScripts opts]
+          concat
+            [ ["-ghci-script", script] | script <- ghcOptGHCiScripts opts
+            ]
         , ---------------
           -- Inputs
 

--- a/Cabal/src/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/src/Distribution/Simple/Program/HcPkg.hs
@@ -14,7 +14,7 @@
 -- Currently only GHC and GHCJS have hc-pkg programs.
 module Distribution.Simple.Program.HcPkg
   ( -- * Types
-    HcPkgInfo (..)
+    ConfiguredProgram (..)
   , RegisterOptions (..)
   , defaultRegisterOptions
 
@@ -45,19 +45,44 @@ module Distribution.Simple.Program.HcPkg
 import Distribution.Compat.Prelude hiding (init)
 import Prelude ()
 
-import Distribution.InstalledPackageInfo
-import Distribution.Parsec
-import Distribution.Pretty
+import Distribution.InstalledPackageInfo (InstalledPackageInfo (..), parseInstalledPackageInfo, showInstalledPackageInfo)
+import Distribution.Parsec (simpleParsec)
+import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Compiler
-import Distribution.Simple.Errors
+  ( PackageDB
+  , PackageDBS
+  , PackageDBStack
+  , PackageDBStackS
+  , PackageDBX (..)
+  , registrationPackageDB
+  )
+import Distribution.Simple.Errors (CabalException (..))
 import Distribution.Simple.Program.Run
-import Distribution.Simple.Program.Types
-import Distribution.Simple.Utils
-import Distribution.Types.ComponentId
-import Distribution.Types.PackageId
-import Distribution.Types.UnitId
+  ( IOEncoding (..)
+  , ProgramInvocation (..)
+  , getProgramInvocationLBS
+  , getProgramInvocationOutput
+  , programInvocation
+  , programInvocationCwd
+  , runProgramInvocation
+  )
+import Distribution.Simple.Program.Types (ConfiguredProgram (..))
+import Distribution.Simple.Utils (IOData (..), dieWithException, writeUTF8File)
+import Distribution.Types.ComponentId (mkComponentId)
+import Distribution.Types.PackageId (PackageId)
+import Distribution.Types.UnitId (mkLegacyUnitId, unUnitId)
 import Distribution.Utils.Path
-import Distribution.Verbosity
+  ( CWD
+  , FileLike ((<.>))
+  , FileOrDir (Dir)
+  , PathLike ((</>))
+  , Pkg
+  , PkgDB
+  , SymbolicPath
+  , interpretSymbolicPath
+  , interpretSymbolicPathCWD
+  )
+import Distribution.Verbosity (Verbosity, VerbosityLevel (..), verbosityLevel)
 
 import Data.List (stripPrefix)
 import System.FilePath as FilePath
@@ -72,53 +97,27 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List.NonEmpty as NE
 import qualified System.FilePath.Posix as FilePath.Posix
 
--- | Information about the features and capabilities of an @hc-pkg@
---   program.
-data HcPkgInfo = HcPkgInfo
-  { hcPkgProgram :: ConfiguredProgram
-  , noPkgDbStack :: Bool
-  -- ^ no package DB stack supported
-  , noVerboseFlag :: Bool
-  -- ^ hc-pkg does not support verbosity flags
-  , flagPackageConf :: Bool
-  -- ^ use package-conf option instead of package-db
-  , supportsDirDbs :: Bool
-  -- ^ supports directory style package databases
-  , requiresDirDbs :: Bool
-  -- ^ requires directory style package databases
-  , nativeMultiInstance :: Bool
-  -- ^ supports --enable-multi-instance flag
-  , recacheMultiInstance :: Bool
-  -- ^ supports multi-instance via recache
-  , suppressFilesCheck :: Bool
-  -- ^ supports --force-files or equivalent
-  }
-
 -- | Call @hc-pkg@ to initialise a package database at the location {path}.
 --
 -- > hc-pkg init {path}
-init :: HcPkgInfo -> Verbosity -> Bool -> FilePath -> IO ()
-init hpi verbosity preferCompat path
-  | not (supportsDirDbs hpi)
-      || (not (requiresDirDbs hpi) && preferCompat) =
-      writeFile path "[]"
-  | otherwise =
-      runProgramInvocation verbosity (initInvocation hpi verbosity path)
+init :: ConfiguredProgram -> Verbosity -> FilePath -> IO ()
+init hpi verbosity path =
+  runProgramInvocation verbosity (initInvocation hpi verbosity path)
 
 -- | Run @hc-pkg@ using a given package DB stack, directly forwarding the
 -- provided command-line arguments to it.
 invoke
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> Verbosity
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDBStack
   -> [String]
   -> IO ()
-invoke hpi verbosity mbWorkDir dbStack extraArgs =
+invoke ghcProg verbosity mbWorkDir dbStack extraArgs =
   runProgramInvocation verbosity invocation
   where
-    args = packageDbStackOpts hpi dbStack ++ extraArgs
-    invocation = programInvocationCwd mbWorkDir (hcPkgProgram hpi) args
+    args = packageDbStackOpts dbStack ++ extraArgs
+    invocation = programInvocationCwd mbWorkDir ghcProg args
 
 -- | Additional variations in the behaviour for 'register'.
 data RegisterOptions = RegisterOptions
@@ -126,9 +125,7 @@ data RegisterOptions = RegisterOptions
   -- ^ Allows re-registering \/ overwriting an existing package
   , registerMultiInstance :: Bool
   -- ^ Insist on the ability to register multiple instances of a
-  -- single version of a single package. This will fail if the @hc-pkg@
-  -- does not support it, see 'nativeMultiInstance' and
-  -- 'recacheMultiInstance'.
+  -- single version of a single package.
   , registerSuppressFilesCheck :: Bool
   -- ^ Require that no checks are performed on the existence of package
   -- files mentioned in the registration info. This must be used if
@@ -149,7 +146,7 @@ defaultRegisterOptions =
 --
 -- > hc-pkg register {filename | -} [--user | --global | --package-db]
 register
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> Verbosity
   -> Maybe (SymbolicPath CWD (Dir from))
   -> PackageDBStackS from
@@ -157,26 +154,10 @@ register
   -> RegisterOptions
   -> IO ()
 register hpi verbosity mbWorkDir packagedbs pkgInfo registerOptions
-  | registerMultiInstance registerOptions
-  , not (nativeMultiInstance hpi || recacheMultiInstance hpi) =
-      dieWithException verbosity RegMultipleInstancePkg
-  | registerSuppressFilesCheck registerOptions
-  , not (suppressFilesCheck hpi) =
-      dieWithException verbosity SuppressingChecksOnFile
-  -- This is a trick. Older versions of GHC do not support the
-  -- --enable-multi-instance flag for ghc-pkg register but it turns out that
-  -- the same ability is available by using ghc-pkg recache. The recache
-  -- command is there to support distro package managers that like to work
-  -- by just installing files and running update commands, rather than
-  -- special add/remove commands. So the way to register by this method is
-  -- to write the package registration file directly into the package db and
-  -- then call hc-pkg recache.
-  --
-  | registerMultiInstance registerOptions
-  , recacheMultiInstance hpi =
+  | registerMultiInstance registerOptions =
       do
         let pkgdb = registrationPackageDB packagedbs
-        writeRegistrationFileDirectly verbosity hpi mbWorkDir pkgdb pkgInfo
+        writeRegistrationFileDirectly verbosity mbWorkDir pkgdb pkgInfo
         recache hpi verbosity mbWorkDir pkgdb
   | otherwise =
       runProgramInvocation
@@ -185,27 +166,24 @@ register hpi verbosity mbWorkDir packagedbs pkgInfo registerOptions
 
 writeRegistrationFileDirectly
   :: Verbosity
-  -> HcPkgInfo
   -> Maybe (SymbolicPath CWD (Dir from))
   -> PackageDBS from
   -> InstalledPackageInfo
   -> IO ()
-writeRegistrationFileDirectly verbosity hpi mbWorkDir (SpecificPackageDB dir) pkgInfo
-  | supportsDirDbs hpi =
-      do
-        let pkgfile = interpretSymbolicPath mbWorkDir dir </> prettyShow (installedUnitId pkgInfo) <.> "conf"
-        writeUTF8File pkgfile (showInstalledPackageInfo pkgInfo)
-  | otherwise =
-      dieWithException verbosity NoSupportDirStylePackageDb
-writeRegistrationFileDirectly verbosity _ _ _ _ =
-  -- We don't know here what the dir for the global or user dbs are,
-  -- if that's needed it'll require a bit more plumbing to support.
-  dieWithException verbosity OnlySupportSpecificPackageDb
+writeRegistrationFileDirectly verbosity mbWorkDir package pkgInfo =
+  case package of
+    (SpecificPackageDB dir) -> do
+      let pkgfile = interpretSymbolicPath mbWorkDir dir </> prettyShow (installedUnitId pkgInfo) <.> "conf"
+      writeUTF8File pkgfile (showInstalledPackageInfo pkgInfo)
+    _ -> do
+      -- We don't know here what the dir for the global or user dbs are,
+      -- if that's needed it'll require a bit more plumbing to support.
+      dieWithException verbosity OnlySupportSpecificPackageDb
 
 -- | Call @hc-pkg@ to unregister a package
 --
 -- > hc-pkg unregister [pkgid] [--user | --global | --package-db]
-unregister :: HcPkgInfo -> Verbosity -> Maybe (SymbolicPath CWD (Dir Pkg)) -> PackageDB -> PackageId -> IO ()
+unregister :: ConfiguredProgram -> Verbosity -> Maybe (SymbolicPath CWD (Dir Pkg)) -> PackageDB -> PackageId -> IO ()
 unregister hpi verbosity mbWorkDir packagedb pkgid =
   runProgramInvocation
     verbosity
@@ -214,7 +192,7 @@ unregister hpi verbosity mbWorkDir packagedb pkgid =
 -- | Call @hc-pkg@ to recache the registered packages.
 --
 -- > hc-pkg recache [--user | --global | --package-db]
-recache :: HcPkgInfo -> Verbosity -> Maybe (SymbolicPath CWD (Dir from)) -> PackageDBS from -> IO ()
+recache :: ConfiguredProgram -> Verbosity -> Maybe (SymbolicPath CWD (Dir from)) -> PackageDBS from -> IO ()
 recache hpi verbosity mbWorkDir packagedb =
   runProgramInvocation
     verbosity
@@ -224,7 +202,7 @@ recache hpi verbosity mbWorkDir packagedb =
 --
 -- > hc-pkg expose [pkgid] [--user | --global | --package-db]
 expose
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> Verbosity
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDB
@@ -239,28 +217,28 @@ expose hpi verbosity mbWorkDir packagedb pkgid =
 --
 -- > hc-pkg describe [pkgid] [--user | --global | --package-db]
 describe
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> Verbosity
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDBStack
   -> PackageId
   -> IO [InstalledPackageInfo]
-describe hpi verbosity mbWorkDir packagedb pid = do
+describe ghcProg verbosity mbWorkDir packagedb pid = do
   output <-
     getProgramInvocationLBS
       verbosity
-      (describeInvocation hpi (verbosityLevel verbosity) mbWorkDir packagedb pid)
+      (describeInvocation ghcProg (verbosityLevel verbosity) mbWorkDir packagedb pid)
       `catchIO` \_ -> return mempty
 
   case parsePackages output of
     Left ok -> return ok
-    _ -> dieWithException verbosity $ FailedToParseOutputDescribe (programId (hcPkgProgram hpi)) pid
+    _ -> dieWithException verbosity $ FailedToParseOutputDescribe (programId ghcProg) pid
 
 -- | Call @hc-pkg@ to hide a package.
 --
 -- > hc-pkg hide [pkgid] [--user | --global | --package-db]
 hide
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> Verbosity
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDB
@@ -274,22 +252,22 @@ hide hpi verbosity mbWorkDir packagedb pkgid =
 -- | Call @hc-pkg@ to get all the details of all the packages in the given
 -- package database.
 dump
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> Verbosity
   -> Maybe (SymbolicPath CWD (Dir from))
   -> PackageDBX (SymbolicPath from (Dir PkgDB))
   -> IO [InstalledPackageInfo]
-dump hpi verbosity mbWorkDir packagedb = do
+dump ghcProg verbosity mbWorkDir packagedb = do
   output <-
     getProgramInvocationLBS
       verbosity
-      (dumpInvocation hpi (verbosityLevel verbosity) mbWorkDir packagedb)
+      (dumpInvocation ghcProg (verbosityLevel verbosity) mbWorkDir packagedb)
       `catchIO` \e ->
-        dieWithException verbosity $ DumpFailed (programId (hcPkgProgram hpi)) (displayException e)
+        dieWithException verbosity $ DumpFailed (programId ghcProg) (displayException e)
 
   case parsePackages output of
     Left ok -> return ok
-    _ -> dieWithException verbosity $ FailedToParseOutputDump (programId (hcPkgProgram hpi))
+    _ -> dieWithException verbosity $ FailedToParseOutputDump (programId ghcProg)
 
 parsePackages :: LBS.ByteString -> Either [InstalledPackageInfo] [String]
 parsePackages lbs0 =
@@ -388,21 +366,21 @@ setUnitId pkginfo = pkginfo
 -- Note in particular that it does not include the 'UnitId', just
 -- the source 'PackageId' which is not necessarily unique in any package db.
 list
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> Verbosity
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDB
   -> IO [PackageId]
-list hpi verbosity mbWorkDir packagedb = do
+list ghcProg verbosity mbWorkDir packagedb = do
   output <-
     getProgramInvocationOutput
       verbosity
-      (listInvocation hpi (verbosityLevel verbosity) mbWorkDir packagedb)
-      `catchIO` \_ -> dieWithException verbosity $ ListFailed (programId (hcPkgProgram hpi))
+      (listInvocation ghcProg (verbosityLevel verbosity) mbWorkDir packagedb)
+      `catchIO` \_ -> dieWithException verbosity $ ListFailed (programId ghcProg)
 
   case parsePackageIds output of
     Just ok -> return ok
-    _ -> dieWithException verbosity $ FailedToParseOutputList (programId (hcPkgProgram hpi))
+    _ -> dieWithException verbosity $ FailedToParseOutputList (programId ghcProg)
   where
     parsePackageIds = traverse simpleParsec . words
 
@@ -410,24 +388,24 @@ list hpi verbosity mbWorkDir packagedb = do
 -- The program invocations
 --
 
-initInvocation :: HcPkgInfo -> Verbosity -> FilePath -> ProgramInvocation
-initInvocation hpi verbosity path =
-  programInvocation (hcPkgProgram hpi) args
+initInvocation :: ConfiguredProgram -> Verbosity -> FilePath -> ProgramInvocation
+initInvocation ghcProg verbosity path =
+  programInvocation ghcProg args
   where
     args =
       ["init", path]
-        ++ verbosityOpts hpi (verbosityLevel verbosity)
+        ++ verbosityOpts (verbosityLevel verbosity)
 
 registerInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir from))
   -> PackageDBStackS from
   -> InstalledPackageInfo
   -> RegisterOptions
   -> ProgramInvocation
-registerInvocation hpi verbosity mbWorkDir packagedbs pkgInfo registerOptions =
-  (programInvocationCwd mbWorkDir (hcPkgProgram hpi) (args "-"))
+registerInvocation ghcProg verbosity mbWorkDir packagedbs pkgInfo registerOptions =
+  (programInvocationCwd mbWorkDir ghcProg (args "-"))
     { progInvokeInput = Just $ IODataText $ showInstalledPackageInfo pkgInfo
     , progInvokeInputEncoding = IOEncodingUTF8
     }
@@ -439,146 +417,135 @@ registerInvocation hpi verbosity mbWorkDir packagedbs pkgInfo registerOptions =
 
     args file =
       [cmdname, file]
-        ++ packageDbStackOpts hpi packagedbs
+        ++ packageDbStackOpts packagedbs
         ++ [ "--enable-multi-instance"
            | registerMultiInstance registerOptions
            ]
         ++ [ "--force-files"
            | registerSuppressFilesCheck registerOptions
            ]
-        ++ verbosityOpts hpi verbosity
+        ++ verbosityOpts verbosity
 
 unregisterInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDB
   -> PackageId
   -> ProgramInvocation
-unregisterInvocation hpi verbosity mbWorkDir packagedb pkgid =
-  programInvocationCwd mbWorkDir (hcPkgProgram hpi) $
-    ["unregister", packageDbOpts hpi packagedb, prettyShow pkgid]
-      ++ verbosityOpts hpi verbosity
+unregisterInvocation ghcProg verbosity mbWorkDir packagedb pkgid =
+  programInvocationCwd mbWorkDir ghcProg $
+    ["unregister", packageDbOpts packagedb, prettyShow pkgid]
+      ++ verbosityOpts verbosity
 
 recacheInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir from))
   -> PackageDBS from
   -> ProgramInvocation
-recacheInvocation hpi verbosity mbWorkDir packagedb =
-  programInvocationCwd mbWorkDir (hcPkgProgram hpi) $
-    ["recache", packageDbOpts hpi packagedb]
-      ++ verbosityOpts hpi verbosity
+recacheInvocation ghcProg verbosity mbWorkDir packagedb =
+  programInvocationCwd mbWorkDir ghcProg $
+    ["recache", packageDbOpts packagedb]
+      ++ verbosityOpts verbosity
 
 exposeInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDB
   -> PackageId
   -> ProgramInvocation
-exposeInvocation hpi verbosity mbWorkDir packagedb pkgid =
-  programInvocationCwd mbWorkDir (hcPkgProgram hpi) $
-    ["expose", packageDbOpts hpi packagedb, prettyShow pkgid]
-      ++ verbosityOpts hpi verbosity
+exposeInvocation ghcProg verbosity mbWorkDir packagedb pkgid =
+  programInvocationCwd mbWorkDir ghcProg $
+    ["expose", packageDbOpts packagedb, prettyShow pkgid]
+      ++ verbosityOpts verbosity
 
 describeInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDBStack
   -> PackageId
   -> ProgramInvocation
-describeInvocation hpi verbosity mbWorkDir packagedbs pkgid =
-  programInvocationCwd mbWorkDir (hcPkgProgram hpi) $
+describeInvocation ghcProg verbosity mbWorkDir packagedbs pkgid =
+  programInvocationCwd mbWorkDir ghcProg $
     ["describe", prettyShow pkgid]
-      ++ packageDbStackOpts hpi packagedbs
-      ++ verbosityOpts hpi verbosity
+      ++ packageDbStackOpts packagedbs
+      ++ verbosityOpts verbosity
 
 hideInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDB
   -> PackageId
   -> ProgramInvocation
-hideInvocation hpi verbosity mbWorkDir packagedb pkgid =
-  programInvocationCwd mbWorkDir (hcPkgProgram hpi) $
-    ["hide", packageDbOpts hpi packagedb, prettyShow pkgid]
-      ++ verbosityOpts hpi verbosity
+hideInvocation ghcProg verbosity mbWorkDir packagedb pkgid =
+  programInvocationCwd mbWorkDir ghcProg $
+    ["hide", packageDbOpts packagedb, prettyShow pkgid]
+      ++ verbosityOpts verbosity
 
 dumpInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir from))
   -> PackageDBX (SymbolicPath from (Dir PkgDB))
   -> ProgramInvocation
-dumpInvocation hpi _verbosity mbWorkDir packagedb =
-  (programInvocationCwd mbWorkDir (hcPkgProgram hpi) args)
+dumpInvocation ghcProg _verbosity mbWorkDir packagedb =
+  (programInvocationCwd mbWorkDir ghcProg args)
     { progInvokeOutputEncoding = IOEncodingUTF8
     }
   where
     args =
-      ["dump", packageDbOpts hpi packagedb]
-        ++ verbosityOpts hpi Silent
+      ["dump", packageDbOpts packagedb]
+        ++ verbosityOpts Silent
 
 -- We use verbosity level 'Silent' because it is important that we
 -- do not contaminate the output with info/debug messages.
 
 listInvocation
-  :: HcPkgInfo
+  :: ConfiguredProgram
   -> VerbosityLevel
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> PackageDB
   -> ProgramInvocation
-listInvocation hpi _verbosity mbWorkDir packagedb =
-  (programInvocationCwd mbWorkDir (hcPkgProgram hpi) args)
+listInvocation ghcProg _verbosity mbWorkDir packagedb =
+  (programInvocationCwd mbWorkDir ghcProg args)
     { progInvokeOutputEncoding = IOEncodingUTF8
     }
   where
     args =
-      ["list", "--simple-output", packageDbOpts hpi packagedb]
-        ++ verbosityOpts hpi Silent
+      ["list", "--simple-output", packageDbOpts packagedb]
+        ++ verbosityOpts Silent
 
 -- We use verbosity level 'Silent' because it is important that we
 -- do not contaminate the output with info/debug messages.
 
-packageDbStackOpts :: HcPkgInfo -> PackageDBStackS from -> [String]
-packageDbStackOpts hpi dbstack
-  | noPkgDbStack hpi = [packageDbOpts hpi (registrationPackageDB dbstack)]
-  | otherwise = case dbstack of
-      (GlobalPackageDB : UserPackageDB : dbs) ->
-        "--global"
-          : "--user"
-          : map specific dbs
-      (GlobalPackageDB : dbs) ->
-        "--global"
-          : ("--no-user-" ++ packageDbFlag hpi)
-          : map specific dbs
-      _ -> ierror
+packageDbStackOpts :: PackageDBStackS from -> [String]
+packageDbStackOpts dbstack = case dbstack of
+  (GlobalPackageDB : UserPackageDB : dbs) ->
+    "--global"
+      : "--user"
+      : map specific dbs
+  (GlobalPackageDB : dbs) ->
+    "--global"
+      : "--no-user-package-db"
+      : map specific dbs
+  _ -> ierror
   where
-    specific (SpecificPackageDB db) = "--" ++ packageDbFlag hpi ++ "=" ++ interpretSymbolicPathCWD db
+    specific (SpecificPackageDB db) = "--package-db=" ++ interpretSymbolicPathCWD db
     specific _ = ierror
     ierror :: a
     ierror = error ("internal error: unexpected package db stack: " ++ show dbstack)
 
-packageDbFlag :: HcPkgInfo -> String
-packageDbFlag hpi
-  | flagPackageConf hpi =
-      "package-conf"
-  | otherwise =
-      "package-db"
+packageDbOpts :: PackageDBX (SymbolicPath from (Dir PkgDB)) -> String
+packageDbOpts GlobalPackageDB = "--global"
+packageDbOpts UserPackageDB = "--user"
+packageDbOpts (SpecificPackageDB db) = "--package-db=" ++ interpretSymbolicPathCWD db
 
-packageDbOpts :: HcPkgInfo -> PackageDBX (SymbolicPath from (Dir PkgDB)) -> String
-packageDbOpts _ GlobalPackageDB = "--global"
-packageDbOpts _ UserPackageDB = "--user"
-packageDbOpts hpi (SpecificPackageDB db) = "--" ++ packageDbFlag hpi ++ "=" ++ interpretSymbolicPathCWD db
-
-verbosityOpts :: HcPkgInfo -> VerbosityLevel -> [String]
-verbosityOpts hpi v
-  | noVerboseFlag hpi =
-      []
+verbosityOpts :: VerbosityLevel -> [String]
+verbosityOpts v
   | v >= Deafening = ["-v2"]
   | v == Silent = ["-v0"]
   | otherwise = []

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -370,20 +370,19 @@ relocRegistrationInfo verbosity pkg lib lbi clbi abi_hash packageDb =
 
 initPackageDB :: Verbosity -> Compiler -> ProgramDb -> FilePath -> IO ()
 initPackageDB verbosity comp progdb dbPath =
-  createPackageDB verbosity comp progdb False dbPath
+  createPackageDB verbosity comp progdb dbPath
 
 -- | Create an empty package DB at the specified location.
 createPackageDB
   :: Verbosity
   -> Compiler
   -> ProgramDb
-  -> Bool
   -> FilePath
   -> IO ()
-createPackageDB verbosity comp progdb preferCompat dbPath =
+createPackageDB verbosity comp progdb dbPath =
   case compilerFlavor comp of
-    GHC -> HcPkg.init (GHC.hcPkgInfo progdb) verbosity preferCompat dbPath
-    GHCJS -> HcPkg.init (GHCJS.hcPkgInfo progdb) verbosity False dbPath
+    GHC -> HcPkg.init (GHC.hcPkgInfo progdb) verbosity dbPath
+    GHCJS -> HcPkg.init (GHCJS.hcPkgInfo progdb) verbosity dbPath
     UHC -> return ()
     _ -> dieWithException verbosity CreatePackageDB
 
@@ -423,7 +422,7 @@ withHcPkg
   -> String
   -> Compiler
   -> ProgramDb
-  -> (HcPkg.HcPkgInfo -> IO a)
+  -> (HcPkg.ConfiguredProgram -> IO a)
   -> IO a
 withHcPkg verbosity name comp progdb f =
   case compilerFlavor comp of
@@ -455,7 +454,7 @@ writeHcPkgRegisterScript
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> [InstalledPackageInfo]
   -> PackageDBStack
-  -> HcPkg.HcPkgInfo
+  -> HcPkg.ConfiguredProgram
   -> IO ()
 writeHcPkgRegisterScript verbosity mbWorkDir ipis packageDbs hpi = do
   let genScript installedPkgInfo =

--- a/cabal-dev-scripts/src/GenPathsModule.hs
+++ b/cabal-dev-scripts/src/GenPathsModule.hs
@@ -25,8 +25,6 @@ $(capture "decls" [d|
     data Z = Z
         { zPackageName                :: PackageName
         , zVersionDigits              :: String
-        , zSupportsCpp                :: Bool
-        , zSupportsNoRebindableSyntax :: Bool
         , zAbsolute                   :: Bool
         , zRelocatable                :: Bool
         , zIsWindows                  :: Bool

--- a/cabal-install/src/Distribution/Client/Init.hs
+++ b/cabal-install/src/Distribution/Client/Init.hs
@@ -55,5 +55,5 @@ initCmd v packageDBs repoCtxt comp progdb initFlags = do
       | fromFlagOrDefault False (simpleProject initFlags) =
           Simple.createProject
       | otherwise = case interactive initFlags of
-          Flag False -> NonInteractive.createProject comp
+          Flag False -> NonInteractive.createProject
           _ -> Interactive.createProject

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
@@ -64,19 +64,17 @@ import Language.Haskell.Extension (Extension (..), Language (..))
 
 import qualified Data.Set as Set
 import Distribution.FieldGrammar.Newtypes
-import Distribution.Simple.Compiler
 import System.FilePath (splitDirectories, (</>))
 
 -- | Main driver for interactive prompt code.
 createProject
   :: Interactive m
-  => Compiler
-  -> Verbosity
+  => Verbosity
   -> InstalledPackageIndex
   -> SourcePackageDb
   -> InitFlags
   -> m ProjectSettings
-createProject comp v pkgIx srcDb initFlags = do
+createProject v pkgIx srcDb initFlags = do
   -- The workflow is as follows:
   --
   --  1. Get the package type, supplied as either a program input or
@@ -120,10 +118,10 @@ createProject comp v pkgIx srcDb initFlags = do
 
   case pkgType of
     Library -> do
-      libTarget <- genLibTarget initFlags comp pkgIx cabalSpec
+      libTarget <- genLibTarget initFlags pkgIx cabalSpec
       testTarget <-
         addLibDepToTest pkgName
-          <$> genTestTarget initFlags comp pkgIx cabalSpec
+          <$> genTestTarget initFlags pkgIx cabalSpec
 
       return $
         ProjectSettings
@@ -133,7 +131,7 @@ createProject comp v pkgIx srcDb initFlags = do
           Nothing
           testTarget
     Executable -> do
-      exeTarget <- genExeTarget initFlags comp pkgIx cabalSpec
+      exeTarget <- genExeTarget initFlags pkgIx cabalSpec
 
       return $
         ProjectSettings
@@ -143,13 +141,13 @@ createProject comp v pkgIx srcDb initFlags = do
           (Just exeTarget)
           Nothing
     LibraryAndExecutable -> do
-      libTarget <- genLibTarget initFlags comp pkgIx cabalSpec
+      libTarget <- genLibTarget initFlags pkgIx cabalSpec
       exeTarget <-
         addLibDepToExe pkgName
-          <$> genExeTarget initFlags comp pkgIx cabalSpec
+          <$> genExeTarget initFlags pkgIx cabalSpec
       testTarget <-
         addLibDepToTest pkgName
-          <$> genTestTarget initFlags comp pkgIx cabalSpec
+          <$> genTestTarget initFlags pkgIx cabalSpec
 
       return $
         ProjectSettings
@@ -159,7 +157,7 @@ createProject comp v pkgIx srcDb initFlags = do
           (Just exeTarget)
           testTarget
     TestSuite -> do
-      testTarget <- genTestTarget initFlags comp pkgIx cabalSpec
+      testTarget <- genTestTarget initFlags pkgIx cabalSpec
 
       return $
         ProjectSettings
@@ -191,15 +189,14 @@ genPkgDescription flags srcDb =
 genLibTarget
   :: Interactive m
   => InitFlags
-  -> Compiler
   -> InstalledPackageIndex
   -> CabalSpecVersion
   -> m LibTarget
-genLibTarget flags comp pkgs v = do
+genLibTarget flags pkgs v = do
   srcDirs <- srcDirsHeuristics flags
   let srcDir = fromMaybe defaultSourceDir $ safeHead srcDirs
   LibTarget srcDirs
-    <$> languageHeuristics flags comp
+    <$> languageHeuristics flags
     <*> exposedModulesHeuristics flags
     <*> libOtherModulesHeuristics flags
     <*> otherExtsHeuristics flags srcDir
@@ -209,17 +206,16 @@ genLibTarget flags comp pkgs v = do
 genExeTarget
   :: Interactive m
   => InitFlags
-  -> Compiler
   -> InstalledPackageIndex
   -> CabalSpecVersion
   -> m ExeTarget
-genExeTarget flags comp pkgs v = do
+genExeTarget flags pkgs v = do
   appDirs <- appDirsHeuristics flags
   let appDir = fromMaybe defaultApplicationDir $ safeHead appDirs
   ExeTarget
     <$> mainFileHeuristics flags
     <*> pure appDirs
-    <*> languageHeuristics flags comp
+    <*> languageHeuristics flags
     <*> exeOtherModulesHeuristics flags
     <*> otherExtsHeuristics flags appDir
     <*> dependenciesHeuristics flags appDir pkgs
@@ -228,11 +224,10 @@ genExeTarget flags comp pkgs v = do
 genTestTarget
   :: Interactive m
   => InitFlags
-  -> Compiler
   -> InstalledPackageIndex
   -> CabalSpecVersion
   -> m (Maybe TestTarget)
-genTestTarget flags comp pkgs v = do
+genTestTarget flags pkgs v = do
   initialized <- initializeTestSuiteHeuristics flags
   testDirs' <- testDirsHeuristics flags
   let testDir = fromMaybe defaultTestDir $ safeHead testDirs'
@@ -243,7 +238,7 @@ genTestTarget flags comp pkgs v = do
         TestTarget
           <$> testMainHeuristics flags
           <*> pure testDirs'
-          <*> languageHeuristics flags comp
+          <*> languageHeuristics flags
           <*> testOtherModulesHeuristics flags
           <*> otherExtsHeuristics flags testDir
           <*> dependenciesHeuristics flags testDir pkgs
@@ -362,8 +357,8 @@ testDirsHeuristics :: Interactive m => InitFlags -> m [String]
 testDirsHeuristics flags = getTestDirs flags $ return [defaultTestDir]
 
 -- | Ask for the Haskell base language of the package.
-languageHeuristics :: Interactive m => InitFlags -> Compiler -> m Language
-languageHeuristics flags comp = getLanguage flags $ guessLanguage comp
+languageHeuristics :: Interactive m => InitFlags -> m Language
+languageHeuristics flags = getLanguage flags $ return defaultLanguage
 
 -- | Ask whether to generate explanatory comments.
 noCommentsHeuristics :: Interactive m => InitFlags -> m Bool

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -22,7 +22,6 @@ module Distribution.Client.Init.NonInteractive.Heuristics
   , guessAuthorName
   , guessAuthorEmail
   , guessCabalSpecVersion
-  , guessLanguage
   , guessPackageType
   , guessSourceDirectories
   , guessApplicationDirectories
@@ -40,10 +39,8 @@ import Distribution.Client.Init.FlagExtractors (getCabalVersionNoPrompt)
 import Distribution.Client.Init.Types
 import Distribution.Client.Init.Utils
 import Distribution.FieldGrammar.Newtypes
-import Distribution.Simple.Compiler
 import Distribution.Types.PackageName (PackageName)
 import Distribution.Version
-import Language.Haskell.Extension
 import System.FilePath
 
 -- | Guess the main file, returns a default value if none is found.
@@ -70,15 +67,6 @@ guessCabalSpecVersion = do
       [x, y, _] -> cabalSpecFromVersionDigits [x, y]
       _ -> Just defaultCabalVersion
     Nothing -> pure defaultCabalVersion
-
--- | Guess the language specification based on the GHC version
-guessLanguage :: Interactive m => Compiler -> m Language
-guessLanguage Compiler{compilerId = CompilerId GHC ver} =
-  return $
-    if ver < mkVersion [7, 0, 1]
-      then Haskell98
-      else Haskell2010
-guessLanguage _ = return defaultLanguage
 
 -- | Guess the package name based on the given root directory.
 guessPackageName :: Interactive m => FilePath -> m PackageName

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -473,7 +473,7 @@ createPackageDBIfMissing
     exists <- Cabal.doesPackageDBExist dbPath
     unless exists $ do
       createDirectoryIfMissingVerbose verbosity True (takeDirectory dbPath)
-      Cabal.createPackageDB verbosity compiler progdb False dbPath
+      Cabal.createPackageDB verbosity compiler progdb dbPath
 createPackageDBIfMissing _ _ _ _ = return ()
 
 -- | Given all the context and resources, (re)build an individual package.

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1480,7 +1480,6 @@ planPackages
       -- GHC 8.4   needs  Cabal >= 2.2
       -- GHC 8.2   needs  Cabal >= 2.0
       -- GHC 8.0   needs  Cabal >= 1.24
-      -- GHC 7.10  needs  Cabal >= 1.22
       --
       -- (NB: we don't need to consider older GHCs as Cabal >= 1.20 is
       -- the absolute lower bound)
@@ -1498,9 +1497,7 @@ planPackages
         | isGHC, compVer >= mkVersion [8, 6] = mkVersion [2, 4]
         | isGHC, compVer >= mkVersion [8, 4] = mkVersion [2, 2]
         | isGHC, compVer >= mkVersion [8, 2] = mkVersion [2, 0]
-        | isGHC, compVer >= mkVersion [8, 0] = mkVersion [1, 24]
-        | isGHC, compVer >= mkVersion [7, 10] = mkVersion [1, 22]
-        | otherwise = mkVersion [1, 20]
+        | otherwise = mkVersion [1, 24]
         where
           isGHC = compFlav `elem` [GHC, GHCJS]
           compFlav = compilerFlavor comp
@@ -4093,27 +4090,13 @@ setupHsConfigureFlags
         ElabComponent _ -> toFlag elabComponentId
 
       configProgramPaths = Map.toList elabProgramPaths
-      configProgramArgs
-        | {- elabSetupScriptCliVersion < mkVersion [1,24,3] -} True =
-            -- workaround for <https://github.com/haskell/cabal/issues/4010>
-            --
-            -- It turns out, that even with Cabal 2.0, there's still cases such as e.g.
-            -- custom Setup.hs scripts calling out to GHC even when going via
-            -- @runProgram ghcProgram@, as e.g. happy does in its
-            -- <http://hackage.haskell.org/package/happy-1.19.5/src/Setup.lhs>
-            -- (see also <https://github.com/haskell/cabal/pull/4433#issuecomment-299396099>)
-            --
-            -- So for now, let's pass the rather harmless and idempotent
-            -- `-hide-all-packages` flag to all invocations (which has
-            -- the benefit that every GHC invocation starts with a
-            -- consistently well-defined clean slate) until we find a
-            -- better way.
-            Map.toList $
-              Map.insertWith
-                (++)
-                "ghc"
-                ["-hide-all-packages"]
-                elabProgramArgs
+      configProgramArgs =
+        Map.toList $
+          Map.insertWith
+            (++)
+            "ghc"
+            ["-hide-all-packages"]
+            elabProgramArgs
       configProgramPathExtra = toNubList elabProgramPathExtra
       configHcFlavor = toFlag (compilerFlavor pkgConfigCompiler)
       configHcPath = mempty -- we use configProgramPaths instead

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/SetupPolicy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/SetupPolicy.hs
@@ -237,9 +237,5 @@ legacyCustomSetupPkgs compiler (Platform _ os) =
       ++ ["unix" | os /= Windows]
       ++ ["ghc-prim" | isGHC]
       ++ ["template-haskell" | isGHC]
-      ++ ["old-time" | notGHC710]
   where
     isGHC = compilerCompatFlavor GHC compiler
-    notGHC710 = case compilerCompatVersion GHC compiler of
-      Nothing -> False
-      Just v -> v <= mkVersion [7, 9]

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1914,16 +1914,11 @@ testSetupScriptStyles config reportSubCase = do
 
   plan0@(_, _, sharedConfig) <- planProject testdir1 config
 
-  let isOSX (Platform _ OSX) = True
-      isOSX _ = False
-      compilerVer = compilerVersion (pkgConfigCompiler sharedConfig)
+  let compilerVer = compilerVersion (pkgConfigCompiler sharedConfig)
   -- Skip the Custom tests when the shipped Cabal library is buggy
-  unless
-    ( (isOSX (pkgConfigPlatform sharedConfig) && (compilerVer < mkVersion [7, 10]))
-        -- 9.10 ships Cabal 3.12.0.0 affected by #9940
-        || (mkVersion [9, 10] <= compilerVer && compilerVer < mkVersion [9, 11])
-    )
-    $ do
+  -- 9.10 ships Cabal 3.12.0.0 affected by #9940
+  unless (mkVersion [9, 10] <= compilerVer && compilerVer < mkVersion [9, 11]) $
+    do
       (plan1, res1) <- executePlan plan0
       pkg1 <- expectPackageInstalled plan1 res1 pkgidA
       elabSetupScriptStyle pkg1 @?= SetupCustomExplicitDeps

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init.hs
@@ -41,7 +41,7 @@ tests = do
       , NonInteractive.tests v initFlags' comp pkgIx srcDb
       , Golden.tests v initFlags' pkgIx srcDb
       , Simple.tests v initFlags' pkgIx srcDb
-      , FileCreators.tests v initFlags' comp pkgIx srcDb
+      , FileCreators.tests v initFlags' pkgIx srcDb
       ]
   where
     v :: Verbosity

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
@@ -14,7 +14,6 @@ import Distribution.Client.Init.FileCreators
 import Distribution.Client.Init.NonInteractive.Command
 import Distribution.Client.Init.Types
 import Distribution.Client.Types
-import Distribution.Simple
 import Distribution.Simple.Flag
 import Distribution.Simple.PackageIndex
 import Distribution.Verbosity
@@ -22,11 +21,10 @@ import Distribution.Verbosity
 tests
   :: Verbosity
   -> InitFlags
-  -> Compiler
   -> InstalledPackageIndex
   -> SourcePackageDb
   -> TestTree
-tests _v _initFlags comp pkgIx srcDb =
+tests _v _initFlags pkgIx srcDb =
   testGroup
     "Distribution.Client.Init.FileCreators"
     [ testCase "Check . as source directory" $ do
@@ -82,7 +80,7 @@ tests _v _initFlags comp pkgIx srcDb =
               ]
 
         case flip runPrompt inputs $ do
-          projSettings <- createProject comp (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb dummyFlags'
+          projSettings <- createProject (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb dummyFlags'
           writeProject projSettings of
           Left (BreakException ex) -> assertFailure $ show ex
           Right _ -> return ()

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
@@ -44,11 +44,11 @@ tests _v _initFlags comp pkgIx srcDb =
     "Distribution.Client.Init.NonInteractive.Command"
     [ testGroup
         "driver function test"
-        [ driverFunctionTest pkgIx srcDb comp
+        [ driverFunctionTest pkgIx srcDb
         ]
     , testGroup
         "target creator tests"
-        [ fileCreatorTests pkgIx srcDb comp
+        [ fileCreatorTests pkgIx srcDb
         ]
     , testGroup
         "non-interactive tests"
@@ -63,9 +63,8 @@ tests _v _initFlags comp pkgIx srcDb =
 driverFunctionTest
   :: InstalledPackageIndex
   -> SourcePackageDb
-  -> Compiler
   -> TestTree
-driverFunctionTest pkgIx srcDb comp =
+driverFunctionTest pkgIx srcDb =
   testGroup
     "createProject"
     [ testGroup
@@ -93,7 +92,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"quxTest/Main.hs\"]"
                     ]
 
-            case (runPrompt $ createProject comp (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb dummyFlags') inputs of
+            case (runPrompt $ createProject (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb dummyFlags') inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -180,7 +179,7 @@ driverFunctionTest pkgIx srcDb comp =
                       "False"
                     ]
 
-            case (runPrompt $ createProject comp (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb dummyFlags') inputs of
+            case (runPrompt $ createProject (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb dummyFlags') inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -358,7 +357,6 @@ driverFunctionTest pkgIx srcDb comp =
 
             case ( runPrompt $
                     createProject
-                      comp
                       (mkVerbosity defaultVerbosityHandles silent)
                       pkgIx
                       srcDb
@@ -510,7 +508,6 @@ driverFunctionTest pkgIx srcDb comp =
 
             case ( runPrompt $
                     createProject
-                      comp
                       (mkVerbosity defaultVerbosityHandles silent)
                       pkgIx
                       srcDb
@@ -664,7 +661,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (runPrompt $ createProject comp (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -774,7 +771,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (runPrompt $ createProject comp (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) Nothing Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -865,7 +862,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (runPrompt $ createProject comp (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject (mkVerbosity defaultVerbosityHandles silent) pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc Nothing (Just exe) Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -905,9 +902,8 @@ driverFunctionTest pkgIx srcDb comp =
 fileCreatorTests
   :: InstalledPackageIndex
   -> SourcePackageDb
-  -> Compiler
   -> TestTree
-fileCreatorTests pkgIx srcDb comp =
+fileCreatorTests pkgIx srcDb =
   testGroup
     "generators"
     [ testGroup
@@ -980,7 +976,7 @@ fileCreatorTests pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (runPrompt $ genLibTarget emptyFlags comp pkgIx defaultCabalVersion) inputs of
+            case (runPrompt $ genLibTarget emptyFlags pkgIx defaultCabalVersion) inputs of
               Left e -> assertFailure $ show e
               Right{} -> return ()
         ]
@@ -1021,7 +1017,7 @@ fileCreatorTests pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (runPrompt $ genExeTarget emptyFlags comp pkgIx defaultCabalVersion) inputs of
+            case (runPrompt $ genExeTarget emptyFlags pkgIx defaultCabalVersion) inputs of
               Left e -> assertFailure $ show e
               Right{} -> return ()
         ]
@@ -1058,7 +1054,7 @@ fileCreatorTests pkgIx srcDb comp =
                     ]
                 flags = emptyFlags{initializeTestSuite = Flag True}
 
-            case (runPrompt $ genTestTarget flags comp pkgIx defaultCabalVersion) inputs of
+            case (runPrompt $ genTestTarget flags pkgIx defaultCabalVersion) inputs of
               Left e -> assertFailure $ show e
               Right{} -> return ()
         ]
@@ -1166,24 +1162,6 @@ nonInteractiveTests pkgIx srcDb comp =
                 cabalVersionHeuristics
                 CabalSpecV2_4
                 ["cabal-install version 2.4.0.0\ncompiled using version 2.4.0.0 of the Cabal library \n"]
-            ]
-        , testGroup
-            "Check languageHeuristics output"
-            [ testSimple
-                "Non GHC compiler"
-                (`languageHeuristics` (comp{compilerId = CompilerId Helium $ mkVersion [1, 8, 1]}))
-                Haskell2010
-                []
-            , testSimple
-                "Higher version compiler"
-                (`languageHeuristics` (comp{compilerId = CompilerId GHC $ mkVersion [8, 10, 4]}))
-                Haskell2010
-                []
-            , testSimple
-                "Lower version compiler"
-                (`languageHeuristics` (comp{compilerId = CompilerId GHC $ mkVersion [6, 0, 1]}))
-                Haskell98
-                []
             ]
         , testGroup
             "Check extraDocFileHeuristics output"

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -27,7 +27,6 @@ import System.IO.Unsafe (unsafePerformIO)
 import Distribution.Deprecated.ParseUtils
 import qualified Distribution.Deprecated.ReadP as Parse
 
-import Distribution.Compiler
 import Distribution.Package
 import Distribution.PackageDescription
 import qualified Distribution.Simple.InstallDirs as InstallDirs
@@ -36,7 +35,6 @@ import Distribution.Simple.Program.Types
 import Distribution.Simple.Utils (toUTF8BS)
 import Distribution.System (OS (Windows), buildOS)
 import Distribution.Types.PackageVersionConstraint
-import Distribution.Version
 
 import Distribution.Parsec
 import Distribution.Pretty
@@ -74,16 +72,10 @@ tests =
       , testProperty "buildonly" prop_roundtrip_legacytypes_buildonly
       , testProperty "specific" prop_roundtrip_legacytypes_specific
       ]
-        ++
-        -- a couple tests seem to trigger a RTS fault in ghc-7.6 and older
-        -- unclear why as of yet
-        concat
-          [ [ testProperty "shared" prop_roundtrip_legacytypes_shared
-            , testProperty "local" prop_roundtrip_legacytypes_local
-            , testProperty "all" prop_roundtrip_legacytypes_all
-            ]
-          | not usingGhc76orOlder
-          ]
+        ++ [ testProperty "shared" prop_roundtrip_legacytypes_shared
+           , testProperty "local" prop_roundtrip_legacytypes_local
+           , testProperty "all" prop_roundtrip_legacytypes_all
+           ]
   , testGroup
       "individual parser tests"
       [ testProperty "package location" prop_parsePackageLocationTokenQ
@@ -103,11 +95,6 @@ tests =
   , testGetProjectRootUsability
   , testFindProjectRoot
   ]
-  where
-    usingGhc76orOlder =
-      case buildCompilerId of
-        CompilerId GHC v -> v < mkVersion [7, 7]
-        _ -> False
 
 testGetProjectRootUsability :: TestTree
 testGetProjectRootUsability =

--- a/changelog.d/11630.md
+++ b/changelog.d/11630.md
@@ -1,0 +1,7 @@
+---
+synopsis: Drop support for anything below GHC 8.0.0, base 4.9.0.0, Cabal 1.24.0.0
+packages: [cabal-install-solver, cabal-install, Cabal-syntax, Cabal]
+prs: 11630
+---
+Drop support for anything below GHC 8.0.0, base 4.9.0.0, Cabal 1.24.0.0
+These versions were no longer tested and likely non-functional.

--- a/templates/Paths_pkg.template.hs
+++ b/templates/Paths_pkg.template.hs
@@ -1,9 +1,5 @@
-{% if supportsCpp %}
 {-# LANGUAGE CPP #-}
-{% endif %}
-{% if supportsNoRebindableSyntax %}
 {-# LANGUAGE NoRebindableSyntax #-}
-{% endif %}
 {% if not absolute %}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {% endif %}
@@ -45,23 +41,8 @@ import Prelude
 import System.Environment (getExecutablePath)
 {% endif %}
 
-{% if supportsCpp %}
-#if defined(VERSION_base)
-
-#if MIN_VERSION_base(4,0,0)
-catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
-#else
-catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a
-#endif
-
-#else
-catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
-#endif
-catchIO = Exception.catch
-{% else %}
 catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
 catchIO = Exception.catch
-{% endif %}
 
 -- |The package version.
 version :: Version


### PR DESCRIPTION

We don't have any testing for such old versions of ghc. Since this code isn't used, I assume it doesn't work, but it's difficult to confirm otherwise.

We just dropped everything below (ghc 8.0.0, base 4.9.0.0, cabal 1.24.0.0)

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)