### PR TITLE
Add ghc-9.14 language extensions

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -556,6 +556,12 @@ data KnownExtension
   | -- | Allow use of or-pattern syntax, condensing multiple patterns
     -- into a single one.
     OrPatterns
+  | -- | Along with 'ImplicitStagePersistence', this gives fine-grained control
+    -- over which modules are needed at each stage of execution.
+    ExplicitLevelImports
+  | -- | Allow identifiers to be used at different levels than where they’re
+    -- defined, using path-based persistence.
+    ImplicitStagePersistence
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Data)
 
 instance Binary KnownExtension

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,8 +29,8 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
-    0xc039c6741dead5203ad2b33bd3bf4dc8
+    0xd355021433c2000dbf333e4efd4a800d
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0xe38f63a643a5782e0ee7d16453796142
+    0x78979713e08179ab070d6ab10cd5ef6c

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -162,8 +162,8 @@ syn keyword cabalExtension contained
   \ ConstraintKinds
   \ DataKinds
   \ DatatypeContexts
-  \ DefaultSignatures
   \ DeepSubsumption
+  \ DefaultSignatures
   \ DeriveAnyClass
   \ DeriveDataTypeable
   \ DeriveFoldable
@@ -182,6 +182,7 @@ syn keyword cabalExtension contained
   \ EmptyDataDeriving
   \ ExistentialQuantification
   \ ExplicitForAll
+  \ ExplicitLevelImports
   \ ExplicitNamespaces
   \ ExtendedDefaultRules
   \ ExtendedLiterals
@@ -201,6 +202,7 @@ syn keyword cabalExtension contained
   \ HexFloatLiterals
   \ ImplicitParams
   \ ImplicitPrelude
+  \ ImplicitStagePersistence
   \ ImportQualifiedPost
   \ ImpredicativeTypes
   \ IncoherentInstances
@@ -213,16 +215,15 @@ syn keyword cabalExtension contained
   \ LiberalTypeSynonyms
   \ LinearTypes
   \ ListTuplePuns
-  \ RequiredTypeArguments
   \ MagicHash
   \ MonadComprehensions
   \ MonadFailDesugaring
   \ MonoLocalBinds
   \ MonoPatBinds
   \ MonomorphismRestriction
-  \ MultilineStrings
   \ MultiParamTypeClasses
   \ MultiWayIf
+  \ MultilineStrings
   \ NPlusKPatterns
   \ NamedDefaults
   \ NamedFieldPuns
@@ -260,6 +261,7 @@ syn keyword cabalExtension contained
   \ RecursiveDo
   \ RegularPatterns
   \ RelaxedPolyRec
+  \ RequiredTypeArguments
   \ RestrictedTypeSynonyms
   \ RoleAnnotations
   \ SafeImports
@@ -307,8 +309,8 @@ syn keyword cabalExtension contained
   \ NoConstraintKinds
   \ NoDataKinds
   \ NoDatatypeContexts
-  \ NoDefaultSignatures
   \ NoDeepSubsumption
+  \ NoDefaultSignatures
   \ NoDeriveAnyClass
   \ NoDeriveDataTypeable
   \ NoDeriveFoldable
@@ -327,6 +329,7 @@ syn keyword cabalExtension contained
   \ NoEmptyDataDeriving
   \ NoExistentialQuantification
   \ NoExplicitForAll
+  \ NoExplicitLevelImports
   \ NoExplicitNamespaces
   \ NoExtendedDefaultRules
   \ NoExtendedLiterals
@@ -346,6 +349,7 @@ syn keyword cabalExtension contained
   \ NoHexFloatLiterals
   \ NoImplicitParams
   \ NoImplicitPrelude
+  \ NoImplicitStagePersistence
   \ NoImportQualifiedPost
   \ NoImpredicativeTypes
   \ NoIncoherentInstances
@@ -357,16 +361,15 @@ syn keyword cabalExtension contained
   \ NoLexicalNegation
   \ NoLiberalTypeSynonyms
   \ NoLinearTypes
-  \ NoRequiredTypeArguments
   \ NoMagicHash
   \ NoMonadComprehensions
   \ NoMonadFailDesugaring
   \ NoMonoLocalBinds
   \ NoMonoPatBinds
   \ NoMonomorphismRestriction
-  \ NoMultilineStrings
   \ NoMultiParamTypeClasses
   \ NoMultiWayIf
+  \ NoMultilineStrings
   \ NoNPlusKPatterns
   \ NoNamedDefaults
   \ NoNamedFieldPuns
@@ -377,12 +380,12 @@ syn keyword cabalExtension contained
   \ NoNullaryTypeClasses
   \ NoNumDecimals
   \ NoNumericUnderscores
+  \ NoOrPatterns
   \ NoOverlappingInstances
   \ NoOverloadedLabels
   \ NoOverloadedLists
   \ NoOverloadedRecordDot
   \ NoOverloadedStrings
-  \ NoOrPatterns
   \ NoPackageImports
   \ NoParallelArrays
   \ NoParallelListComp
@@ -404,6 +407,7 @@ syn keyword cabalExtension contained
   \ NoRecursiveDo
   \ NoRegularPatterns
   \ NoRelaxedPolyRec
+  \ NoRequiredTypeArguments
   \ NoRestrictedTypeSynonyms
   \ NoRoleAnnotations
   \ NoSafeImports


### PR DESCRIPTION
Fixes #11635. I made similar changes to #10339. The test is the updated md5 check.

> [!IMPORTANT]
> Will this need a backport?

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

