### PR TITLE
fix-whitespace: Ignore haddocks directory

### DIFF
--- a/fix-whitespace.yaml
+++ b/fix-whitespace.yaml
@@ -19,7 +19,7 @@
 # 3) included-files is a white-list of files,
 # 4) excluded-files is a black-list of included-files.
 #
-# The extended glob pattern can be used to specify file/direcotory names.
+# The extended glob pattern can be used to specify file and directory names.
 # For details, see http://hackage.haskell.org/package/filemanip-0.3.6.3/docs/System-FilePath-GlobPattern.html
 #
 included-dirs:
@@ -32,6 +32,7 @@ excluded-dirs:
   - doc/.venv
   - .stack-work
   - .vscode
+  - haddocks
 
 # Every matched filename is included unless it is matched by excluded-files.
 included-files:


### PR DESCRIPTION
Fixes #11638.

I also found and fixed a typo that typos missed, here I split `a/b` so that the typo is detected in `b`:

```diff
$ git diff
diff --git a/fix-whitespace.yaml b/fix-whitespace.yaml
index 7ab454137..a2b3f54f6 100644
--- a/fix-whitespace.yaml
+++ b/fix-whitespace.yaml
@@ -19,7 +19,7 @@
 # 3) included-files is a white-list of files,
 # 4) excluded-files is a black-list of included-files.
 #
-# The extended glob pattern can be used to specify file/direcotory names.
+# The extended glob pattern can be used to specify file and direcotory names.
 # For details, see http://hackage.haskell.org/package/filemanip-0.3.6.3/docs/System-FilePath-GlobPattern.html
 #
 included-dirs:
```

```
$ typos fix-whitespace.yaml
error: `direcotory` should be `directory`
   ╭▸ fix-whitespace.yaml:22:61
   │
22 │ # The extended glob pattern can be used to specify file and direcotory names.
   ╰╴                                                            ━━━━━━━━━━
```

I get the same typo detection if I run `make hs-typos`.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
