### PR TITLE
HLint monoid laws, functor law and replicateM_

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -3,10 +3,7 @@
 - ignore: {name: "Avoid lambda"} # 51 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 23 hints
 - ignore: {name: "Eta reduce"} # 138 hints
-- ignore: {name: "Functor law"} # 10 hints
 - ignore: {name: "Hoist not"} # 16 hints
-- ignore: {name: "Monoid law, left identity"} # 3 hints
-- ignore: {name: "Monoid law, right identity"} # 3 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Move guards forward"} # 5 hints
 - ignore: {name: "Redundant $!"} # 1 hint
@@ -39,10 +36,13 @@
 - ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints
-- ignore: {name: "Use replicateM_"} # 2 hints
 - ignore: {name: "Use typeRep"} # 2 hints
 - ignore: {name: "Use unless"} # 23 hints
 - ignore: {name: "Use void"} # 23 hints
+
+- ignore: {name: "Functor law", within: [Test.Laws]}
+- ignore: {name: "Monoid law, left identity", within: [Test.Laws, UnitTests.Distribution.Utils.NubList]}
+- ignore: {name: "Monoid law, right identity", within: [Test.Laws, UnitTests.Distribution.Utils.NubList]}
 
 - group:
     name: cabal-suggestions

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Cycles.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Cycles.hs
@@ -23,11 +23,11 @@ detectCyclesPhase = go
     -- Only check children of choice nodes.
     go :: Tree d c -> Tree d c
     go (PChoice qpn rdm gr                         cs) =
-        PChoice qpn rdm gr     $ fmap (checkChild qpn)   (fmap go cs)
+        PChoice qpn rdm gr     $ fmap (checkChild qpn . go) cs
     go (FChoice qfn@(FN qpn _) rdm gr w m d cs) =
-        FChoice qfn rdm gr w m d $ fmap (checkChild qpn) (fmap go cs)
+        FChoice qfn rdm gr w m d $ fmap (checkChild qpn . go) cs
     go (SChoice qsn@(SN qpn _) rdm gr w     cs) =
-        SChoice qsn rdm gr w   $ fmap (checkChild qpn)   (fmap go cs)
+        SChoice qsn rdm gr w   $ fmap (checkChild qpn . go) cs
     go (GoalChoice rdm cs) = GoalChoice rdm (fmap go cs)
     go x@(Fail _ _) = x
     go x@(Done _ _) = x

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Explore.hs
@@ -194,7 +194,7 @@ assign tree = go tree (A M.empty M.empty M.empty)
         where f k             r = r (A pa (M.insert qfn k fa) sa)
     go (SChoice qsn rdm y t     ts) (A pa fa sa) = SChoice qsn rdm y t     $ W.mapWithKey f (fmap go ts)
         where f k             r = r (A pa fa (M.insert qsn k sa))
-    go (GoalChoice  rdm         ts) a            = GoalChoice  rdm         $ fmap ($ a) (fmap go ts)
+    go (GoalChoice  rdm         ts) a            = GoalChoice  rdm         $ fmap (`go` a) ts
 
 -- | A tree traversal that simultaneously propagates conflict sets up
 -- the tree from the leaves and creates a log.

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -387,9 +387,8 @@ instance Arbitrary Glob where
       take
         (max 1 sz)
         [ pure GlobDirTrailing
-        , GlobFile <$> (getGlobPieces <$> arbitrary)
-        , GlobDir
-            <$> (getGlobPieces <$> arbitrary)
+        , GlobFile . getGlobPieces <$> arbitrary
+        , (GlobDir . getGlobPieces <$> arbitrary)
             <*> resize (sz `div` 2) arbitrary
         ]
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -419,8 +419,7 @@ prop_roundtrip_printparse_RelaxDeps' rdep =
 
 instance Arbitrary ProjectConfig where
   arbitrary =
-    ProjectConfig
-      <$> (map getPackageLocationString <$> arbitrary)
+    (ProjectConfig . map getPackageLocationString <$> arbitrary)
       <*> (map getPackageLocationString <$> arbitrary)
       <*> shortListOf 3 arbitrary
       <*> arbitrary
@@ -702,15 +701,14 @@ instance Arbitrary ProjectConfigProvenance where
 
 instance Arbitrary PackageConfig where
   arbitrary =
-    PackageConfig
-      <$> ( MapLast . Map.fromList
-              <$> shortListOf
-                10
-                ( (,)
-                    <$> arbitraryProgramName
-                    <*> arbitraryShortToken
-                )
+    ( PackageConfig . MapLast . Map.fromList
+        <$> shortListOf
+          10
+          ( (,)
+              <$> arbitraryProgramName
+              <*> arbitraryShortToken
           )
+    )
       <*> ( MapMappend . Map.fromList
               <$> shortListOf
                 10

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/tests/test-Foo.hs
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/tests/test-Foo.hs
@@ -7,6 +7,6 @@ import Control.Monad
 main :: IO ()
 main | fooTest [] = do
         -- Make sure that the output buffer is drained
-        replicateM 10000 $ putStrLn "The quick brown fox jumps over the lazy dog"
+        replicateM_ 10000 $ putStrLn "The quick brown fox jumps over the lazy dog"
         exitSuccess
      | otherwise = exitFailure

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/tests/test-Short.hs
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/tests/test-Short.hs
@@ -6,6 +6,6 @@ import Control.Monad
 
 main :: IO ()
 main | fooTest [] = do
-        replicateM 5 $ putStrLn "The quick brown fox jumps over the lazy dog"
+        replicateM_ 5 $ putStrLn "The quick brown fox jumps over the lazy dog"
         exitSuccess
      | otherwise = exitFailure


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's the following suggestions so that this will be suggested by our CI linting.

- "Functor law"
- "Monoid law, left identity"
- "Monoid law, right identity"
- "use replicateM_"

The ignores for the laws, functor and monoid, these are now restricted to modules that test these laws.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
