### PR TITLE
refactor(cabal-install): remove dead code

### DIFF
--- a/cabal-install/src/Distribution/Client/SolverInstallPlan.hs
+++ b/cabal-install/src/Distribution/Client/SolverInstallPlan.hs
@@ -94,18 +94,6 @@ data SolverInstallPlan = SolverInstallPlan
   }
   deriving (Generic)
 
-{-
--- | Much like 'planPkgIdOf', but mapping back to full packages.
-planPkgOf :: SolverInstallPlan
-          -> Graph.Vertex
-          -> SolverPlanPackage
-planPkgOf plan v =
-    case Graph.lookupKey (planIndex plan)
-                         (planPkgIdOf plan v) of
-      Just pkg -> pkg
-      Nothing  -> error "InstallPlan: internal error: planPkgOf lookup failed"
--}
-
 instance Binary SolverInstallPlan
 instance Structured SolverInstallPlan
 


### PR DESCRIPTION
Remove commented-out `planPkgOf` function from `SolverInstallPlan`.