### PR TITLE
refactor(cabal-install-solver): remove workaround for bug closed years ago

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Types/Progress.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Progress.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 module Distribution.Solver.Types.Progress
     ( Progress(..)
     , foldProgress
@@ -13,14 +14,7 @@ import Distribution.Solver.Compat.Prelude hiding (fail)
 data Progress step fail done = Step step (Progress step fail done)
                              | Fail fail
                              | Done done
-
--- This Functor instance works around a bug in GHC 7.6.3.
--- See https://gitlab.haskell.org/ghc/ghc/-/issues/7436#note_66637.
--- The derived functor instance caused a space leak in the solver.
-instance Functor (Progress step fail) where
-  fmap f (Step s p) = Step s (fmap f p)
-  fmap _ (Fail x)   = Fail x
-  fmap f (Done r)   = Done (f r)
+  deriving (Functor)
 
 -- | Consume a 'Progress' calculation. Much like 'foldr' for lists but with two
 -- base cases, one for a final result and one for failure.


### PR DESCRIPTION
Replace the manual `Functor` instance on `Progress` with `deriving (Functor)`. The manual instance was a workaround
  for a GHC 7.6.3 space leak (https://gitlab.haskell.org/ghc/ghc/-/issues/7436), which has long been fixed.