### PR TITLE
fix(Cabal): fix abi tag in case ghc's unit-id is the same as the compiler id

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -236,9 +236,18 @@ configureCompiler verbosity hcPath conf0 = do
       -- @compilerId@: "ghc-9.13.20250413"
       -- So, we need to be careful to only strip the /common/ prefix.
       -- In this example, @AbiTag@ is "inplace".
+      -- If the @Project Unit Id@ exactly matches @compilerId@, stripping the
+      -- common prefix yields the empty string, which should be treated as
+      -- @NoAbiTag@ rather than @AbiTag ""@.
       compilerAbiTag :: AbiTag
       compilerAbiTag =
-        maybe NoAbiTag (AbiTag . dropWhile (== '-') . stripCommonPrefix (prettyShow compilerId)) projectUnitId
+        let abiTagSuffix =
+              dropWhile (== '-') . stripCommonPrefix (prettyShow compilerId)
+                <$> projectUnitId
+         in case abiTagSuffix of
+              Nothing -> NoAbiTag
+              Just "" -> NoAbiTag
+              Just tag -> AbiTag tag
 
       wiredInUnitIds = do
         ghcInternalUnitId <- Map.lookup "ghc-internal Unit Id" ghcInfoMap


### PR DESCRIPTION
When computing the ABI tag, `compilerId` is stripped as a common prefix from
GHC's "Project Unit Id" info entry via `stripCommonPrefix`. When the project
unit-id exactly matches the compiler id, `stripCommonPrefix` returns `""`, and
the old code produced `AbiTag ""` instead of `NoAbiTag`.

Rewrite `compilerAbiTag` with explicit case analysis so that a missing, empty,
or fully-stripped "Project Unit Id" value correctly yields `NoAbiTag`.
