### PR TITLE
refactor(Cabal, cabal-install): add HasCallStack to dieProgress and ProjectPlanning

### DIFF
--- a/Cabal/src/Distribution/Utils/LogProgress.hs
+++ b/Cabal/src/Distribution/Utils/LogProgress.hs
@@ -16,6 +16,7 @@ import Prelude ()
 import Distribution.Simple.Utils
 import Distribution.Utils.Progress
 import Distribution.Verbosity
+import GHC.Stack (HasCallStack, callStack, prettyCallStack)
 import System.IO (hFlush, hPutStr, hPutStrLn)
 import Text.PrettyPrint
 
@@ -87,10 +88,14 @@ infoProgress s = LogProgress $ \env ->
       InfoMsg s
 
 -- | Fail the computation with an error message.
-dieProgress :: Doc -> LogProgress a
+dieProgress :: HasCallStack => Doc -> LogProgress a
 dieProgress s = LogProgress $ \env ->
   failProgress $
-    hang (text "Error:") 4 (formatMsg (le_context env) s)
+    hang (text "Error:") 4 $
+      vcat
+        [ formatMsg (le_context env) s
+        , vcat (map text (lines (prettyCallStack callStack)))
+        ]
 
 -- | Format a message with context. (Something simple for now.)
 formatMsg :: [CtxMsg] -> Doc -> Doc

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -236,6 +236,7 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Distribution.Client.Errors
 import Distribution.Solver.Types.ProjectConfigPath
+import GHC.Stack (HasCallStack)
 import System.Directory (getCurrentDirectory)
 import System.FilePath
 import qualified Text.PrettyPrint as Disp
@@ -356,7 +357,8 @@ sanityCheckElaboratedPackage
 -- | Return the up-to-date project config and information about the local
 -- packages within the project.
 rebuildProjectConfig
-  :: Verbosity
+  :: HasCallStack
+  => Verbosity
   -> HttpTransport
   -> DistDirLayout
   -> ProjectConfig
@@ -670,7 +672,8 @@ See #9840 for more information about the problems surrounding the lossy
 -- dependencies of executables and setup scripts.
 --
 rebuildInstallPlan
-  :: Verbosity
+  :: HasCallStack
+  => Verbosity
   -> DistDirLayout
   -> CabalDirLayout
   -> ProjectConfig
@@ -911,7 +914,8 @@ rebuildInstallPlan
       -- version of the plan has the final nix-style hashed ids.
       --
       phaseElaboratePlan
-        :: ProjectConfig
+        :: HasCallStack
+        => ProjectConfig
         -> (Compiler, Platform, ProgramDb)
         -> Maybe PkgConfigDb
         -> SolverInstallPlan
@@ -1667,7 +1671,8 @@ planPackages
 -- In theory should be able to make an elaborated install plan with a policy
 -- matching that of the classic @cabal install --user@ or @--global@
 elaborateInstallPlan
-  :: Verbosity
+  :: HasCallStack
+  => Verbosity
   -> Platform
   -> Compiler
   -> ProgramDb
@@ -1726,8 +1731,7 @@ elaborateInstallPlan
                   )
           f _ = Nothing
 
-      elaboratedInstallPlan
-        :: LogProgress (InstallPlan.GenericInstallPlan IPI.InstalledPackageInfo ElaboratedConfiguredPackage)
+      elaboratedInstallPlan :: LogProgress ElaboratedInstallPlan
       elaboratedInstallPlan =
         flip InstallPlan.fromSolverInstallPlanWithProgress solverPlan $ \mapDep planpkg ->
           case planpkg of

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
@@ -12,5 +12,5 @@ Failed to build MainIsBench-0.1-inplace-Bench. The exception was:
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:1392:16 in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
+  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
 

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
@@ -11,6 +11,5 @@ Failed to build MainIsExe-0.1-inplace-Exe. The exception was:
 Error: [Cabal-7554]
 can't find source for MyDummy in ., cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/Exe/autogen, cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/global-autogen
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/PreProcess.hs:311:11 in Cabal-3.17.0.0-inplace:Distribution.Simple.PreProcess
-
+  dieWithException, called at src/Distribution/Simple/PreProcess.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.PreProcess
 

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
@@ -12,5 +12,5 @@ Failed to build MainIsTest-0.1-inplace-Test. The exception was:
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:1392:16 in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
+  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
 

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
@@ -5,3 +5,5 @@ Error:
         MissingReq
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
@@ -5,3 +5,5 @@ Error:
         MissingReq
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
@@ -3,3 +3,5 @@ Configuring Fail2-0.1.0.0...
 Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.ConfiguredComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
@@ -3,3 +3,5 @@ Configuring Fail2-0.1.0.0...
 Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.ConfiguredComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
@@ -4,3 +4,5 @@ Error:
     Non-library component has unfilled requirements:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
@@ -4,3 +4,5 @@ Error:
     Non-library component has unfilled requirements:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
@@ -6,3 +6,5 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-a
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
@@ -6,3 +6,5 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-a
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
@@ -7,3 +7,5 @@ Error:
             framework-0.1.0.0 (has unfilled signature: App)
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
@@ -7,3 +7,5 @@ Error:
             framework-0.1.0.0 (has unfilled signature: App)
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
@@ -13,3 +13,5 @@ Error:
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
       While filling requirements of build-depends: fail:mylib
     In the stanza library
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
@@ -13,3 +13,5 @@ Error:
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
       While filling requirements of build-depends: fail:mylib
     In the stanza library
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
@@ -8,3 +8,5 @@ Error:
         nor any of its 'build-depends' dependencies.
     In the stanza 'library'
     In the inplace package 'Reexport2-1.0'
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
@@ -7,3 +7,5 @@ Error:
     Try moving this module to a separate library, e.g.,
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
@@ -7,3 +7,5 @@ Error:
     Try moving this module to a separate library, e.g.,
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
@@ -5,3 +5,5 @@ Error:
     Ensure "build-depends:" doesn't include any library with signatures: 'A'
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
@@ -5,3 +5,5 @@ Error:
     Ensure "build-depends:" doesn't include any library with signatures: 'A'
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
@@ -5,3 +5,8 @@ Error:
         library bar
         library foo
     In the inplace package 'DepCycle-1.0'
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectOrchestration

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
@@ -3,3 +3,5 @@ Configuring DepCycle-1.0...
 Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
@@ -4,4 +4,4 @@ Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/Configure.hs:93:22 in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
@@ -3,3 +3,5 @@ Configuring DepCycle-1.0...
 Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/Configure.hs:93:22 in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
+++ b/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
@@ -4,3 +4,8 @@ Error:
     Internal libraries only supported with per-component builds.
     Per-component builds were disabled because you passed --disable-per-component
     In the inplace package 'p-0.1.0.0'
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectOrchestration

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
@@ -21,3 +21,5 @@ Error:
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
@@ -21,3 +21,5 @@ Error:
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
@@ -7,3 +7,5 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
@@ -7,3 +7,5 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
@@ -7,3 +7,5 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
+    CallStack (from HasCallStack):
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
@@ -7,3 +7,5 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
+    CallStack (from HasCallStack):
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -95,6 +95,7 @@ normalizeOutput nenv =
     -- hackage-security locks occur non-deterministically
     . resub "(Released|Acquired|Waiting) .*hackage-security-lock\n" ""
     . resub "installed: [0-9]+(\\.[0-9]+)*" "installed: <VERSION>"
+    . resub "\\.hs:[0-9]+:[0-9]+" ".hs:_:_"
   where
     sameDir = "(\\.((\\\\)+|\\/))*"
     packageIdRegex pid =


### PR DESCRIPTION
Two related improvements to call-stack propagation:

- Add a `HasCallStack` constraint to `dieProgress` and include the
  pretty-printed call stack in the error output (`Cabal`)
- Add `HasCallStack` constraints to `rebuildProjectConfig`,
  `rebuildInstallPlan`, `phaseElaboratePlan`, `elaborateInstallPlan`, and
  `elaboratedInstallPlan` in `ProjectPlanning` (`cabal-install`)
