### PR TITLE
Follow hlint suggestion: move guards forward

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -5,7 +5,6 @@
 - ignore: {name: "Eta reduce"} # 138 hints
 - ignore: {name: "Hoist not"} # 16 hints
 - ignore: {name: "Move filter"} # 4 hints
-- ignore: {name: "Move guards forward"} # 5 hints
 - ignore: {name: "Redundant $!"} # 1 hint
 - ignore: {name: "Redundant <$>"} # 17 hints
 - ignore: {name: "Redundant bracket"} # 257 hints

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -1277,8 +1277,8 @@ renderPureArgs version comp platform args =
         flagToMaybe (argGhcLibDir args) -- error if Nothing?
     , -- https://github.com/haskell/haddock/pull/547
       [ "--reexport=" ++ prettyShow r
-      | r <- argReexports args
-      , isVersion 2 19
+      | isVersion 2 19
+      , r <- argReexports args
       ]
     , argTargets args
     , maybe [] ((: []) . (resourcesDirFlag ++)) . flagToMaybe . argResourcesDir $ args

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -852,7 +852,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
         , concat [["-odir", u dir] | dir <- flag ghcOptObjDir]
         , concat [["-hidir", u dir] | dir <- flag ghcOptHiDir]
         , concat [["-hiedir", u dir] | dir <- flag ghcOptHieDir]
-        , concat [["-gbcdir", u dir] | dir <- flag ghcOptBytecodeDir, bytecodeArtifactsSupported comp]
+        , concat [["-gbcdir", u dir] | bytecodeArtifactsSupported comp, dir <- flag ghcOptBytecodeDir]
         , concat [["-stubdir", u dir] | dir <- flag ghcOptStubDir]
         , -----------------------
           -- Source search path
@@ -965,9 +965,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
         , ----------------
           -- GHCi
 
-          concat
-            [ ["-ghci-script", script] | script <- ghcOptGHCiScripts opts, flagGhciScript implInfo
-            ]
+          concat [["-ghci-script", script] | flagGhciScript implInfo, script <- ghcOptGHCiScripts opts]
         , ---------------
           -- Inputs
 

--- a/cabal-install/src/Distribution/Client/Errors.hs
+++ b/cabal-install/src/Distribution/Client/Errors.hs
@@ -712,8 +712,7 @@ exceptionMessageCabalInstall e = case e of
                   | (thing, _got, alts@(_ : _)) <- nosuch'
                   ]
           ]
-      | (target, nosuch) <- targets
-      , let groupByContainer =
+      | let groupByContainer =
               map
                 ( \g@((inside, _, _, _) : _) ->
                     ( inside
@@ -724,6 +723,7 @@ exceptionMessageCabalInstall e = case e of
                 )
                 . groupBy ((==) `on` (\(x, _, _, _) -> x))
                 . sortBy (compare `on` (\(x, _, _, _) -> x))
+      , (target, nosuch) <- targets
       ]
     where
       mungeThing "file" = "file target"

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -1198,8 +1198,8 @@ storeDetailedBuildReports verbosity logsDir reports =
         createDirectoryIfMissing True reportsDir -- FIXME
         writeFile reportFile (show (showBuildReport report, buildLog))
     | (report, Just repo) <- reports
-    , Just remoteRepo <- [maybeRepoRemote repo]
     , isLikelyToHaveLogFile (BuildReports.installOutcome report)
+    , Just remoteRepo <- [maybeRepoRemote repo]
     ]
   where
     isLikelyToHaveLogFile BuildReports.ConfigureFailed{} = True


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "move guards forward" suggestion so that this will be suggested by our CI linting.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
