### PR TITLE
update IntegrationTests2 for tasty-1.5.4

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -454,7 +454,7 @@ test-suite integration-tests2
     , directory
     , filepath
     , process
-    , tasty >= 1.5 && <1.6
+    , tasty >= 1.5.4 && <1.6
     , tasty-hunit >= 0.10
     , tasty-expected-failure
     , silently

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -115,7 +115,7 @@ main = do
   defaultMainWithIngredients
     (defaultIngredients ++ [includingOptions projectConfigOptionDescriptions])
     ( localOption (NumThreads 1) $ withProjectConfig $ \config ->
-        sequentialTestGroup
+        dependentTestGroup
           "Integration tests (internal)"
           AllFinish
           (tests config)
@@ -145,14 +145,14 @@ tests config =
   -- TODO: tests for:
   -- \* normal success
   -- \* dry-run tests with changes
-  [ sequentialTestGroup
+  [ dependentTestGroup
       "Discovery and planning"
       AllFinish
       [ testCase "no package" (testExceptionInFindingPackage config)
       , testCase "no package2" (testExceptionInFindingPackage2 config)
       , testCase "proj conf1" (testExceptionInProjectConfig config)
       ]
-  , sequentialTestGroup
+  , dependentTestGroup
       "Target selectors"
       AllFinish
       [ testCaseSteps "valid" testTargetSelectors
@@ -171,7 +171,7 @@ tests config =
       , testCaseSteps "problems (bench)" (testTargetProblemsBench config)
       , testCaseSteps "problems (haddock)" (testTargetProblemsHaddock config)
       ]
-  , sequentialTestGroup
+  , dependentTestGroup
       "Exceptions during building (local inplace)"
       AllFinish
       [ testCase "configure" (testExceptionInConfigureStep config)
@@ -182,14 +182,14 @@ tests config =
     -- TODO: need to check we can build sub-libs, foreign libs and exes
     -- components for non-local packages / packages in the store.
 
-    sequentialTestGroup "Successful builds" AllFinish $
+    dependentTestGroup "Successful builds" AllFinish $
       [ testCaseSteps "Setup script styles" (testSetupScriptStyles config)
       , testCase "keep-going" (testBuildKeepGoing config)
       ]
         ++
         -- disabled because https://github.com/haskell/cabal/issues/6272
         [testCase "local tarball" (testBuildLocalTarball config) | System.Info.os /= "mingw32"]
-  , sequentialTestGroup
+  , dependentTestGroup
       "Regression tests"
       AllFinish
       [ testCase "issue #3324" (testRegressionIssue3324 config)
@@ -197,13 +197,13 @@ tests config =
       , testCase "program options scope local" (testProgramOptionsLocal config)
       , testCase "program options scope specific" (testProgramOptionsSpecific config)
       ]
-  , sequentialTestGroup
+  , dependentTestGroup
       "Flag tests"
       AllFinish
       [ testCase "Test Config options for commented options" testConfigOptionComments
       , testCase "Test Ignore Project Flag" testIgnoreProjectFlag
       ]
-  , sequentialTestGroup
+  , dependentTestGroup
       "haddock-project"
       AllFinish
       [ testCase "dependencies" (testHaddockProjectDependencies config)


### PR DESCRIPTION
It has backward compatibility, but tagged as `DEPRECATED`, and we build tests with `-Werror=deprecations`.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
