### PR TITLE
don't wait for queue fill for high priority PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -134,6 +134,20 @@ pull_request_rules:
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
 
+  # high priority PRs: don't queue, just merge it immediately
+  - actions:
+      merge:
+        # this is where we differ from the preceding
+        method: squash
+    name: Merge high priority pull requests directly (without a queue)
+    conditions:
+      - base=master
+      - label=merge me
+      - 'label=priority: high :fire:'
+      - label=merge delay passed
+      - '#approved-reviews-by>=2'
+      - '-label~=^blocked:'
+
   # merge strategy for release branches
   - actions:
       queue:


### PR DESCRIPTION
Please read [Github PR Conventions](CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ Mergify only reads rules from `master`
