### PR TITLE
Follow hlint suggestion: use unless

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -36,7 +36,6 @@
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints
 - ignore: {name: "Use typeRep"} # 2 hints
-- ignore: {name: "Use unless"} # 23 hints
 - ignore: {name: "Use void"} # 23 hints
 
 - ignore: {name: "Functor law", within: [Test.Laws]}

--- a/Cabal-tests/lib/Test/Utils/TempTestDir.hs
+++ b/Cabal-tests/lib/Test/Utils/TempTestDir.hs
@@ -12,7 +12,7 @@ import Distribution.Verbosity
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (throwIO, try)
-import Control.Monad (when)
+import Control.Monad (unless, when)
 import Control.Monad.Catch ( bracket, MonadMask)
 import Control.Monad.IO.Class
 
@@ -40,7 +40,7 @@ withTestDir' verbosity tempFileOpts template action = do
     (liftIO
       -- This ensures that the temp files are not deleted at the end of the test.
       -- It replicates the behavior of @withTempDirectoryEx@.
-      . when (not (optKeepTempFiles tempFileOpts))
+      . unless (optKeepTempFiles tempFileOpts)
       -- This is the bit that helps with Windows deleting all files.
       . removeDirectoryRecursiveHack verbosity
       )

--- a/Cabal/src/Distribution/Backpack/UnifyM.hs
+++ b/Cabal/src/Distribution/Backpack/UnifyM.hs
@@ -186,7 +186,7 @@ failIfErrs :: UnifyM s ()
 failIfErrs = do
   env <- getUnifEnv
   errs <- liftST $ readSTRef (unify_errs env)
-  when (not (null errs)) failM
+  unless (null errs) failM
 
 tryM :: UnifyM s a -> UnifyM s (Maybe a)
 tryM m =

--- a/Cabal/src/Distribution/Simple/Build.hs
+++ b/Cabal/src/Distribution/Simple/Build.hs
@@ -306,7 +306,7 @@ dumpBuildInfo verbosity distPref dumpBuildInfoFlag pkg_descr lbi flags = do
           ++ unlines warns
     LBS.writeFile buildInfoFile buildInfoText
 
-  when (not shouldDumpBuildInfo) $
+  unless shouldDumpBuildInfo $
     -- Remove existing build-info.json as it might be outdated now.
     removeFileForcibly buildInfoFile
   where
@@ -624,7 +624,7 @@ generateCode
   -> Verbosity
   -> IO (SymbolicPath Pkg (Dir Source), [ModuleName.ModuleName])
 generateCode codeGens nm pdesc bi lbi clbi verbosity = do
-  when (not . null $ codeGens) $ createDirectoryIfMissingVerbose verbosity True $ i tgtDir
+  unless (null codeGens) $ createDirectoryIfMissingVerbose verbosity True $ i tgtDir
   (tgtDir,) . concat <$> mapM go codeGens
   where
     allLibs = (maybe id (:) $ library pdesc) (subLibraries pdesc)

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1180,7 +1180,7 @@ finalCheckPackage
             nub $
               mapMaybe defaultLanguage (enabledBuildInfos pkg_descr enabled)
       let langs = unsupportedLanguages comp langlist
-      when (not (null langs)) $
+      unless (null langs) $
         dieWithException verbosity $
           UnsupportedLanguages (packageId g_pkg_descr) (compilerId comp) (map prettyShow langs)
       let extlist =
@@ -1189,14 +1189,14 @@ finalCheckPackage
                 allExtensions
                 (enabledBuildInfos pkg_descr enabled)
       let exts = unsupportedExtensions comp extlist
-      when (not (null exts)) $
+      unless (null exts) $
         dieWithException verbosity $
           UnsupportedLanguageExtension (packageId g_pkg_descr) (compilerId comp) (map prettyShow exts)
 
       -- Check foreign library build requirements
       let flibs = [flib | CFLib flib <- enabledComponents pkg_descr enabled]
       let unsupportedFLibs = unsupportedForeignLibs comp compPlatform flibs
-      when (not (null unsupportedFLibs)) $
+      unless (null unsupportedFLibs) $
         dieWithException verbosity $
           CantFindForeignLibraries unsupportedFLibs
 
@@ -1470,7 +1470,7 @@ checkExactConfiguration verbosity pkg_descr0 cfg =
     let cmdlineFlags = map fst (unFlagAssignment (configConfigurationsFlags cfg))
         allFlags = map flagName . genPackageFlags $ pkg_descr0
         diffFlags = allFlags \\ cmdlineFlags
-    when (not . null $ diffFlags) $
+    unless (null diffFlags) $
       dieWithException verbosity $
         FlagsNotSpecified diffFlags
 
@@ -2221,7 +2221,7 @@ combinedConstraints
       , Map (PackageName, ComponentName) InstalledPackageInfo
       )
 combinedConstraints constraints dependencies installedPackages = do
-  when (not (null badComponentIds)) $
+  unless (null badComponentIds) $
     Left $
       CombinedConstraints (dispDependencies badComponentIds)
 

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -940,7 +940,7 @@ installFLib verbosity lbi targetDir builtDir _pkg flib =
         else installOrdinaryFile verbosity src dst
       -- Now install appropriate symlinks if library is versioned
       let (Platform _ os) = hostPlatform lbi
-      when (not (null (foreignLibVersion flib os))) $ do
+      unless (null (foreignLibVersion flib os)) $ do
         when (os /= Linux) $ dieWithException verbosity CantInstallForeignLib
 #ifndef mingw32_HOST_OS
         -- 'createSymbolicLink file1 file2' creates a symbolic link

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -217,7 +217,7 @@ linkOrLoadComponent
           get_rpaths ways =
             if DynWay `Set.member` ways then getRPaths pbci else return (toNubListR [])
          in
-          when (not $ componentIsIndefinite clbi) $ do
+          unless (componentIsIndefinite clbi) $ do
             -- If not building dynamically, we don't pass any runtime paths.
             liftIO $ do
               info verbosity "Linking..."

--- a/Cabal/src/Distribution/Simple/Install.hs
+++ b/Cabal/src/Distribution/Simple/Install.hs
@@ -288,7 +288,7 @@ copyComponent verbosity pkg_descr lbi (CExe exe) clbi copydest = do
         ++ binPref
     )
   inPath <- isInSearchPath binPref
-  when (not inPath) $
+  unless inPath $
     warn
       verbosity
       ( "The directory "

--- a/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
@@ -94,7 +94,7 @@ readPkgConfigDb verbosity progdb = handle ioErrorHandler $ do
               -- in multi-byte UTF-8 sequences.
               . map (LBS.takeWhile (not . isAsciiSpace))
               $ pkgList
-        when (not (null failedPkgNames)) $
+        unless (null failedPkgNames) $
           info verbosity ("Some pkg-config packages have names containing invalid unicode: " ++ intercalate ", " failedPkgNames)
         (outs, _errs, exitCode) <-
                      getProgramInvocationOutputAndErrors verbosity

--- a/cabal-install/src/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/src/Distribution/Client/CmdConfigure.hs
@@ -164,7 +164,7 @@ configureAction' flags@NixStyleFlags{..} _extraArgs globalFlags = do
                 (fromFlagOrDefault defaultProjectFileParser $ projectConfigProjectFileParser $ projectConfigShared cliConfig)
                 httpTransport
                 (distDirLayout baseCtx)
-          when (not (null imps && null bs)) $ dieWithException v UnableToPerformInplaceUpdate
+          unless (null imps && null bs) $ dieWithException v UnableToPerformInplaceUpdate
           return (baseCtx, conf <> cliConfig)
         else return (baseCtx, cliConfig)
   where

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -328,7 +328,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
       --
 
       let (missingHaddocks, packageInfos') = partitionEithers packageInfos
-      when (not (null missingHaddocks)) $ do
+      unless (null missingHaddocks) $ do
         warn verbosity "missing haddocks for some packages from the store"
         -- Show the package list if `-v1` is passed; it's usually a long list.
         -- One needs to add `package` stantza in `cabal.project` file for

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -852,7 +852,7 @@ partitionToKnownTargetsAndHackagePackages verbosity pkgDb elaboratedPlan targetS
               dieWithException verbosity $ UnknownPackage (unPackageName hn) (("- " ++) . unPackageName . fst <$> xs)
         _ -> return ()
 
-      when (not . null $ errs') $ reportBuildTargetProblems verbosity errs'
+      unless (null errs') $ reportBuildTargetProblems verbosity errs'
 
       let
         targetSelectors' = flip filter targetSelectors $ \case

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -264,7 +264,7 @@ outdatedAction flags targetStrings globalFlags =
               deps
               sourcePkgDb
               (ListOutdatedSettings ignorePred minorPred)
-      when (not quiet) $
+      unless quiet $
         showResult verbosity outdatedDeps simpleOutput
       when (exitCode && (not . null $ outdatedDeps)) exitFailure
   where
@@ -300,7 +300,7 @@ showResult :: Verbosity -> [OutdatedDependency] -> Bool -> IO ()
 showResult verbosity outdatedDeps simpleOutput =
   if not . null $ outdatedDeps
     then do
-      when (not simpleOutput) $
+      unless simpleOutput $
         notice verbosity "Outdated dependencies:"
       if simpleOutput
         then -- Simple output just prints package names, one per line

--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -236,7 +236,7 @@ pathAction flags@NixStyleFlags{extraFlags = pathFlags'} cliTargetStrings globalF
               , pathDirectories = Flag [minBound .. maxBound]
               }
           else pathFlags'
-  when (not $ null cliTargetStrings) $
+  unless (null cliTargetStrings) $
     dieWithException verbosity CmdPathAcceptsNoTargets
   when (buildSettingDryRun (buildSettings baseCtx)) $
     dieWithException verbosity CmdPathCommandDoesn'tSupportDryRun

--- a/cabal-install/src/Distribution/Client/Freeze.hs
+++ b/cabal-install/src/Distribution/Client/Freeze.hs
@@ -184,7 +184,7 @@ getFreezePkgs
     where
       sanityCheck :: [PackageSpecifier UnresolvedSourcePackage] -> IO ()
       sanityCheck pkgSpecifiers = do
-        when (not . null $ [n | n@(NamedPackage _ _) <- pkgSpecifiers]) $
+        unless (null [n | n@(NamedPackage _ _) <- pkgSpecifiers]) $
           dieWithException verbosity UnexpectedNamedPkgSpecifiers
         when (length pkgSpecifiers /= 1) $
           dieWithException verbosity UnexpectedSourcePkgSpecifiers

--- a/cabal-install/src/Distribution/Deprecated/ReadP.hs
+++ b/cabal-install/src/Distribution/Deprecated/ReadP.hs
@@ -212,9 +212,7 @@ eof :: ReadP r ()
 -- ^ Succeeds iff we are at the end of input
 eof = do
   s <- look
-  if null s
-    then return ()
-    else pfail
+  unless (null s) pfail
 
 (+++) :: ReadP r a -> ReadP r a -> ReadP r a
 -- ^ Symmetric choice.

--- a/cabal-testsuite/PackageTests/DataDirSetupTest/test/DataDirTest.hs
+++ b/cabal-testsuite/PackageTests/DataDirSetupTest/test/DataDirTest.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 
-import Control.Monad (when)
+import Control.Monad (unless)
 import System.Directory (createDirectory, doesFileExist, getCurrentDirectory, setCurrentDirectory)
 import System.Environment (getEnv)
 import System.Exit (exitFailure, exitSuccess)
@@ -39,7 +39,7 @@ main = do
     putStrLn $ "File exists after cd: " ++ show fileExistsAfterCd
 
     -- Exit with error if we can't find the file
-    when (not fileExistsAfterCd) $ do
+    unless fileExistsAfterCd $ do
         hPutStrLn stderr "ERROR: Could not find data file after changing directory!"
         hPutStrLn stderr $ "datadir_test_datadir was set to: " ++ dataDirEnv
         exitFailure


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use unless" suggestion so that this will be suggested by our CI linting.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
