### PR TITLE
Follow hlint suggestion: use typeRep

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -35,7 +35,6 @@
 - ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints
-- ignore: {name: "Use typeRep"} # 2 hints
 - ignore: {name: "Use void"} # 23 hints
 
 - ignore: {name: "Functor law", within: [Test.Laws]}

--- a/Cabal-described/src/Distribution/Described.hs
+++ b/Cabal-described/src/Distribution/Described.hs
@@ -39,7 +39,7 @@ module Distribution.Described (
 
 import Prelude
        ( Bool (..), Char, Either (..), Enum (..), Eq (..), Ord (..), Show (..), String
-       , elem, fmap, foldr, id, map, maybe, otherwise, return, reverse, undefined
+       , elem, fmap, foldr, id, map, maybe, otherwise, return, reverse
        , ($), (.), (<$>)
        )
 
@@ -47,7 +47,7 @@ import Data.Functor.Identity (Identity (..))
 import Data.Maybe            (fromMaybe)
 import Data.Proxy            (Proxy (..))
 import Data.String           (IsString (..))
-import Data.Typeable         (Typeable, typeOf)
+import Data.Typeable         (Typeable, typeRep)
 import Data.Void             (Void, vacuous)
 import Test.QuickCheck       (Arbitrary (..), Property, counterexample)
 import Test.Tasty            (TestTree, testGroup)
@@ -294,7 +294,7 @@ testDescribed _ = testGroup name
     , testProperty "roundtrip" propRoundtrip
     ]
   where
-    name = show (typeOf (undefined :: a))
+    name = show (typeRep (Proxy :: Proxy a))
 
     propParsec :: Ex a -> Property
     propParsec (Example str) = counterexample (show res) $ case res of

--- a/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
@@ -262,7 +262,7 @@ assertException action = do
     Right _ ->
       assertFailure $
         "expected exception of type "
-          ++ show (typeOf (undefined :: e))
+          ++ show (typeRep (Proxy :: Proxy e))
 
 -- | Expect that one line in a file matches exactly the given words (i.e. at
 -- least insensitive to whitespace)


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use typeRep" suggestion so that this will be suggested by our CI linting.

Avoids the use of `undefined`.

> [!NOTE]
> The `Proxy a` in `testDescribed` could be dropped if we were to use `-XRequiredTypeArguments` but I'll leave that for the furture. Was interesting to read about and try out this new language extension and see it in action in with `showType` from [HIW, Vladislav Zavialov - Required Type Arguments](https://youtu.be/Jnjbuu5vYvo?t=688).

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
