### PR TITLE
Remove obsolete flatDeps alias

### DIFF
--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -18,7 +18,7 @@ executable gen-spdx
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=2.2.3.0
-    , base                  >=4.13 && <4.21
+    , base                  >=4.13 && <5
     , bytestring
     , containers
     , Diff                  ^>=0.4
@@ -35,7 +35,7 @@ executable gen-spdx-exc
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=2.2.3.0
-    , base                  >=4.13 && <4.21
+    , base                  >=4.13 && <5
     , bytestring
     , containers
     , Diff                  ^>=0.4

--- a/cabal-dev-scripts/src/GenUtils.hs
+++ b/cabal-dev-scripts/src/GenUtils.hs
@@ -7,7 +7,6 @@ module GenUtils where
 
 import Control.Lens (each, ix, (%~), (&))
 import Data.Char    (toUpper)
-import Data.Maybe   (fromMaybe)
 import Data.Proxy   (Proxy (..))
 import Data.Text    (Text)
 import GHC.Generics (Generic)

--- a/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
@@ -31,7 +31,6 @@ module Distribution.Solver.Types.ComponentDeps (
   , fromInstalled
     -- ** Deconstructing ComponentDeps
   , toList
-  , flatDeps
   , nonSetupDeps
   , libraryDeps
   , setupDeps
@@ -44,7 +43,6 @@ import Distribution.Types.UnqualComponentName
 import Distribution.Solver.Compat.Prelude hiding (empty,toList,zip)
 
 import qualified Data.Map as Map
-import Data.Foldable (fold)
 
 import Distribution.Pretty (Pretty (..))
 import qualified Distribution.Types.ComponentName as CN
@@ -175,14 +173,6 @@ fromInstalled = fromLibraryDeps
 
 toList :: ComponentDeps a -> [ComponentDep a]
 toList = Map.toList . unComponentDeps
-
--- | All dependencies of a package.
---
--- This is just a synonym for 'fold', but perhaps a use of 'flatDeps' is more
--- obvious than a use of 'fold', and moreover this avoids introducing lots of
--- @#ifdef@s for 7.10 just for the use of 'fold'.
-flatDeps :: Monoid a => ComponentDeps a -> a
-flatDeps = fold
 
 -- | All dependencies except the setup dependencies.
 --

--- a/cabal-install-solver/src/Distribution/Solver/Types/ResolverPackage.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ResolverPackage.hs
@@ -17,6 +17,7 @@ import qualified Distribution.Solver.Types.ComponentDeps as CD
 import Distribution.Compat.Graph (IsNode(..))
 import Distribution.Package (Package(..), HasUnitId(..))
 import Distribution.Simple.Utils (ordNub)
+import Data.Foldable (fold)
 
 -- | The dependency resolver picks either pre-existing installed packages
 -- or it picks source packages along with package configuration.
@@ -48,5 +49,5 @@ instance IsNode (ResolverPackage loc) where
   nodeKey (Configured spkg) = PlannedId (packageId spkg)
   -- Use dependencies for ALL components
   nodeNeighbors pkg =
-    ordNub $ CD.flatDeps (resolverPackageLibDeps pkg) ++
-             CD.flatDeps (resolverPackageExeDeps pkg)
+    ordNub $ fold (resolverPackageLibDeps pkg) ++
+             fold (resolverPackageExeDeps pkg)

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -167,6 +167,7 @@ import Distribution.Solver.Types.Variable
 import Control.Exception
   ( assert
   )
+import Data.Foldable (fold)
 import Data.List
   ( maximumBy
   )
@@ -1099,9 +1100,6 @@ configuredPackageProblems
       specifiedDeps1 :: ComponentDeps [PackageId]
       specifiedDeps1 = fmap (map solverSrcId) specifiedDeps0
 
-      specifiedDeps :: [PackageId]
-      specifiedDeps = CD.flatDeps specifiedDeps1
-
       mergedFlags :: [MergeResult PD.FlagName PD.FlagName]
       mergedFlags =
         mergeBy
@@ -1118,7 +1116,7 @@ configuredPackageProblems
       dependencyName (Dependency name _ _) = name
 
       mergedDeps :: [MergeResult Dependency PackageId]
-      mergedDeps = mergeDeps requiredDeps specifiedDeps
+      mergedDeps = mergeDeps requiredDeps (fold specifiedDeps1)
 
       mergeDeps
         :: [Dependency]

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -274,6 +274,7 @@ import Distribution.Version
   )
 
 import qualified Data.ByteString as BS
+import Data.Foldable (fold)
 import Distribution.Client.Errors
 
 -- TODO:
@@ -1002,7 +1003,7 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
                 )
             )
           _ <-
-          CD.flatDeps (confPkgDeps cpkg)
+          fold (confPkgDeps cpkg)
       ]
 
     revDeps :: Map.Map PackageId [PackageId]

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2169,7 +2169,7 @@ elaborateInstallPlan
 
             -- TODO: Why is this flat?
             pkgPkgConfigDependencies =
-              CD.flatDeps $ buildComponentDeps compPkgConfigDependencies
+              fold $ buildComponentDeps compPkgConfigDependencies
 
             pkgDependsOnSelfLib =
               CD.fromList
@@ -3577,7 +3577,7 @@ pruneInstallPlanPass1 pkgs
     pruneOptionalDependencies elab@ElaboratedConfiguredPackage{elabPkgOrComp = ElabComponent _} =
       InstallPlan.depends elab -- no pruning
     pruneOptionalDependencies ElaboratedConfiguredPackage{elabPkgOrComp = ElabPackage pkg} =
-      (CD.flatDeps . CD.filterDeps keepNeeded) (pkgOrderDependencies pkg)
+      (fold . CD.filterDeps keepNeeded) (pkgOrderDependencies pkg)
       where
         keepNeeded (CD.ComponentTest _) _ = TestStanzas `optStanzaSetMember` stanzas
         keepNeeded (CD.ComponentBench _) _ = BenchStanzas `optStanzaSetMember` stanzas

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -119,6 +119,7 @@ import Distribution.Utils.Path (getSymbolicPath)
 import Distribution.Version
 
 import qualified Data.ByteString.Lazy as LBS
+import Data.Foldable (fold)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Monoid as Mon
@@ -558,7 +559,7 @@ elabOrderDependencies elab =
   case elabPkgOrComp elab of
     -- Important not to have duplicates: otherwise InstallPlan gets
     -- confused.
-    ElabPackage pkg -> ordNub (CD.flatDeps (pkgOrderDependencies pkg))
+    ElabPackage pkg -> ordNub (fold (pkgOrderDependencies pkg))
     ElabComponent comp -> compOrderDependencies comp
 
 -- | Like 'elabOrderDependencies', but only returns dependencies on
@@ -569,7 +570,7 @@ elabOrderLibDependencies elab =
     ElabPackage pkg ->
       map (newSimpleUnitId . confInstId) $
         ordNub $
-          CD.flatDeps (map fst <$> pkgLibDependencies pkg)
+          fold (map fst <$> pkgLibDependencies pkg)
     ElabComponent comp -> compOrderLibDependencies comp
 
 -- | The library dependencies (i.e., the libraries we depend on, NOT

--- a/cabal-install/src/Distribution/Client/Types/ConfiguredPackage.hs
+++ b/cabal-install/src/Distribution/Client/Types/ConfiguredPackage.hs
@@ -16,6 +16,7 @@ import Distribution.Types.Flag (FlagAssignment)
 import Distribution.Types.LibraryName (LibraryName (..))
 import Distribution.Types.MungedPackageId (computeCompatPackageId)
 
+import Data.Foldable (fold)
 import Distribution.Client.Types.ConfiguredId
 import Distribution.Solver.Types.OptionalStanza (OptionalStanzaSet)
 import Distribution.Solver.Types.PackageFixedDeps
@@ -65,7 +66,7 @@ instance IsNode (ConfiguredPackage loc) where
   -- TODO: if we update ConfiguredPackage to support order-only
   -- dependencies, need to include those here.
   -- NB: have to deduplicate, otherwise the planner gets confused
-  nodeNeighbors = ordNub . CD.flatDeps . depends
+  nodeNeighbors = ordNub . fold . depends
 
 instance Binary loc => Binary (ConfiguredPackage loc)
 
@@ -80,4 +81,4 @@ instance HasUnitId (ConfiguredPackage loc) where
   installedUnitId = newSimpleUnitId . confPkgId
 
 instance PackageInstalled (ConfiguredPackage loc) where
-  installedDepends = CD.flatDeps . depends
+  installedDepends = fold . depends

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -11,6 +11,7 @@ import Control.Exception (try)
 import Data.ByteString as BS (null)
 import Data.ByteString.Lazy as BSL (pack, toChunks)
 import Data.ByteString.Lazy.Char8 as BSLL (init, length, pack)
+import Data.Either (isLeft)
 import Distribution.Client.GZipUtils (maybeDecompress)
 
 import Test.Tasty
@@ -55,8 +56,3 @@ prop_maybeDecompress_gzip ws = property $ maybeDecompress compressedGZip === ori
   where
     original = BSL.pack ws
     compressedGZip = GZip.compress original
-
--- (Only available from "Data.Either" since 7.8.)
-isLeft :: Either a b -> Bool
-isLeft (Right _) = False
-isLeft (Left _) = True

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -86,6 +86,7 @@ import Distribution.Client.Dependency
 import qualified Distribution.Client.SolverInstallPlan as CI.SolverInstallPlan
 import Distribution.Client.Types
 
+import Data.Foldable (fold)
 import Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import Distribution.Solver.Types.ConstraintSource
@@ -417,7 +418,7 @@ exAvSrcPkg ex =
             usedFlags :: Map ExampleFlagName C.PackageFlag
             usedFlags = Map.fromList [(fn, mkDefaultFlag fn) | fn <- names]
               where
-                names = extractFlags $ CD.flatDeps (exAvDeps ex)
+                names = extractFlags $ fold (exAvDeps ex)
          in -- 'declaredFlags' overrides 'usedFlags' to give flags non-default settings:
             Map.elems $ declaredFlags `Map.union` usedFlags
 


### PR DESCRIPTION
It was only used to avoid #ifdefs for GHC 7.10 compatibility, which is no longer needed.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
