### PR TITLE
don't delete duplicate C headers

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -2607,14 +2607,10 @@ checkForeignDeps pkg lbi verbosity =
     -- in either the generated (most likely by `configure`)
     -- build directory (e.g. `dist/build`) or in the source directory.
     --
-    -- If it exists in both, we'll remove the one in the source
-    -- directory, as the generated should take precedence.
+    -- If it exists in both, issue a warning, because C compilers are
+    -- not guaranteed to pick the correct one and there appears to be
+    -- no way to control which is picked.
     --
-    -- C compilers like to prefer source local relative includes,
-    -- so the search paths provided to the compiler via -I are
-    -- ignored if the included file can be found relative to the
-    -- including file.  As such we need to take drastic measures
-    -- and delete the offending file in the source directory.
     checkDuplicateHeaders = do
       let relIncDirs = filter (not . isAbsolute) (collectField (fmap getSymbolicPath . includeDirs))
           isHeader = isSuffixOf ".h"
@@ -2631,9 +2627,7 @@ checkForeignDeps pkg lbi verbosity =
             ++ (getSymbolicPath (buildDir lbi) </> hdr)
             ++ " and "
             ++ (baseDir </> hdr)
-            ++ "; removing "
-            ++ (baseDir </> hdr)
-        removeFileForcibly (baseDir </> hdr)
+            ++ ". Which one the C compiler will use is unspecified."
 
     findOffendingHdr =
       ifBuildsWith

--- a/changelog.d/hsec-2026-0006
+++ b/changelog.d/hsec-2026-0006
@@ -1,0 +1,15 @@
+---
+synopsis: don't delete duplicate C header files
+packages: [Cabal]
+prs: 11733
+issues: 11176
+significance: significant
+---
+
+PR 4874 introduced a change which removes C headers that duplicate `autogen-includes`.
+This is unacceptable behavior, and in addition can be exploited on Windows to remove
+any file on the system. Issue a warning about undefined C compiler behavior instead.
+
+Original PR: https://github.com/haskell/cabal/pull/4874/changes#diff-e3cd8c042e1d9d4f3d54c4ec03a508cc2e61598aa7f88033d1cf847e5b712647R1658
+
+Security advisory for arbitrary file removal: https://haskell.github.io/security-advisories/advisory/HSEC-2026-0006.html


### PR DESCRIPTION
https://github.com/haskell/cabal/pull/4874 introduced a change which forcibly removes C headers that are duplicated by `autogen-includes`. Issue a warning instead, because we have no business deleting sources from a package.

https://haskell.github.io/security-advisories/advisory/HSEC-2026-0006.html because this can remove arbitrary (header only, as yet) files on Windows. (No way has been found to abuse it on POSIX… yet.)

---

**Template Α: This PR modifies [behaviour or interface](CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
