### PR TITLE
Follow hlint suggestion: use fmap

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,12 +1,12 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
-- ignore: {name: "Avoid lambda"} # 51 hints
-- ignore: {name: "Eta reduce"} # 138 hints
+- ignore: {name: "Avoid lambda"} # 49 hints
+- ignore: {name: "Eta reduce"} # 139 hints
 - ignore: {name: "Hoist not"} # 16 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Redundant $!"} # 1 hint
-- ignore: {name: "Redundant <$>"} # 17 hints
-- ignore: {name: "Redundant bracket"} # 257 hints
+- ignore: {name: "Redundant <$>"} # 18 hints
+- ignore: {name: "Redundant bracket"} # 279 hints
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 19 hints
@@ -23,9 +23,8 @@
 - ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
-- ignore: {name: "Use camelCase"} # 96 hints
+- ignore: {name: "Use camelCase"} # 97 hints
 - ignore: {name: "Use const"} # 36 hints
-- ignore: {name: "Use fmap"} # 23 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
@@ -39,6 +38,7 @@
 - ignore: {name: "Functor law", within: [Test.Laws]}
 - ignore: {name: "Monoid law, left identity", within: [Test.Laws, UnitTests.Distribution.Utils.NubList]}
 - ignore: {name: "Monoid law, right identity", within: [Test.Laws, UnitTests.Distribution.Utils.NubList]}
+- ignore: {name: "Use fmap", within: [Distribution.Client.HttpUtils, Distribution.Simple.SrcDist]}
 
 - group:
     name: cabal-suggestions

--- a/Cabal-syntax/src/Distribution/Utils/Generic.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Generic.hs
@@ -544,7 +544,7 @@ unfoldrM f = go
       m <- f b
       case m of
         Nothing -> return []
-        Just (a, b') -> liftM (a :) (go b')
+        Just (a, b') -> (a :) <$> (go b')
 
 -- | The opposite of 'snoc', which is the reverse of 'cons'
 --

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -312,7 +312,7 @@ maybeGetPersistBuildConfig
   -- ^ The @dist@ directory path.
   -> IO (Maybe LocalBuildInfo)
 maybeGetPersistBuildConfig mbWorkDir =
-  liftM (either (const Nothing) Just) . tryGetPersistBuildConfig mbWorkDir
+  fmap (either (const Nothing) Just) . tryGetPersistBuildConfig mbWorkDir
 
 -- | After running configure, output the 'LocalBuildInfo' to the
 -- 'localBuildInfoFile'.
@@ -422,7 +422,7 @@ findDistPref
   -- ^ override \"dist\" prefix
   -> IO (SymbolicPath Pkg (Dir Dist))
 findDistPref defDistPref overrideDistPref = do
-  envDistPref <- liftM parseEnvDistPref (lookupEnv "CABAL_BUILDDIR")
+  envDistPref <- parseEnvDistPref <$> lookupEnv "CABAL_BUILDDIR"
   return $ fromFlagOrDefault defDistPref (mappend envDistPref overrideDistPref)
   where
     parseEnvDistPref env =

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -125,8 +125,8 @@ getInstalledPackages verbosity comp mbWorkDir packagedbs progdb = do
   let pkgDirs = nub (concatMap (packageDbPaths userPkgDir systemPkgDir mbWorkDir) packagedbs)
   -- putStrLn $ "pkgdirs: " ++ show pkgDirs
   pkgs <-
-    liftM (map addBuiltinVersions . concat) $
-      traverse
+    map addBuiltinVersions . concat
+      <$> traverse
         (\d -> listDirectory d >>= filterM (isPkgDir (prettyShow compilerid) d))
         pkgDirs
   -- putStrLn $ "pkgs: " ++ show pkgs

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
@@ -164,10 +164,10 @@ inn (DoneF       x s           ) = Done       x s
 inn (FailF       c x           ) = Fail       c x
 
 innM :: Monad m => TreeF d c (m (Tree d c)) -> m (Tree d c)
-innM (PChoiceF    p s i       ts) = liftM (PChoice    p s i      ) (sequence ts)
-innM (FChoiceF    p s i b m d ts) = liftM (FChoice    p s i b m d) (sequence ts)
-innM (SChoiceF    p s i b     ts) = liftM (SChoice    p s i b    ) (sequence ts)
-innM (GoalChoiceF   s         ts) = liftM (GoalChoice   s        ) (sequence ts)
+innM (PChoiceF    p s i       ts) = PChoice    p s i       <$> sequence ts
+innM (FChoiceF    p s i b m d ts) = FChoice    p s i b m d <$> sequence ts
+innM (SChoiceF    p s i b     ts) = SChoice    p s i b     <$> sequence ts
+innM (GoalChoiceF   s         ts) = GoalChoice   s         <$> sequence ts
 innM (DoneF       x s           ) = return $ Done     x s
 innM (FailF       c x           ) = return $ Fail     c x
 

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1046,7 +1046,7 @@ getConfigFilePathAndSource verbosity configFileFlag =
 
     sources =
       [ (CommandlineOption, return . flagToMaybe $ configFileFlag)
-      , (EnvironmentVariable, lookup "CABAL_CONFIG" `liftM` getEnvironment)
+      , (EnvironmentVariable, lookup "CABAL_CONFIG" <$> getEnvironment)
       , (Default, defaultSource)
       ]
 

--- a/cabal-install/src/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/src/Distribution/Client/GZipUtils.hs
@@ -42,7 +42,7 @@ maybeDecompress bytes = runST (go bytes decompressor)
     -- (https://en.wikipedia.org/wiki/Gzip#File_structure)
     -- at the beginning of the gzip header.  (not an option for zlib, though.)
     go :: Monad m => ByteString -> DecompressStream m -> m ByteString
-    go cs (DecompressOutputAvailable bs k) = liftM (Chunk bs) $ go' cs =<< k
+    go cs (DecompressOutputAvailable bs k) = Chunk bs <$> (go' cs =<< k)
     go _ (DecompressStreamEnd _bs) = return Empty
     go _ (DecompressStreamError _err) = return bytes
     go cs (DecompressInputRequired k) = go cs' =<< k c
@@ -53,7 +53,7 @@ maybeDecompress bytes = runST (go bytes decompressor)
     -- and we throw them (as pure exceptions).
     -- TODO: We could (and should) avoid these pure exceptions.
     go' :: Monad m => ByteString -> DecompressStream m -> m ByteString
-    go' cs (DecompressOutputAvailable bs k) = liftM (Chunk bs) $ go' cs =<< k
+    go' cs (DecompressOutputAvailable bs k) = Chunk bs <$> (go' cs =<< k)
     go' _ (DecompressStreamEnd _bs) = return Empty
     go' _ (DecompressStreamError err) = throw err
     go' cs (DecompressInputRequired k) = go' cs' =<< k c

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -282,7 +282,7 @@ buildAndRegisterUnpackedPackage
       configureFlags v =
         flip filterConfigureFlags v
           <$> setupHsConfigureFlags
-            (\p -> makeSymbolicPath <$> canonicalizePath p)
+            (fmap makeSymbolicPath . canonicalizePath)
             plan
             rpkg
             pkgshared

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1281,28 +1281,29 @@ findProjectPackages
       checkIsFileGlobPackage pkglocstr =
         case simpleParsec pkglocstr of
           Nothing -> return Nothing
-          Just glob -> liftM Just $ do
-            matches <- matchFileGlob glob
-            case matches of
-              []
-                | isJust (isTrivialRootedGlob glob) ->
-                    return
-                      ( Left
-                          ( BadPackageLocationFile
-                              (BadLocNonexistentFile pkglocstr)
-                          )
-                      )
-              [] -> return (Left (BadLocGlobEmptyMatch pkglocstr))
-              _ -> do
-                (failures, pkglocs) <-
-                  partitionEithers
-                    <$> traverse checkFilePackageMatch matches
-                return $! case (failures, pkglocs) of
-                  ([failure], [])
-                    | isJust (isTrivialRootedGlob glob) ->
-                        Left (BadPackageLocationFile failure)
-                  (_, []) -> Left (BadLocGlobBadMatches pkglocstr failures)
-                  _ -> Right pkglocs
+          Just glob ->
+            Just <$> do
+              matches <- matchFileGlob glob
+              case matches of
+                []
+                  | isJust (isTrivialRootedGlob glob) ->
+                      return
+                        ( Left
+                            ( BadPackageLocationFile
+                                (BadLocNonexistentFile pkglocstr)
+                            )
+                        )
+                [] -> return (Left (BadLocGlobEmptyMatch pkglocstr))
+                _ -> do
+                  (failures, pkglocs) <-
+                    partitionEithers
+                      <$> traverse checkFilePackageMatch matches
+                  return $! case (failures, pkglocs) of
+                    ([failure], [])
+                      | isJust (isTrivialRootedGlob glob) ->
+                          Left (BadPackageLocationFile failure)
+                    (_, []) -> Left (BadLocGlobBadMatches pkglocstr failures)
+                    _ -> Right pkglocs
 
       checkIsSingleFilePackage pkglocstr = do
         let filename = distProjectRootDirectory </> pkglocstr

--- a/cabal-install/src/Distribution/Client/Targets.hs
+++ b/cabal-install/src/Distribution/Client/Targets.hs
@@ -164,10 +164,7 @@ data UserTarget
 
 readUserTargets :: Verbosity -> [String] -> IO [UserTarget]
 readUserTargets verbosity targetStrs = do
-  (problems, targets) <-
-    liftM
-      partitionEithers
-      (traverse readUserTarget targetStrs)
+  (problems, targets) <- partitionEithers <$> traverse readUserTarget targetStrs
   reportUserTargetProblems verbosity problems
   return targets
 

--- a/cabal-install/src/Distribution/Deprecated/ViewAsFieldDescr.hs
+++ b/cabal-install/src/Distribution/Deprecated/ViewAsFieldDescr.hs
@@ -53,7 +53,7 @@ viewAsFieldDescr (OptionField n (d : dd)) = FieldDescr n get set
     --    set :: LineNo -> String -> a -> ParseResult a
     set line val a =
       case optDescr of
-        ReqArg _ _ _ readE _ -> ($ a) `liftM` runE line n readE val
+        ReqArg _ _ _ readE _ -> ($ a) <$> runE line n readE val
         -- We parse for a single value instead of a
         -- list, as one can't really implement
         -- parseList :: ReadE a -> ReadE [a] with
@@ -62,8 +62,8 @@ viewAsFieldDescr (OptionField n (d : dd)) = FieldDescr n get set
           case getChoiceByLongFlag optDescr val of
             Just f -> return (f a)
             _ -> syntaxError line val
-        BoolOpt _ _ _ setV _ -> (`setV` a) `liftM` runE line n (parsecToReadE ("<viewAsFieldDescr>" ++) parsec) val
-        OptArg _ _ _ readE _ _ -> ($ a) `liftM` runE line n readE val
+        BoolOpt _ _ _ setV _ -> (`setV` a) <$> runE line n (parsecToReadE ("<viewAsFieldDescr>" ++) parsec) val
+        OptArg _ _ _ readE _ _ -> ($ a) <$> runE line n readE val
 
 -- Optional arguments are parsed just like
 -- required arguments here; we don't


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use fmap" suggestion so that this will be suggested by our CI linting. Most of these are replacements of `liftM` with `fmap`. I exclude this suggestion in `[Distribution.Client.HttpUtils, Distribution.Simple.SrcDist]` as I thought the eta reduction didn't read as well.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
