### PR TITLE
Remove obsolete file exclusion

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -53,8 +53,6 @@
     - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs
     - --ignore-glob=Cabal-tests/tests/custom-setup/CabalDoctestSetup.hs
     - --ignore-glob=Cabal-tests/tests/custom-setup/IdrisSetup.hs
-    # TODO: Remove --ignore-glob for ghc-supported-languages.hs when this module compiles
-    - --ignore-glob=Cabal-tests/tests/misc/ghc-supported-languages.hs
     - --ignore-glob=cabal-testsuite/PackageTests/BuildWays/q/app/Main.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CMain/10168/src/Lib.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSources/src/Demo.hs


### PR DESCRIPTION
Minor follow on from #11634 that I missed at the time.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
