### PR TITLE
Follow hlint suggestion: redundant <$>

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -5,18 +5,17 @@
 - ignore: {name: "Hoist not"} # 16 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Redundant $!"} # 1 hint
-- ignore: {name: "Redundant <$>"} # 18 hints
-- ignore: {name: "Redundant bracket"} # 279 hints
-- ignore: {name: "Redundant guard"} # 2 hints
+- ignore: {name: "Redundant bracket"} # 273 hints
+- ignore: {name: "Redundant guard"} # 1 hint
 - ignore: {name: "Redundant if"} # 6 hints
-- ignore: {name: "Redundant lambda"} # 19 hints
+- ignore: {name: "Redundant lambda"} # 16 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant return"} # 9 hints
 - ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 29 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 78 hints
+- ignore: {name: "Use <$>"} # 82 hints
 - ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
@@ -28,7 +27,7 @@
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
-- ignore: {name: "Use map once"} # 7 hints
+- ignore: {name: "Use map once"} # 6 hints
 - ignore: {name: "Use map with tuple-section"} # 3 hints
 - ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 2 hints

--- a/Cabal-syntax/src/Distribution/Types/CondTree.hs
+++ b/Cabal-syntax/src/Distribution/Types/CondTree.hs
@@ -125,8 +125,7 @@ traverseCondTreeV f (CondNode a ifs) =
 -- | @@Traversal@@ for the data
 traverseCondBranchA :: L.Traversal (CondBranch v a) (CondBranch v b) a b
 traverseCondBranchA f (CondBranch cnd t me) =
-  CondBranch
-    <$> pure cnd
+  pure (CondBranch cnd)
     <*> traverseCondTreeA f t
     <*> traverse (traverseCondTreeA f) me
 

--- a/Cabal-syntax/src/Distribution/Types/GenericPackageDescription/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/GenericPackageDescription/Lens.hs
@@ -81,8 +81,7 @@ allCondTrees
   -> GenericPackageDescription
   -> f GenericPackageDescription
 allCondTrees f (GenericPackageDescription p v a1 x1 x2 x3 x4 x5 x6) =
-  GenericPackageDescription
-    <$> pure p
+  pure (GenericPackageDescription p)
     <*> pure v
     <*> pure a1
     <*> traverse f x1

--- a/Cabal-syntax/src/Distribution/Types/LegacyExeDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/LegacyExeDependency.hs
@@ -43,7 +43,7 @@ instance Parsec LegacyExeDependency where
     verRange <- parsecMaybeQuoted parsec <|> pure anyVersion
     pure $ LegacyExeDependency name verRange
     where
-      nameP = intercalate "-" <$> toList <$> P.sepByNonEmpty component (P.char '-')
+      nameP = intercalate "-" . toList <$> P.sepByNonEmpty component (P.char '-')
       component = do
         cs <- P.munch1 (\c -> isAlphaNum c || c == '+' || c == '_')
         if all isDigit cs then fail "invalid component" else return cs

--- a/Cabal-syntax/src/Distribution/Types/Version.hs
+++ b/Cabal-syntax/src/Distribution/Types/Version.hs
@@ -99,7 +99,7 @@ instance Pretty Version where
       )
 
 instance Parsec Version where
-  parsec = mkVersion <$> toList <$> P.sepByNonEmpty versionDigitParser (P.char '.') <* tags
+  parsec = (mkVersion . toList <$> P.sepByNonEmpty versionDigitParser (P.char '.')) <* tags
     where
       tags = do
         ts <- many $ P.char '-' *> some (P.satisfy isAlphaNum)

--- a/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
@@ -513,7 +513,7 @@ versionRangeParser digitParser csv = expr
 
     -- a plain version without tags or wildcards
     verPlain :: CabalParsing m => m Version
-    verPlain = mkVersion <$> toList <$> P.sepByNonEmpty digitParser (P.char '.')
+    verPlain = mkVersion . toList <$> P.sepByNonEmpty digitParser (P.char '.')
 
     -- either wildcard or normal version
     verOrWild :: CabalParsing m => m (Bool, Version)

--- a/Cabal/src/Distribution/Compat/ResponseFile.hs
+++ b/Cabal/src/Distribution/Compat/ResponseFile.hs
@@ -31,4 +31,4 @@ expandResponse = go recursionLimit "."
     expand _n _dir x = return [x]
 
     readRecursively :: Int -> FilePath -> IO [String]
-    readRecursively n f = go (n - 1) (takeDirectory f) =<< unescapeArgs <$> readFile f
+    readRecursively n f = go (n - 1) (takeDirectory f) . unescapeArgs =<< readFile f

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -237,12 +237,7 @@ configureCompiler verbosity hcPath conf0 = do
       -- In this example, @AbiTag@ is "inplace".
       compilerAbiTag :: AbiTag
       compilerAbiTag =
-        maybe
-          NoAbiTag
-          AbiTag
-          ( dropWhile (== '-') . stripCommonPrefix (prettyShow compilerId)
-              <$> projectUnitId
-          )
+        maybe NoAbiTag (AbiTag . dropWhile (== '-') . stripCommonPrefix (prettyShow compilerId)) projectUnitId
 
       wiredInUnitIds = do
         ghcInternalUnitId <- Map.lookup "ghc-internal Unit Id" ghcInfoMap

--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -377,12 +377,8 @@ renderListBinProblem (TargetProblemMatchesMultiple targetSelector targets) =
     ++ renderTargetSelector targetSelector
     ++ " which includes "
     ++ renderListCommaAnd
-      ( ("the " ++)
-          <$> showComponentName
-          <$> availableTargetComponentName
-          <$> foldMap
-            (`filterTargetsKind` targets)
-            [ExeKind, TestKind, BenchKind]
+      ( (("the " ++) <$> showComponentName) . availableTargetComponentName
+          <$> foldMap (`filterTargetsKind` targets) [ExeKind, TestKind, BenchKind]
       )
     ++ "."
 renderListBinProblem (TargetProblemMultipleTargets selectorMap) =

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -556,9 +556,7 @@ renderRunProblem (TargetProblemMatchesMultiple targetSelector targets) =
           <$> zip
             ["executables", "test-suites", "benchmarks"]
             ( filter (not . null) . map sortNub $
-                map (componentNameRaw . availableTargetComponentName)
-                  <$> (`filterTargetsKind` targets)
-                  <$> [ExeKind, TestKind, BenchKind]
+                (map (componentNameRaw . availableTargetComponentName) . (`filterTargetsKind` targets) <$> [ExeKind, TestKind, BenchKind])
             )
       )
 renderRunProblem (TargetProblemMultipleTargets selectorMap) =

--- a/cabal-install/src/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Init/Utils.hs
@@ -176,7 +176,7 @@ retrieveModuleImports m = do
 -- | Given a module, retrieve all of its language pragmas
 retrieveModuleExtensions :: Interactive m => FilePath -> m [Extension]
 retrieveModuleExtensions m = do
-  catMaybes <$> map (simpleParsec . trim) . grabModuleExtensions <$> readFile m
+  mapMaybe (simpleParsec . trim) . grabModuleExtensions <$> readFile m
   where
     stop c = (c /= '\n') && (c /= ' ') && (c /= ',') && (c /= '#')
 

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -322,7 +322,7 @@ main args = do
   -- for more information.
   let (args0, args1) = break (== "--") args
 
-  mainWorker =<< (++ args1) <$> expandResponse args0
+  mainWorker . (++ args1) =<< expandResponse args0
 
 -- | Check whether assertions are enabled and print a warning in that case.
 warnIfAssertionsAreEnabled :: IO ()

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -612,8 +612,7 @@ findProjectRoot verbosity mprojectDir mprojectFile = do
 
           getProjectRootUsability file >>= \case
             ProjectRootUsabilityPresentAndUsable ->
-              uncurry projectRoot
-                =<< first dropTrailingPathSeparator . splitFileName <$> canonicalizePath file
+              uncurry projectRoot . first dropTrailingPathSeparator . splitFileName =<< canonicalizePath file
             ProjectRootUsabilityNotPresent ->
               left (BadProjectRootExplicitFileNotFound file)
             ProjectRootUsabilityPresentAndUnusable ->

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -404,8 +404,7 @@ getSetup verbosity options mpkg = do
   where
     mbWorkDir = useWorkingDir options
     getPkg =
-      (relativeSymbolicPath <$> tryFindPackageDesc verbosity mbWorkDir)
-        >>= readGenericPackageDescription verbosity mbWorkDir
+      (tryFindPackageDesc verbosity mbWorkDir >>= readGenericPackageDescription verbosity mbWorkDir . relativeSymbolicPath)
         >>= return . packageDescription
 
 -- | Decide if we're going to be able to do a direct internal call to the

--- a/cabal-install/src/Distribution/Client/Utils/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/Utils/Parsec.hs
@@ -81,8 +81,7 @@ instance (Newtype a b, Sep sep, Pretty b) => Pretty (NubList' sep b a) where
 
 remoteRepoGrammar :: RepoName -> ParsecFieldGrammar RemoteRepo RemoteRepo
 remoteRepoGrammar name =
-  RemoteRepo
-    <$> pure name
+  pure (RemoteRepo name)
     <*> uniqueFieldAla "url" URI_NT remoteRepoURILens
     <*> optionalField "secure" remoteRepoSecureLens
     <*> monoidalFieldAla "root-keys" (alaList' FSep Token) remoteRepoRootKeysLens

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -111,8 +111,7 @@ instance Arbitrary URI where
 
 instance Arbitrary URIAuth where
   arbitrary =
-    URIAuth
-      <$> pure "" -- no password as this does not roundtrip
+    pure (URIAuth "") -- no password as this does not roundtrip
       <*> arbitraryURIToken
       <*> arbitraryURIPort
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -453,7 +453,7 @@ instance Arbitrary RepoDirSet where
   arbitrary =
     sized $ \n ->
       oneof $
-        [RepoDirSet <$> pure 1]
+        [pure (RepoDirSet 1)]
           ++ [RepoDirSet <$> choose (2, 5) | n >= 3]
   shrink (RepoDirSet n) =
     [RepoDirSet i | i <- shrink n, i > 0]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -558,7 +558,7 @@ instance Arbitrary Component where
 -- internal libraries.
 arbitraryUQN :: Gen UnqualComponentName
 arbitraryUQN =
-  mkUnqualComponentName <$> (\c -> "component-" ++ [c]) <$> elements "ABC"
+  mkUnqualComponentName . (\c -> "component-" ++ [c]) <$> elements "ABC"
 
 instance Arbitrary ExampleInstalled where
   arbitrary = error "arbitrary not implemented: ExampleInstalled"


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "redundant <$>" suggestion so that this will be suggested by our CI linting. A lot of these replace a sequence of `f <$> g <$> etc` with `f . g <$> etc`.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
