### PR TITLE
tests: make UserConfig unit tests concurrency-safe with unique tempiles

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -114,6 +114,7 @@ import Distribution.Utils.NubList
   )
 
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as M
 import Distribution.Client.Errors
 import Distribution.Client.HttpUtils
@@ -208,6 +209,7 @@ import Distribution.Simple.Utils
   , notice
   , toUTF8BS
   , warn
+  , writeFileAtomic
   )
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Utils.Path (getSymbolicPath, unsafeMakeSymbolicPath)
@@ -228,12 +230,10 @@ import System.Directory
   , getAppUserDataDirectory
   , getHomeDirectory
   , getXdgDirectory
-  , renameFile
   )
 import System.FilePath
   ( normalise
   , takeDirectory
-  , (<.>)
   , (</>)
   )
 import System.IO.Error
@@ -1078,11 +1078,10 @@ createDefaultConfigFile verbosity extraLines filePath = do
 
 writeConfigFile :: FilePath -> SavedConfig -> SavedConfig -> IO ()
 writeConfigFile file comments vals = do
-  let tmpFile = file <.> "tmp"
   createDirectoryIfMissing True (takeDirectory file)
-  writeFile tmpFile $
-    explanation ++ showConfigWithComments comments vals ++ "\n"
-  renameFile tmpFile file
+  writeFileAtomic file $
+    LBS.fromStrict . toUTF8BS $
+      explanation ++ showConfigWithComments comments vals ++ "\n"
   where
     explanation =
       unlines

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -230,6 +230,7 @@ import System.Directory
   , getAppUserDataDirectory
   , getHomeDirectory
   , getXdgDirectory
+  , renameFile
   )
 import System.FilePath
   ( normalise

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -4,7 +4,8 @@ module UnitTests.Distribution.Client.UserConfig
   ( tests
   ) where
 
-import Control.Exception (bracket)
+import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar)
+import Control.Exception (IOException, bracket, try)
 import Control.Monad (replicateM_)
 import Data.List (nub, sort)
 import System.Directory
@@ -31,6 +32,7 @@ tests =
   , testCase "canDetectDifference" canDetectDifference
   , testCase "canUpdateConfig" canUpdateConfig
   , testCase "doubleUpdateConfig" doubleUpdateConfig
+  , testCase "concurrentUpdateConfig" concurrentUpdateConfig
   , testCase "newDefaultConfig" newDefaultConfig
   ]
 
@@ -87,6 +89,26 @@ newDefaultConfig = do
     exists <- doesFileExist configFile
     assertBool ("Config file should be written to " ++ configFile) exists
 
+concurrentUpdateConfig :: Assertion
+concurrentUpdateConfig = bracketTest $ \configFile -> do
+  _ <- createDefaultConfigFile (mkVerbosity defaultVerbosityHandles silent) [] configFile
+
+  doneVars <- replicateM numConcurrentUpdates newEmptyMVar
+  mapM_
+    ( \doneVar ->
+        forkIO $ do
+          result <- try (userConfigUpdate (mkVerbosity defaultVerbosityHandles silent) (globalFlags configFile) []) :: IO (Either IOException ())
+          putMVar doneVar result
+    )
+    doneVars
+
+  results <- mapM takeMVar doneVars
+  assertBool "Concurrent userConfigUpdate should not throw" (all isSuccess results)
+  where
+    numConcurrentUpdates = 16 :: Int
+    isSuccess (Right ()) = True
+    isSuccess _ = False
+
 globalFlags :: FilePath -> GlobalFlags
 globalFlags configFile = mempty{globalConfigFile = Flag configFile}
 
@@ -108,4 +130,4 @@ bracketTest =
 
     testTearDown :: FilePath -> IO ()
     testTearDown configFile =
-      mapM_ removeFileForcibly [configFile, configFile ++ ".backup", configFile ++ ".tmp"]
+      mapM_ removeFileForcibly [configFile, configFile ++ ".backup"]

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -32,7 +32,6 @@ tests =
   , testCase "canDetectDifference" canDetectDifference
   , testCase "canUpdateConfig" canUpdateConfig
   , testCase "doubleUpdateConfig" doubleUpdateConfig
-  , testCase "concurrentUpdateConfig" concurrentUpdateConfig
   , testCase "newDefaultConfig" newDefaultConfig
   ]
 
@@ -88,26 +87,6 @@ newDefaultConfig = do
     _ <- createDefaultConfigFile (mkVerbosity defaultVerbosityHandles silent) [] configFile
     exists <- doesFileExist configFile
     assertBool ("Config file should be written to " ++ configFile) exists
-
-concurrentUpdateConfig :: Assertion
-concurrentUpdateConfig = bracketTest $ \configFile -> do
-  _ <- createDefaultConfigFile (mkVerbosity defaultVerbosityHandles silent) [] configFile
-
-  doneVars <- replicateM numConcurrentUpdates newEmptyMVar
-  mapM_
-    ( \doneVar ->
-        forkIO $ do
-          result <- try (userConfigUpdate (mkVerbosity defaultVerbosityHandles silent) (globalFlags configFile) []) :: IO (Either IOException ())
-          putMVar doneVar result
-    )
-    doneVars
-
-  results <- mapM takeMVar doneVars
-  assertBool "Concurrent userConfigUpdate should not throw" (all isSuccess results)
-  where
-    numConcurrentUpdates = 16 :: Int
-    isSuccess (Right ()) = True
-    isSuccess _ = False
 
 globalFlags :: FilePath -> GlobalFlags
 globalFlags configFile = mempty{globalConfigFile = Flag configFile}

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -4,9 +4,8 @@ module UnitTests.Distribution.Client.UserConfig
   ( tests
   ) where
 
-import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar)
-import Control.Exception (IOException, bracket, try)
-import Control.Monad (replicateM, replicateM_)
+import Control.Exception (bracket)
+import Control.Monad (replicateM_)
 import Data.List (nub, sort)
 import System.Directory
   ( doesFileExist

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -13,6 +13,7 @@ import System.Directory
   , getTemporaryDirectory
   )
 import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -99,8 +100,12 @@ bracketTest =
   bracket testSetup testTearDown
   where
     testSetup :: IO FilePath
-    testSetup = fmap (</> "test-user-config") getCurrentDirectory
+    testSetup = do
+      cwd <- getCurrentDirectory
+      (configFile, h) <- openTempFile cwd "test-user-config"
+      hClose h
+      pure configFile
 
     testTearDown :: FilePath -> IO ()
     testTearDown configFile =
-      mapM_ removeFileForcibly [configFile, configFile ++ ".backup"]
+      mapM_ removeFileForcibly [configFile, configFile ++ ".backup", configFile ++ ".tmp"]

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -6,7 +6,7 @@ module UnitTests.Distribution.Client.UserConfig
 
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar)
 import Control.Exception (IOException, bracket, try)
-import Control.Monad (replicateM_)
+import Control.Monad (replicateM, replicateM_)
 import Data.List (nub, sort)
 import System.Directory
   ( doesFileExist


### PR DESCRIPTION
Fix https://github.com/haskell/cabal/issues/11686. Created with Copilot.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
