### PR TITLE
Keep a running InstalledPackageIndex to skip expensive per-package ghc-pkg calls

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -34,6 +34,7 @@ module Distribution.Simple.Configure
   ( configure
   , configure_setupHooks
   , computePackageInfo
+  , computePackageInfoFromIndex
   , configureFinal
   , runPreConfPackageHook
   , runPostConfPackageHook
@@ -1180,10 +1181,22 @@ computePackageInfo verbHandles cfg lbc0 g_pkg_descr comp = do
       mbWorkDir
       packageDbs
       programDb0
+  computePackageInfoFromIndex verbHandles cfg g_pkg_descr installedPackageSet
 
-  -- The set of package names which are "shadowed" by internal
-  -- packages, and which component they map to
-  let internalPackageSet :: Set LibraryName
+-- | Like 'computePackageInfo' but takes a given 'InstalledPackageIndex'
+-- instead of needing to query the @hc-pkg@ program to obtain it.
+computePackageInfoFromIndex
+  :: VerbosityHandles
+  -> ConfigFlags
+  -> GenericPackageDescription
+  -> InstalledPackageIndex
+  -> IO ([PackageVersionConstraint], PackageInfo)
+computePackageInfoFromIndex verbHandles cfg g_pkg_descr installedPackageSet = do
+  let common = configCommonFlags cfg
+      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      -- The set of package names which are "shadowed" by internal
+      -- packages, and which component they map to
+      internalPackageSet :: Set LibraryName
       internalPackageSet = getInternalLibraries g_pkg_descr
 
   -- Some sanity checks related to dynamic/static linking.

--- a/cabal-install/src/Distribution/Client/InLibrary.hs
+++ b/cabal-install/src/Distribution/Client/InLibrary.hs
@@ -30,6 +30,7 @@ import qualified Distribution.Simple.Configure as Cabal
 import Distribution.Simple.Haddock (haddock_setupHooks)
 import Distribution.Simple.Install (install_setupHooks)
 import Distribution.Simple.LocalBuildInfo (mbWorkDirLBI)
+import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PreProcess as Cabal
 import Distribution.Simple.Program.Db
 import qualified Distribution.Simple.Register as Cabal
@@ -68,6 +69,7 @@ data LibraryConfigureInputs = LibraryConfigureInputs
   , packageDescription :: PD.PackageDescription
   , gPackageDescription :: PD.GenericPackageDescription
   , flagAssignment :: PD.FlagAssignment
+  , installedPkgIndex :: InstalledPackageIndex
   }
 
 libraryConfigureInputsFromElabPackage
@@ -76,6 +78,7 @@ libraryConfigureInputsFromElabPackage
   -> ProgramDb
   -> ElaboratedSharedConfig
   -> ElaboratedReadyPackage
+  -> InstalledPackageIndex
   -> [String]
   -- ^ targets
   -> LibraryConfigureInputs
@@ -90,6 +93,7 @@ libraryConfigureInputsFromElabPackage
     , pkgConfigCompiler = compil
     }
   (ReadyPackage pkg)
+  ipi
   userTargets =
     LibraryConfigureInputs
       { verbosityHandles = verbHandles
@@ -119,6 +123,7 @@ libraryConfigureInputsFromElabPackage
       , packageDescription = pkgDescr
       , gPackageDescription = gpkgDescr
       , flagAssignment = elabFlagAssignment pkg
+      , installedPkgIndex = ipi
       }
     where
       pkgDescr = elabPkgDescription pkg
@@ -140,6 +145,7 @@ configure
     , packageDescription = pkgDescr
     , gPackageDescription = gpkgDescr
     , flagAssignment = flagAssgn
+    , installedPkgIndex = ipi
     }
   cfg = do
     -- Here, we essentially want to call the Cabal library 'configure' function,
@@ -157,14 +163,15 @@ configure
           configureHooks $
             ExternalHooksExe.buildTypeSetupHooks verbosity mbWorkDir distPref bt
 
+    let pkgId :: PD.PackageIdentifier
+        pkgId = PD.package pkgDescr
+
     -- cabal-install uses paths relative to the current working directory,
     -- while the Cabal library expects symbolic paths. Perform the conversion here
     -- by making the paths absolute.
     packageDBs' <- traverse (traverse $ fmap makeSymbolicPath . canonicalizePath) packageDBs
 
     -- Configure package
-    let pkgId :: PD.PackageIdentifier
-        pkgId = PD.package pkgDescr
     case mbComp of
       Nothing -> setupMessage verbosity "Configuring" pkgId
       Just cname ->
@@ -188,11 +195,17 @@ configure
               { testsRequested = Cabal.fromFlag (Cabal.configTests cfg)
               , benchmarksRequested = Cabal.fromFlag (Cabal.configBenchmarks cfg)
               }
-    (_allConstraints, pkgInfo) <-
-      Cabal.computePackageInfo verbHandles cfg lbc1 gpkgDescr compil
-    -- It's OK to discard constraints here: we already have a finalized PackageDescription
+
+    -- NB: it's OK to discard constraints here: we already have a finalized PackageDescription
     -- in hand, and we are using exact UnitIds for all dependencies (this corresponds
     -- to using --exact-configuration and --dependency flags with the Setup CLI).
+    (_allConstraints, pkgInfo) <-
+      -- Use cabal-install's running InstalledPackageIndex 'ipi' to skip over
+      -- having to invoke ghc-pkg once per package.
+      --
+      -- See (ProjIPI3) from Note [Per-project InstalledPackageIndex]
+      -- in Distribution.Client.ProjectBuilding.
+      Cabal.computePackageInfoFromIndex verbHandles cfg gpkgDescr ipi
 
     -- Post-configure hooks & per-component configure
     lbi1 <-

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -87,7 +87,10 @@ import qualified Data.Set as Set
 
 import qualified Text.PrettyPrint as Disp
 
+import Control.Concurrent.STM (TVar, newTVarIO)
 import Control.Exception (assert, handle)
+import qualified Distribution.Client.IndexUtils as IndexUtils
+import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import System.Directory (doesDirectoryExist, doesFileExist, renameDirectory)
 import System.FilePath (makeRelative, normalise, takeDirectory, (<.>), (</>))
 import System.Semaphore (SemaphoreIdentifier)
@@ -367,6 +370,19 @@ rebuildTargets
         createDirectoryIfMissingVerbose verbosity True distTempDirectory
         traverse_ (createPackageDBIfMissing verbosity compiler progdb) packageDBsToUse
 
+        -- Populate the running InstalledPackageIndex by doing a single
+        -- bulk read at startup. This allows us to obtain the
+        -- InstalledPackageInfo of every 'PreExisting' and 'Installed' unit
+        -- in the plan, regardless of how they ended up in the PackageDBs.
+        -- See (ProjIPI1) in Note [Per-project InstalledPackageIndex].
+        initialIPI <-
+          -- NB: 'getInstalledPackages' returns an error when there are no
+          -- PackageDBs, so we handle that case explicitly first.
+          if null packageDBsToUse
+            then return mempty
+            else IndexUtils.getInstalledPackages verbosity compiler packageDBsToUse progdb
+        ipiTVar <- newTVarIO initialIPI
+
         -- Concurrency control: create the job controller and concurrency limits
         -- for downloading, building and installing.
         withJobControl (newJobControlFromParStrat verbosity (Just compiler) buildSettingNumJobs Nothing) $ \jobControl -> do
@@ -401,6 +417,7 @@ rebuildTargets
                       cacheLock
                       sharedPackageConfig
                       installPlan
+                      ipiTVar
                       pkg
                       pkgBuildStatus
     where
@@ -457,6 +474,34 @@ rebuildTargets
           isRemote (RemoteSourceRepoPackage _ _) = True
           isRemote _ = False
 
+{- Note [Per-project InstalledPackageIndex]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In cabal-install, we keep a running InstalledPackageIndex, used for the whole
+project, containing all registered units relevant to the project.
+
+We do this to avoid repeatedly querying @ghc-pkg@ on a per-package basis when
+configuring individual packages.
+
+  (ProjIPI1)
+    We initialise the index with a single @ghc-pkg dump@ invocation, which
+    queries all the package DBs that the plan touches. This single read
+    replaces the per-package query that 'computePackageInfo' would otherwise
+    perform.
+
+    This robustly handles the case of resuming an interrupted build.
+
+  (ProjIPI2)
+    During execution, each time we register a library, we insert its
+    InstalledPackageInfo into the index, so that subsequent packages that
+    depend on it have it available, without needing to re-query @ghc-pkg@.
+
+  (ProjIPI3)
+    Before configuring a package, we read the running InstalledPackageIndex
+    and pass it to Cabal's 'computePackageInfoFromIndex' instead of
+    'computePackageInfo', skipping the expensive per-package @ghc-pkg dump@
+    invocation.
+-}
+
 -- | Create a package DB if it does not currently exist. Note that this action
 -- is /not/ safe to run concurrently.
 createPackageDBIfMissing
@@ -488,6 +533,7 @@ rebuildTarget
   -> Lock
   -> ElaboratedSharedConfig
   -> ElaboratedInstallPlan
+  -> TVar InstalledPackageIndex
   -> ElaboratedReadyPackage
   -> BuildStatus
   -> IO BuildResult
@@ -502,6 +548,7 @@ rebuildTarget
   cacheLock
   sharedPackageConfig
   plan
+  ipiTVar
   rpkg@(ReadyPackage pkg)
   pkgBuildStatus
     -- Technically, doing the --only-download filtering only in this function is
@@ -588,6 +635,7 @@ rebuildTarget
           sharedPackageConfig
           plan
           rpkg
+          ipiTVar
           srcdir
           builddir
 
@@ -604,6 +652,7 @@ rebuildTarget
           sharedPackageConfig
           plan
           rpkg
+          ipiTVar
           buildStatus
           srcdir
           builddir

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -90,6 +90,8 @@ import Distribution.Simple.LocalBuildInfo
   , LibraryName (..)
   )
 import qualified Distribution.Simple.LocalBuildInfo as Cabal
+import Distribution.Simple.PackageIndex (InstalledPackageIndex)
+import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.Program
 import qualified Distribution.Simple.Register as Cabal
 import qualified Distribution.Simple.Setup as Cabal
@@ -113,7 +115,9 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS.Char8
 import qualified Data.List.NonEmpty as NE
 
+import Control.Concurrent.STM (TVar, atomically, modifyTVar)
 import Control.Exception (ErrorCall, Handler (..), SomeAsyncException, assert, catches, onException)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, listDirectory)
 import System.FilePath (dropDrive, normalise, takeDirectory, (<.>), (</>))
 import System.IO (Handle, IOMode (AppendMode), withFile)
@@ -147,6 +151,9 @@ data PackageBuildingPhase r where
           :: PackageDBStackCWD
           -> Cabal.RegisterOptions
           -> IO InstalledPackageInfo
+       , getInstalledPackageInfo :: IO InstalledPackageInfo
+        -- ^ Compute the 'InstalledPackageInfo' from the build output,
+        -- without registering with @ghc-pkg@. Deterministic.
        }
     -> PackageBuildingPhase ()
   PBTestPhase :: {runTest :: IO ()} -> PackageBuildingPhase ()
@@ -169,6 +176,9 @@ buildAndRegisterUnpackedPackage
   -> ElaboratedSharedConfig
   -> ElaboratedInstallPlan
   -> ElaboratedReadyPackage
+  -> TVar InstalledPackageIndex
+  -- ^ Running 'InstalledPackageIndex', updated as @cabal-install@ registers
+  -- packages
   -> SymbolicPath CWD (Dir Pkg)
   -> SymbolicPath Pkg (Dir Dist)
   -> Maybe FilePath
@@ -188,6 +198,7 @@ buildAndRegisterUnpackedPackage
     }
   plan
   rpkg@(ReadyPackage pkg)
+  ipiTVar
   srcdir
   builddir
   mlogFile
@@ -202,7 +213,7 @@ buildAndRegisterUnpackedPackage
               Cabal.configCommonFlags
               configureFlags
               configureArgs
-              (InLibraryArgs $ InLibraryConfigureArgs pkgshared rpkg)
+              (InLibraryArgs $ InLibraryConfigureArgs pkgshared rpkg ipiTVar)
 
     -- Build phase
     delegate $
@@ -228,6 +239,11 @@ buildAndRegisterUnpackedPackage
               (InLibraryArgs $ InLibraryPostConfigureArgs SHaddockPhase mbLBI)
 
     -- Install phase
+    let getIpkg = do
+          -- Grab and modify the InstalledPackageInfo. We decide what
+          -- the installed package id is, not the build system.
+          ipkg0 <- generateInstalledPackageInfo mbLBI
+          return ipkg0{Installed.installedUnitId = uid}
     delegate $
       PBInstallPhase
         { runCopy = \destdir ->
@@ -240,11 +256,8 @@ buildAndRegisterUnpackedPackage
                 (InLibraryArgs $ InLibraryPostConfigureArgs SCopyPhase mbLBI)
         , runRegister = \pkgDBStack registerOpts ->
             annotateFailure mlogFile InstallFailed $ do
-              -- We register ourselves rather than via Setup.hs. We need to
-              -- grab and modify the InstalledPackageInfo. We decide what
-              -- the installed package id is, not the build system.
-              ipkg0 <- generateInstalledPackageInfo mbLBI
-              let ipkg = ipkg0{Installed.installedUnitId = uid}
+              -- We register ourselves, rather than via Setup.hs.
+              ipkg <- getIpkg
               criticalSection registerLock $
                 Cabal.registerPackage
                   verbosity
@@ -255,6 +268,7 @@ buildAndRegisterUnpackedPackage
                   ipkg
                   registerOpts
               return ipkg
+        , getInstalledPackageInfo = getIpkg
         }
 
     -- Test phase
@@ -483,6 +497,7 @@ buildInplaceUnpackedPackage
   -> ElaboratedSharedConfig
   -> ElaboratedInstallPlan
   -> ElaboratedReadyPackage
+  -> TVar InstalledPackageIndex
   -> BuildStatusRebuild
   -> SymbolicPath CWD (Dir Pkg)
   -> SymbolicPath Pkg (Dir Dist)
@@ -501,6 +516,7 @@ buildInplaceUnpackedPackage
   pkgshared@ElaboratedSharedConfig{pkgConfigPlatform = Platform _ os}
   plan
   rpkg@(ReadyPackage pkg)
+  ipiTVar
   buildStatus
   srcdir
   builddir = do
@@ -523,6 +539,7 @@ buildInplaceUnpackedPackage
       pkgshared
       plan
       rpkg
+      ipiTVar
       srcdir
       builddir
       Nothing -- no log file for inplace builds!
@@ -575,6 +592,10 @@ buildInplaceUnpackedPackage
                     runRegister
                       (elabRegisterPackageDBStack pkg)
                       Cabal.defaultRegisterOptions
+                  -- Keep the per-project running InstalledPackageIndex up to date.
+                  -- See (ProjIPI2) from Note [Per-project InstalledPackageIndex]
+                  -- in Distribution.Client.ProjectBuilding.
+                  atomically $ modifyTVar ipiTVar (PackageIndex.insert ipkg)
                   return (Just ipkg)
                 else return Nothing
 
@@ -668,7 +689,10 @@ buildInplaceUnpackedPackage
 
       whenReRegister action =
         case buildStatus of
-          -- We registered the package already
+          -- We registered the package already.
+          -- No need to update ipiTVar: the InstalledPackageInfo for this package
+          -- was picked up at startup.
+          -- See Note [Per-project InstalledPackageIndex] in Distribution.Client.ProjectBuilding.
           BuildStatusBuild (Just _) _ ->
             info verbosity "whenReRegister: previously registered"
           -- There is nothing to register
@@ -697,6 +721,7 @@ buildAndInstallUnpackedPackage
   -> ElaboratedSharedConfig
   -> ElaboratedInstallPlan
   -> ElaboratedReadyPackage
+  -> TVar InstalledPackageIndex
   -> SymbolicPath CWD (Dir Pkg)
   -> SymbolicPath Pkg (Dir Dist)
   -> IO BuildResult
@@ -716,6 +741,7 @@ buildAndInstallUnpackedPackage
     }
   plan
   rpkg@(ReadyPackage pkg)
+  ipiTVar
   srcdir
   builddir = do
     createDirectoryIfMissingVerbose verbosity True (interpretSymbolicPath (Just srcdir) builddir)
@@ -743,6 +769,7 @@ buildAndInstallUnpackedPackage
       pkgshared
       plan
       rpkg
+      ipiTVar
       srcdir
       builddir
       mlogFile
@@ -758,8 +785,12 @@ buildAndInstallUnpackedPackage
           noticeProgress ProgressHaddock
           _monitors <- runHaddock
           return ()
-        PBInstallPhase{runCopy, runRegister} -> do
+        PBInstallPhase{runCopy, runRegister, getInstalledPackageInfo} -> do
           noticeProgress ProgressInstalling
+
+          -- Create an IORef used to retrieve the InstalledPackageInfo computed
+          -- by running "register".
+          ipkgRef <- newIORef Nothing
 
           let registerPkg
                 | not (elabRequiresRegistration pkg) =
@@ -772,14 +803,15 @@ buildAndInstallUnpackedPackage
                           == storePackageDBStack compiler (elabPackageDbs pkg)
                       )
                       (return ())
-                    _ <-
+                    ipkg <-
                       runRegister
                         (elabRegisterPackageDBStack pkg)
                         Cabal.defaultRegisterOptions
                           { Cabal.registerMultiInstance = True
                           , Cabal.registerSuppressFilesCheck = True
                           }
-                    return ()
+                    -- Write the InstalledPackageInfo to the IORef
+                    writeIORef ipkgRef (Just ipkg)
 
           -- Actual installation
           void $
@@ -790,6 +822,20 @@ buildAndInstallUnpackedPackage
               uid
               (copyPkgFiles verbosity pkgshared pkg runCopy)
               registerPkg
+
+          -- Keep the per-project running InstalledPackageIndex TVar up to date.
+          -- This must run regardless of whether newStoreEntry won or lost the
+          -- race (UseNewStoreEntry/UseExistingStoreEntry).
+          --
+          -- See (ProjIPI2) in Note [Per-project InstalledPackageIndex].
+          when (elabRequiresRegistration pkg) $ do
+            -- If we won the race, we use the InstalledPackageInfo that was
+            -- computed by 'runRegister'. If we lost, then we fall back to
+            -- 'getInstalledPackageInfo' which re-runs 'Cabal register'
+            -- (takes ~100ms).
+            mipkg <- readIORef ipkgRef
+            ipkg <- maybe getInstalledPackageInfo return mipkg
+            atomically $ modifyTVar ipiTVar (PackageIndex.insert ipkg)
 
         -- No tests on install
         PBTestPhase{} -> return ()

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -173,6 +173,9 @@ import Distribution.Simple.SetupHooks.HooksMain
   ( hooksVersion )
 import Distribution.Client.SetupHooks.CallHooksExe
   ( externalSetupHooksABI, hooksProgFilePath )
+
+import Control.Concurrent.STM (TVar, readTVarIO)
+import qualified Data.ByteString.Lazy as BS
 import Data.List (foldl1')
 import Data.Kind (Type, Constraint)
 import qualified Data.Map.Lazy as Map
@@ -184,8 +187,6 @@ import System.IO (Handle, hPutStr)
 import System.Process (StdStream (..))
 import qualified System.Process as Process
 
-import qualified Data.ByteString.Lazy as BS
-
 #ifdef mingw32_HOST_OS
 import Distribution.Simple.Utils
          ( withTempDirectory )
@@ -195,6 +196,8 @@ import System.Directory    ( doesDirectoryExist )
 import System.FilePath     ( equalFilePath, takeDirectory, takeFileName )
 import qualified System.Win32 as Win32
 #endif
+
+--------------------------------------------------------------------------------
 
 data AllowInLibrary
   = AllowInLibrary
@@ -244,6 +247,7 @@ data InLibraryArgs (flags :: Type) where
   InLibraryConfigureArgs
     :: ElaboratedSharedConfig
     -> ElaboratedReadyPackage
+    -> TVar InstalledPackageIndex
     -> InLibraryArgs ConfigFlags
   InLibraryPostConfigureArgs
     :: SPostConfigurePhase flags
@@ -643,7 +647,7 @@ setupWrapper verbosity options mpkg cmd getCommonFlags getFlags getExtraArgs wra
       case wrapperArgs of
         InLibraryArgs libArgs ->
           case libArgs of
-            InLibraryConfigureArgs elabSharedConfig elabReadyPkg -> do
+            InLibraryConfigureArgs elabSharedConfig elabReadyPkg ipiTVar -> do
               -- Start from the pre-configured compiler ProgramDb, augmented
               -- with all builtin programs (restored as unconfigured).
               -- This ensures:
@@ -668,6 +672,10 @@ setupWrapper verbosity options mpkg cmd getCommonFlags getFlags getExtraArgs wra
                   (useExtraPathEnv options)
                   (useExtraEnvOverrides options)
                   baseProgDb
+              -- Read the project InstalledPackageIndex to avoid needing to query
+              -- @ghc-pkg@ to obtain it.
+              -- in Distribution.Client.ProjectBuilding.
+              ipi <- readTVarIO ipiTVar
               lbi0 <-
                 InLibrary.configure
                   (InLibrary.libraryConfigureInputsFromElabPackage
@@ -676,6 +684,7 @@ setupWrapper verbosity options mpkg cmd getCommonFlags getFlags getExtraArgs wra
                      setupProgDb
                      elabSharedConfig
                      elabReadyPkg
+                     ipi
                      extraArgs
                   )
                   flags

--- a/changelog.d/cached-ipi.md
+++ b/changelog.d/cached-ipi.md
@@ -1,0 +1,14 @@
+---
+synopsis: Caching of InstalledPackageIndex
+packages: [Cabal, cabal-install]
+prs: 11767
+---
+
+`cabal-install` now keeps a running `InstalledPackageIndex` that it updates
+as packages in a project get built. This allows skipping expensive `ghc-pkg`
+calls when configuring each package (within `computePackageInfo` in the
+Cabal `configure` function).
+
+To enable this, a new function in the `Cabal` library, `computePackageInfoFromIndex` , has been extracted from the `computePackageInfo` function (all inside `Distribution.Simple.Configure`).
+This allows passing an explicit `InstalledPackageIndex` instead of querying
+`ghc-pkg` to obtain it.


### PR DESCRIPTION
Building on the in-library refactor that landed in 6867dd5, this patch extracts `computePackageInfoFromIndex` from the Cabal `computePackageInfo` function, which allows cabal-install to use a running `InstalledPackageIndex` instead of having to repeatedly query ghc-pkg, once per package.

Several cabal-install functions now pass around a `TVar InstalledPackageIndex` which keeps track of the `InstalledPackageIndex` used for building a project. Each time a dependency gets registered, we update this `TVar`, and read from it to obtain an `InstalledPackageIndex` to pass to the Cabal configure function, skipping slow calls to `ghc-pkg`.

---

**Template Α: This PR modifies [behaviour or interface](CONTRIBUTING.md#changelog)**

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] No manual QA notes necessary (no change to the command line interface).
* [x] Testing approach: the existing tests continue to work even though we query `ghc-pkg` far less.
