### PR TITLE
cabal-install: add --build-timings flag

### DIFF
--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -173,6 +173,7 @@ testProjectConfigBuildOnly = do
         , cinstInstallMethod = Flag InstallMethodSymlink
         , cinstInstalldir = Flag "path/to/installdir"
         }
+    projectConfigBuildTimings = mempty
 
 testProjectConfigShared :: Assertion
 testProjectConfigShared = do

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -447,6 +447,7 @@ instance Semigroup SavedConfig where
           , installKeepGoing = combine installKeepGoing
           , installRunTests = combine installRunTests
           , installOfflineMode = combine installOfflineMode
+          , installBuildTimings = combine installBuildTimings
           }
         where
           combine = combine' savedInstallFlags

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
@@ -118,10 +119,12 @@ import qualified Data.List.NonEmpty as NE
 import Control.Concurrent.STM (TVar, atomically, modifyTVar)
 import Control.Exception (ErrorCall, Handler (..), SomeAsyncException, assert, catches, onException)
 import Data.IORef (newIORef, readIORef, writeIORef)
+import GHC.Clock (getMonotonicTime)
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, listDirectory)
 import System.FilePath (dropDrive, normalise, takeDirectory, (<.>), (</>))
 import System.IO (Handle, IOMode (AppendMode), withFile)
 import System.Semaphore (SemaphoreIdentifier)
+import Text.Printf (printf)
 
 import GHC.Stack
 import Web.Browser (openBrowser)
@@ -189,7 +192,10 @@ buildAndRegisterUnpackedPackage
   verbosity
   distDirLayout@DistDirLayout{distTempDirectory}
   maybe_semaphore
-  buildTimeSettings@BuildTimeSettings{buildSettingKeepTempFiles}
+  buildTimeSettings@BuildTimeSettings
+    { buildSettingKeepTempFiles
+    , buildSettingBuildTimings
+    }
   registerLock
   cacheLock
   pkgshared@ElaboratedSharedConfig
@@ -205,7 +211,7 @@ buildAndRegisterUnpackedPackage
   delegate = do
     -- Configure phase
     mbLBI <-
-      delegate $
+      timedDelegate $
         PBConfigurePhase $
           annotateFailure mlogFile ConfigureFailed $
             setup
@@ -216,7 +222,7 @@ buildAndRegisterUnpackedPackage
               (InLibraryArgs $ InLibraryConfigureArgs pkgshared rpkg ipiTVar)
 
     -- Build phase
-    delegate $
+    timedDelegate $
       PBBuildPhase $
         annotateFailure mlogFile BuildFailed $ do
           setup
@@ -228,7 +234,7 @@ buildAndRegisterUnpackedPackage
 
     -- Haddock phase
     whenHaddock $
-      delegate $
+      timedDelegate $
         PBHaddockPhase $
           annotateFailure mlogFile HaddocksFailed $ do
             setup
@@ -244,7 +250,7 @@ buildAndRegisterUnpackedPackage
           -- the installed package id is, not the build system.
           ipkg0 <- generateInstalledPackageInfo mbLBI
           return ipkg0{Installed.installedUnitId = uid}
-    delegate $
+    timedDelegate $
       PBInstallPhase
         { runCopy = \destdir ->
             annotateFailure mlogFile InstallFailed $
@@ -273,7 +279,7 @@ buildAndRegisterUnpackedPackage
 
     -- Test phase
     whenTest $
-      delegate $
+      timedDelegate $
         PBTestPhase $
           annotateFailure mlogFile TestsFailed $
             setup
@@ -285,7 +291,7 @@ buildAndRegisterUnpackedPackage
 
     -- Bench phase
     whenBench $
-      delegate $
+      timedDelegate $
         PBBenchPhase $
           annotateFailure mlogFile BenchFailed $
             setup
@@ -297,7 +303,7 @@ buildAndRegisterUnpackedPackage
 
     -- Repl phase
     whenRepl $
-      delegate $
+      timedDelegate $
         PBReplPhase $
           annotateFailure mlogFile ReplFailed $
             setupInteractive
@@ -310,6 +316,33 @@ buildAndRegisterUnpackedPackage
     return ()
     where
       uid = installedUnitId rpkg
+
+      timedDelegate :: forall r. PackageBuildingPhase r -> IO r
+      timedDelegate phase
+        | buildSettingBuildTimings = do
+            t0 <- getMonotonicTime
+            let
+              printTiming :: String -> IO ()
+              printTiming suffix = do
+                t1 <- getMonotonicTime
+                let
+                  elapsed = t1 - t0
+                  pkgstr = prettyShow (packageId rpkg)
+                  msg =
+                    unwords
+                      [ "[build-timings]"
+                      , buildPhaseName phase
+                      , pkgstr
+                      , -- Print milliseconds (3 decimal places)
+                        printf "%.3fs" elapsed
+                      , suffix
+                      ]
+                notice verbosity msg
+            r <- delegate phase `onException` printTiming "(failed)"
+            !_ <- evaluate r
+            printTiming ""
+            return r
+        | otherwise = delegate phase
 
       comp_par_strat = case maybe_semaphore of
         Just sem_ident -> Cabal.toFlag sem_ident
@@ -1013,6 +1046,16 @@ annotateFailure mlogFile annotate action =
 --------------------------------------------------------------------------------
 -- * Other Utils
 --------------------------------------------------------------------------------
+
+-- | Display name for each build phase, used in timing output.
+buildPhaseName :: PackageBuildingPhase r -> String
+buildPhaseName PBConfigurePhase{} = "configure"
+buildPhaseName PBBuildPhase{} = "build"
+buildPhaseName PBHaddockPhase{} = "haddock"
+buildPhaseName PBReplPhase{} = "repl"
+buildPhaseName PBInstallPhase{} = "install"
+buildPhaseName PBTestPhase{} = "test"
+buildPhaseName PBBenchPhase{} = "bench"
 
 hasValidHaddockTargets :: ElaboratedConfiguredPackage -> Bool
 hasValidHaddockTargets ElaboratedConfiguredPackage{..}

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -470,6 +470,7 @@ resolveBuildTimeSettings
         fromFlag projectConfigReportPlanningFailure
       buildSettingProgPathExtra = fromNubList projectConfigProgPathExtra
       buildSettingHaddockOpen = False
+      buildSettingBuildTimings = fromFlagOrDefault False projectConfigBuildTimings
 
       ProjectConfigBuildOnly{..} =
         defaults

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -66,6 +66,7 @@ projectConfigBuildOnlyFieldGrammar =
     <*> optionalFieldDefAla "remote-repo-cache" (alaFlag FilePathNT) L.projectConfigCacheDir mempty
     <*> optionalFieldDefAla "logs-dir" (alaFlag FilePathNT) L.projectConfigLogsDir mempty
     <*> blurFieldGrammar L.projectConfigClientInstallFlags clientInstallFlagsGrammar
+    <*> optionalFieldDef "build-timings" L.projectConfigBuildTimings mempty
 
 projectConfigSharedFieldGrammar :: ProjectConfigPath -> ParsecFieldGrammar' ProjectConfigShared
 projectConfigSharedFieldGrammar source =

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -887,6 +887,7 @@ convertLegacyBuildOnlyFlags
         , installUseSemaphore = projectConfigUseSemaphore
         , installKeepGoing = projectConfigKeepGoing
         , installOfflineMode = projectConfigOfflineMode
+        , installBuildTimings = projectConfigBuildTimings
         } = installFlags
 
 convertToLegacyProjectConfig :: ProjectConfig -> LegacyProjectConfig
@@ -1022,6 +1023,7 @@ convertToLegacySharedConfig
           , installKeepGoing = projectConfigKeepGoing
           , installRunTests = mempty
           , installOfflineMode = projectConfigOfflineMode
+          , installBuildTimings = projectConfigBuildTimings
           }
 
       projectFlags =
@@ -1458,6 +1460,7 @@ legacySharedConfigFieldDescrs constraintSrc =
           , "keep-going"
           , "offline"
           , "per-component"
+          , "build-timings"
           , -- solver flags:
             "max-backjumps"
           , "reorder-goals"

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Lens.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Lens.hs
@@ -164,6 +164,10 @@ projectConfigClientInstallFlags :: Lens' ProjectConfigBuildOnly ClientInstallFla
 projectConfigClientInstallFlags f s = fmap (\x -> s{T.projectConfigClientInstallFlags = x}) (f (T.projectConfigClientInstallFlags s))
 {-# INLINEABLE projectConfigClientInstallFlags #-}
 
+projectConfigBuildTimings :: Lens' ProjectConfigBuildOnly (Flag Bool)
+projectConfigBuildTimings f s = fmap (\x -> s{T.projectConfigBuildTimings = x}) (f (T.projectConfigBuildTimings s))
+{-# INLINEABLE projectConfigBuildTimings #-}
+
 projectConfigDistDir :: Lens' ProjectConfigShared (Flag FilePath)
 projectConfigDistDir f s = fmap (\x -> s{T.projectConfigDistDir = x}) (f (T.projectConfigDistDir s))
 {-# INLINEABLE projectConfigDistDir #-}

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -184,6 +184,7 @@ data ProjectConfigBuildOnly = ProjectConfigBuildOnly
   , projectConfigCacheDir :: Flag FilePath
   , projectConfigLogsDir :: Flag FilePath
   , projectConfigClientInstallFlags :: ClientInstallFlags
+  , projectConfigBuildTimings :: Flag Bool
   }
   deriving (Eq, Show, Generic)
   deriving (Semigroup, Monoid) via Generically ProjectConfigBuildOnly
@@ -497,6 +498,7 @@ data BuildTimeSettings = BuildTimeSettings
   , buildSettingIgnoreExpiry :: Bool
   , buildSettingProgPathExtra :: [FilePath]
   , buildSettingHaddockOpen :: Bool
+  , buildSettingBuildTimings :: Bool
   }
   deriving (Generic)
 

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -2243,6 +2243,7 @@ data InstallFlags = InstallFlags
   , installKeepGoing :: Flag Bool
   , installRunTests :: Flag Bool
   , installOfflineMode :: Flag Bool
+  , installBuildTimings :: Flag Bool
   }
   deriving (Eq, Show, Generic)
   deriving (Semigroup, Monoid) via Generically InstallFlags
@@ -2287,6 +2288,7 @@ defaultInstallFlags =
     , installKeepGoing = Flag False
     , installRunTests = mempty
     , installOfflineMode = Flag False
+    , installBuildTimings = Flag False
     }
   where
     docIndexFile =
@@ -2789,6 +2791,13 @@ installOptions showOrParseArgs =
           "Don't download packages from the Internet."
           installOfflineMode
           (\v flags -> flags{installOfflineMode = v})
+          (yesNoOpt showOrParseArgs)
+       , option
+          []
+          ["build-timings"]
+          "Print elapsed time for each build phase."
+          installBuildTimings
+          (\v flags -> flags{installBuildTimings = v})
           (yesNoOpt showOrParseArgs)
        ]
     ++ case showOrParseArgs of -- TODO: remove when "cabal install"

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -524,6 +524,7 @@ instance Arbitrary ProjectConfigBuildOnly where
       <*> (fmap getShortToken <$> arbitrary)
       <*> (fmap getShortToken <$> arbitrary)
       <*> arbitrary
+      <*> arbitrary
     where
       arbitraryNumJobs = fmap (fmap getPositive) <$> arbitrary
 
@@ -548,6 +549,7 @@ instance Arbitrary ProjectConfigBuildOnly where
       , projectConfigCacheDir = x15
       , projectConfigLogsDir = x16
       , projectConfigClientInstallFlags = x17
+      , projectConfigBuildTimings = x20
       } =
       [ ProjectConfigBuildOnly
         { projectConfigVerbosity = x00'
@@ -569,17 +571,18 @@ instance Arbitrary ProjectConfigBuildOnly where
         , projectConfigCacheDir = x15
         , projectConfigLogsDir = x16
         , projectConfigClientInstallFlags = x17'
+        , projectConfigBuildTimings = x20'
         }
       | ( (x00', x01', x02', x03', x04')
           , (x05', x06', x07', x09')
           , (x10', x11', x12', x14')
-          , (x17', x18', x19')
+          , (x17', x18', x19', x20')
           ) <-
           shrink
             ( (x00, x01, x02, x03, x04)
             , (x05, x06, x07, preShrink_NumJobs x09)
             , (x10, x11, x12, x14)
-            , (x17, x18, x19)
+            , (x17, x18, x19, x20)
             )
       ]
       where

--- a/changelog.d/build-timings.md
+++ b/changelog.d/build-timings.md
@@ -1,0 +1,13 @@
+synopsis: Add flag for build timings
+packages: cabal-install
+prs: #11769
+description:{
+Introduce `--build-timings` flag to `cabal-install`. This flag makes `cabal-install`
+log timing information to stdout, in a format like:
+
+```
+[build-timings] configure aeson-2.2.3.0 0.042s
+[build-timings] build     aeson-2.2.3.0 3.284s
+[build-timings] install   aeson-2.2.3.0 0.123s
+```
+}

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -511,6 +511,14 @@ package, and thus apply globally:
     The command line variant of this flag is ``--package-db=DB`` which can be
     specified multiple times.
 
+.. option:: --build-timings
+
+    Log timing information to stdout, in the following format::
+
+        [build-timings] configure aeson-2.2.3.0 0.042s
+        [build-timings] build     aeson-2.2.3.0 3.284s
+        [build-timings] install   aeson-2.2.3.0 0.123s
+
 Phase control
 -------------
 


### PR DESCRIPTION
This new flag makes cabal-install dump timing information for the various stages of building a package. This allows us to better see how much time is spending in configure/build stages.

I used this to figure out where we were wasting time for PRs #11767 and #11768. I think it makes sense to add it as a flag so that all users can get better observability (a bit like the `-dshow-passes` GHC flag).

---

**Template Α: This PR modifies [behaviour or interface](CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added.