### PR TITLE
Add verbosity patterns

### DIFF
--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -410,7 +410,7 @@ configureAction verbHandles globalFlags hooks flags args = do
           { configCommonFlags = commonFlags'
           }
       mbWorkDir = flagToMaybe $ setupWorkingDir commonFlags'
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity commonFlags')
+      CommonSetupVerbosity verbosity = (verbHandles, commonFlags')
 
   -- See docs for 'HookedBuildInfo'
   pbi <- preConf hooks args flags'
@@ -466,7 +466,7 @@ getCommonFlags
   -> IO (LocalBuildInfo, CommonSetupFlags)
 getCommonFlags verbHandles globalFlags hooks commonFlags args = do
   distPref <- findDistPrefOrDefault (setupDistPref commonFlags)
-  let verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity commonFlags)
+  let CommonSetupVerbosity verbosity = (verbHandles, commonFlags)
   lbi <- getBuildConfig globalFlags hooks verbosity distPref
   let common' = configCommonFlags $ configFlags lbi
   return
@@ -485,7 +485,7 @@ getCommonFlags verbHandles globalFlags hooks commonFlags args = do
 buildAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> BuildFlags -> Args -> IO ()
 buildAction verbHandles globalFlags hooks flags args = do
   let common = buildCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{buildCommonFlags = common'}
 
@@ -509,7 +509,7 @@ buildAction verbHandles globalFlags hooks flags args = do
 replAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> ReplFlags -> Args -> IO ()
 replAction verbHandles globalFlags hooks flags args = do
   let common = replCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{replCommonFlags = common'}
   progs <-
@@ -537,7 +537,7 @@ replAction verbHandles globalFlags hooks flags args = do
 hscolourAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> HscolourFlags -> Args -> IO ()
 hscolourAction verbHandles globalFlags hooks flags args = do
   let common = hscolourCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (_lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{hscolourCommonFlags = common'}
       distPref = fromFlag $ setupDistPref common'
@@ -555,7 +555,7 @@ hscolourAction verbHandles globalFlags hooks flags args = do
 haddockAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> HaddockFlags -> Args -> IO ()
 haddockAction verbHandles globalFlags hooks flags args = do
   let common = haddockCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{haddockCommonFlags = common'}
 
@@ -579,7 +579,7 @@ haddockAction verbHandles globalFlags hooks flags args = do
 cleanAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> CleanFlags -> Args -> IO ()
 cleanAction verbHandles globalFlags hooks flags args = do
   let common = cleanCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   distPref <- findDistPrefOrDefault (setupDistPref common)
   elbi <- tryGetBuildConfig globalFlags hooks verbosity distPref
   let common' =
@@ -627,7 +627,7 @@ cleanAction verbHandles globalFlags hooks flags args = do
 copyAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> CopyFlags -> Args -> IO ()
 copyAction verbHandles globalFlags hooks flags args = do
   let common = copyCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (_lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{copyCommonFlags = common'}
       distPref = fromFlag $ setupDistPref common'
@@ -644,7 +644,7 @@ copyAction verbHandles globalFlags hooks flags args = do
 installAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> InstallFlags -> Args -> IO ()
 installAction verbHandles globalFlags hooks flags args = do
   let common = installCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (_lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{installCommonFlags = common'}
       distPref = fromFlag $ setupDistPref common'
@@ -666,12 +666,12 @@ sdistAction verbHandles _globalFlags _hooks flags _args = do
   let pkg_descr = flattenPackageDescription ppd
   sdist verbHandles pkg_descr flags srcPref knownSuffixHandlers
   where
-    verbosity = mkVerbosity verbHandles $ fromFlag (setupVerbosity $ sDistCommonFlags flags)
+    CommonSetupVerbosity verbosity = (verbHandles, sDistCommonFlags flags)
 
 testAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> TestFlags -> Args -> IO ()
 testAction verbHandles globalFlags hooks flags args = do
   let common = testCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (_lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{testCommonFlags = common'}
       distPref = fromFlag $ setupDistPref common'
@@ -688,7 +688,7 @@ testAction verbHandles globalFlags hooks flags args = do
 benchAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> BenchmarkFlags -> Args -> IO ()
 benchAction verbHandles globalFlags hooks flags args = do
   let common = benchmarkCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (_lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{benchmarkCommonFlags = common'}
       distPref = fromFlag $ setupDistPref common'
@@ -705,7 +705,7 @@ benchAction verbHandles globalFlags hooks flags args = do
 registerAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> RegisterFlags -> Args -> IO ()
 registerAction verbHandles globalFlags hooks flags args = do
   let common = registerCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (_lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{registerCommonFlags = common'}
       distPref = fromFlag $ setupDistPref common'
@@ -722,7 +722,7 @@ registerAction verbHandles globalFlags hooks flags args = do
 unregisterAction :: VerbosityHandles -> GlobalFlags -> UserHooks -> RegisterFlags -> Args -> IO ()
 unregisterAction verbHandles globalFlags hooks flags args = do
   let common = registerCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
   (_lbi, common') <- getCommonFlags verbHandles globalFlags hooks common args
   let flags' = flags{registerCommonFlags = common'}
       distPref = fromFlag $ setupDistPref common'
@@ -892,7 +892,7 @@ getBuildConfig globalFlags hooks verbosity distPref = do
 clean :: VerbosityHandles -> PackageDescription -> CleanFlags -> IO ()
 clean verbHandles pkg_descr flags = do
   let common = cleanCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag (setupVerbosity common))
+      CommonSetupVerbosity verbosity = (verbHandles, common)
       distPref = fromFlagOrDefault defaultDistPref $ setupDistPref common
       mbWorkDir = flagToMaybe $ setupWorkingDir common
       i = interpretSymbolicPath mbWorkDir -- See Note [Symbolic paths] in Distribution.Utils.Path
@@ -950,9 +950,7 @@ simpleUserHooksWithHandles verbHandles =
     finalChecks _args flags pkg_descr lbi =
       checkForeignDeps pkg_descr lbi (modifyVerbosityFlags lessVerbose verbosity)
       where
-        verbosity =
-          mkVerbosity verbHandles $
-            fromFlag (setupVerbosity $ configCommonFlags flags)
+        CommonSetupVerbosity verbosity = (verbHandles, configCommonFlags flags)
 
 -- | Basic autoconf 'UserHooks':
 --
@@ -989,7 +987,7 @@ autoconfUserHooks =
     defaultPostConf args flags pkg_descr lbi =
       do
         let common = configCommonFlags flags
-            verbosity = mkVerbosity defaultVerbosityHandles (fromFlag $ setupVerbosity common)
+            CommonSetupVerbosity verbosity = (defaultVerbosityHandles, common)
             mbWorkDir = flagToMaybe $ setupWorkingDir common
         runConfigureScript
           defaultVerbosityHandles
@@ -1010,7 +1008,7 @@ autoconfUserHooks =
       -> IO HookedBuildInfo
     readHookWithArgs get_common_flags _args flags = do
       let common = get_common_flags flags
-          verbosity = mkVerbosity defaultVerbosityHandles (fromFlag (setupVerbosity common))
+          CommonSetupVerbosity verbosity = (defaultVerbosityHandles, common)
           mbWorkDir = flagToMaybe $ setupWorkingDir common
           distPref = setupDistPref common
       dist_dir <- findDistPrefOrDefault distPref
@@ -1023,7 +1021,7 @@ autoconfUserHooks =
       -> IO HookedBuildInfo
     readHook get_common_flags args flags = do
       let common = get_common_flags flags
-          verbosity = mkVerbosity defaultVerbosityHandles (fromFlag (setupVerbosity common))
+          CommonSetupVerbosity verbosity = (defaultVerbosityHandles, common)
           mbWorkDir = flagToMaybe $ setupWorkingDir common
           distPref = setupDistPref common
       noExtraFlags args
@@ -1210,6 +1208,4 @@ defaultRegHook verbHandles pkg_descr localbuildinfo _ flags
         "Package contains no library to register:"
         (packageId pkg_descr)
   where
-    verbosity =
-      mkVerbosity verbHandles $
-        fromFlag (setupVerbosity $ registerCommonFlags flags)
+    CommonSetupVerbosity verbosity = (verbHandles, registerCommonFlags flags)

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Module      :  Distribution.Simple.Configure
@@ -190,6 +192,10 @@ import Text.PrettyPrint
 import qualified Data.Maybe as M
 import qualified Data.Set as Set
 import qualified Distribution.Compat.NonEmptySet as NES
+
+pattern ConfigVerbosity :: Verbosity -> (VerbosityHandles, ConfigFlags)
+pattern ConfigVerbosity v <- (fmap configCommonFlags -> CommonSetupVerbosity v)
+{-# COMPLETE ConfigVerbosity #-}
 
 type UseExternalInternalDeps = Bool
 
@@ -788,8 +794,7 @@ computeLocalBuildConfig
   -> ProgramDb
   -> IO LBC.LocalBuildConfig
 computeLocalBuildConfig verbHandles cfg comp programDb = do
-  let common = configCommonFlags cfg
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+  let ConfigVerbosity verbosity = (verbHandles, cfg)
   rawBuildOptions <- buildOptionsFromConfigFlags verbosity cfg comp
   buildOptions <- adjustBuildOptionsAndWarn verbosity comp programDb rawBuildOptions
   return $
@@ -1067,8 +1072,7 @@ configurePackage
   -> PackageDBStack
   -> IO (LBC.LocalBuildConfig, LBC.PackageBuildDescr)
 configurePackage verbHandles cfg lbc0 pkg_descr00 flags enabled comp platform packageDbs = do
-  let common = configCommonFlags cfg
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+  let ConfigVerbosity verbosity = (verbHandles, cfg)
       programDb0 = LBC.withPrograms lbc0
 
       -- add extra include/lib dirs as specified in cfg
@@ -1166,9 +1170,8 @@ computePackageInfo
   -> Compiler
   -> IO ([PackageVersionConstraint], PackageInfo)
 computePackageInfo verbHandles cfg lbc0 g_pkg_descr comp = do
-  let common = configCommonFlags cfg
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
-      mbWorkDir = flagToMaybe $ setupWorkingDir common
+  let ConfigVerbosity verbosity = (verbHandles, cfg)
+      mbWorkDir = flagToMaybe . setupWorkingDir $ configCommonFlags cfg
 
   let programDb0 = LBC.withPrograms lbc0
       -- What package database(s) to use
@@ -1253,8 +1256,7 @@ finalizePackageDescription
   -> PackageInfo
   -> IO (PackageDBStack, PackageDescription, FlagAssignment)
 finalizePackageDescription verbHandles cfg g_pkg_descr comp platform enabled allConstraints pkgInfo = do
-  let common = configCommonFlags cfg
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+  let ConfigVerbosity verbosity = (verbHandles, cfg)
 
   -- What package database(s) to use
   let packageDbs :: PackageDBStack
@@ -1369,9 +1371,8 @@ finalCheckPackage
     )
   hookedBuildInfo =
     do
-      let common = configCommonFlags cfg
-          verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
-          cabalFileDir = packageRoot common
+      let ConfigVerbosity verbosity = (verbHandles, cfg)
+          cabalFileDir = packageRoot $ configCommonFlags cfg
 
       checkCompilerProblems verbosity comp pkg_descr enabled
       checkPackageProblems
@@ -1432,8 +1433,7 @@ configureComponents
   promisedDepsSet
   externalPkgDeps =
     do
-      let common = configCommonFlags cfg
-          verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      let ConfigVerbosity verbosity = (verbHandles, cfg)
           use_external_internal_deps =
             case enabled of
               OneComponentRequestedSpec{} -> True
@@ -2664,8 +2664,7 @@ configCompilerAuxEx
   -> IO (Compiler, Platform, ProgramDb)
 configCompilerAuxEx verbHandles cfg = do
   programDb <- mkProgramDb verbHandles cfg defaultProgramDb
-  let common = configCommonFlags cfg
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+  let ConfigVerbosity verbosity = (verbHandles, cfg)
   configCompilerEx
     (flagToMaybe $ configHcFlavor cfg)
     (flagToMaybe $ configHcPath cfg)

--- a/Cabal/src/Distribution/Simple/ConfigureScript.hs
+++ b/Cabal/src/Distribution/Simple/ConfigureScript.hs
@@ -55,7 +55,7 @@ runConfigureScript
   -> IO ()
 runConfigureScript verbHandles cfg flags programDb hp = do
   let commonCfg = configCommonFlags cfg
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity commonCfg)
+      CommonSetupVerbosity verbosity = (verbHandles, commonCfg)
   dist_dir <- findDistPrefOrDefault $ setupDistPref commonCfg
   let build_dir = dist_dir </> makeRelativePathEx "build"
       mbWorkDir = flagToMaybe $ setupWorkingDir commonCfg

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -694,7 +694,7 @@ runReplOrWriteFlags ghcProg verbHandles lbi rflags ghcOpts pkg_name target =
       platform = hostPlatform lbi
       common = configCommonFlags $ configFlags lbi
       mbWorkDir = mbWorkDirLBI lbi
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
       tempFileOptions = commonSetupTempFileOptions common
    in case replOptionsFlagOutput (replReplOptions rflags) of
         NoFlag -> do

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -53,7 +53,6 @@ import Distribution.Simple.Errors
 import Distribution.Simple.FileMonitor.Types
   ( MonitorFilePath
   )
-import Distribution.Simple.Flag
 import Distribution.Simple.Glob (matchDirFileGlob)
 import Distribution.Simple.InstallDirs
 import Distribution.Simple.LocalBuildInfo hiding (substPathTemplate)
@@ -1524,7 +1523,7 @@ hscolour'
         onNoHsColour $ exceptionMessage excep
         return []
       common = hscolourCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
       distPref = fromFlag $ setupDistPref common
       mbWorkDir = mbWorkDirLBI lbi
       i = interpretSymbolicPathLBI lbi -- See Note [Symbolic paths] in Distribution.Utils.Path

--- a/Cabal/src/Distribution/Simple/Install.hs
+++ b/Cabal/src/Distribution/Simple/Install.hs
@@ -138,7 +138,7 @@ install_setupHooks
     where
       common = copyCommonFlags flags
       distPref = fromFlag $ setupDistPref common
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
       copydest = fromFlag (copyDest flags)
 
       checkHasLibsOrExes =

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -167,7 +167,7 @@ generateOne verbHandles pkg lib lbi clbi regFlags =
         withPackageDB lbi
           ++ maybeToList (flagToMaybe (regPackageDB regFlags))
     distPref = fromFlag $ setupDistPref common
-    verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+    CommonSetupVerbosity verbosity = (verbHandles, common)
     mbWorkDir = flagToMaybe $ setupWorkingDir common
 
 registerAll
@@ -228,7 +228,7 @@ registerAll verbHandles pkg lbi regFlags ipis =
         withPackageDB lbi
           ++ maybeToList (flagToMaybe (regPackageDB regFlags))
     common = registerCommonFlags regFlags
-    verbosity = mkVerbosity verbHandles (fromFlag (setupVerbosity common))
+    CommonSetupVerbosity verbosity = (verbHandles, common)
     mbWorkDir = mbWorkDirLBI lbi
 
     writeRegistrationFileOrDirectory = do
@@ -727,7 +727,7 @@ unregisterWithHandles verbHandles pkg lbi regFlags = do
   let pkgid = packageId pkg
       common = registerCommonFlags regFlags
       genScript = fromFlag (regGenScript regFlags)
-      verbosity = mkVerbosity verbHandles (fromFlag (setupVerbosity common))
+      CommonSetupVerbosity verbosity = (verbHandles, common)
       packageDb =
         fromFlagOrDefault
           (registrationPackageDB (withPackageDB lbi))

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -34,6 +34,8 @@ module Distribution.Simple.Setup
   , defaultGlobalFlags
   , globalCommand
   , CommonSetupFlags (..)
+  , pattern CommonSetupVerbosity
+  , pattern DefaultCommonSetupVerbosity
   , defaultCommonSetupFlags
   , commonSetupTempFileOptions
   , ConfigFlags (..)

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Module      :  Distribution.Simple.Setup.Common
@@ -15,6 +16,8 @@
 -- See: @Distribution.Simple.Setup@
 module Distribution.Simple.Setup.Common
   ( CommonSetupFlags (..)
+  , pattern CommonSetupVerbosity
+  , pattern DefaultCommonSetupVerbosity
   , defaultCommonSetupFlags
   , withCommonSetupOptions
   , commonSetupTempFileOptions
@@ -106,6 +109,19 @@ defaultCommonSetupFlags =
     , setupTargets = []
     , setupKeepTempFiles = NoFlag
     }
+
+-- | From the provided handles and 'fromFlag' to get the setup verbosity from
+-- the provided flags, constructs a verbosity.
+pattern CommonSetupVerbosity :: Verbosity -> (VerbosityHandles, CommonSetupFlags)
+pattern CommonSetupVerbosity v <- (uncurry mkVerbosity . fmap (fromFlag . setupVerbosity) -> v)
+
+-- | Same as 'CommonSetupVerbosity', but using the default verbosity handles and
+-- 'fromFlagOrDefault' to get the verbosity from the flags.
+pattern DefaultCommonSetupVerbosity :: Verbosity -> CommonSetupFlags
+pattern DefaultCommonSetupVerbosity v <- (mkVerbosity defaultVerbosityHandles . fromFlagOrDefault normal . setupVerbosity -> v)
+
+{-# COMPLETE CommonSetupVerbosity #-}
+{-# COMPLETE DefaultCommonSetupVerbosity #-}
 
 -- | Get `TempFileOptions` that respect the `setupKeepTempFiles` flag.
 commonSetupTempFileOptions :: CommonSetupFlags -> TempFileOptions

--- a/Cabal/src/Distribution/Simple/SrcDist.hs
+++ b/Cabal/src/Distribution/Simple/SrcDist.hs
@@ -119,7 +119,7 @@ sdist verbHandles pkg flags mkTmpDir pps = do
         overwriteSnapshotPackageDesc verbosity pkg' targetDir
 
     common = sDistCommonFlags flags
-    verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+    CommonSetupVerbosity verbosity = (verbHandles, common)
     mbWorkDir = flagToMaybe $ setupWorkingDir common
     i = interpretSymbolicPath mbWorkDir -- See Note [Symbolic paths] in Distribution.Utils.Path
     snapshot = fromFlag (sDistSnapshot flags)

--- a/Cabal/src/Distribution/Simple/Test.hs
+++ b/Cabal/src/Distribution/Simple/Test.hs
@@ -67,7 +67,7 @@ test
 test args verbHandles pkg_descr lbi0 flags = do
   curDir <- LBI.absoluteWorkingDirLBI lbi0
   let common = testCommonFlags flags
-      verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+      CommonSetupVerbosity verbosity = (verbHandles, common)
       distPref = fromFlag $ setupDistPref common
       i = LBI.interpretSymbolicPathLBI lbi -- See Note [Symbolic paths] in Distribution.Utils.Path
       machineTemplate = fromFlag $ testMachineLog flags

--- a/Cabal/src/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/src/Distribution/Simple/Test/ExeV10.hs
@@ -201,7 +201,7 @@ runTest verbHandles pkg_descr lbi clbi hpcMarkupInfo flags suite = do
     testName' = unUnqualComponentName $ PD.testName suite
 
     distPref = fromFlag $ setupDistPref commonFlags
-    verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity commonFlags)
+    CommonSetupVerbosity verbosity = (verbHandles, commonFlags)
     details = fromFlag $ testShowDetails flags
     testLogDir = distPref </> makeRelativePathEx "test"
 

--- a/Cabal/src/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/src/Distribution/Simple/Test/LibV09.hs
@@ -212,7 +212,7 @@ runTest verbHandles pkg_descr lbi clbi hpcMarkupInfo flags suite = do
       hClose h >> return f
 
     distPref = fromFlag $ setupDistPref common
-    verbosity = mkVerbosity verbHandles (fromFlag $ setupVerbosity common)
+    CommonSetupVerbosity verbosity = (verbHandles, common)
 
 -- TODO: This is abusing the notion of a 'PathTemplate'.  The result isn't
 -- necessarily a path.

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -48,11 +48,7 @@ import Distribution.Client.ScriptUtils
   , updateContextAndWriteProjectFile
   , withContextAndSelectors
   )
-import Distribution.Client.Setup
-  ( CommonSetupFlags (setupVerbosity)
-  , ConfigFlags (..)
-  , GlobalFlags (..)
-  )
+import Distribution.Client.Setup (ConfigFlags (..), GlobalFlags (..))
 import Distribution.Client.TargetProblem (TargetProblem (..))
 
 import Distribution.Simple.BuildPaths
@@ -91,6 +87,7 @@ import Distribution.Simple.Setup
   , Visibility (..)
   , defaultHaddockFlags
   , haddockProjectCommand
+  , pattern DefaultCommonSetupVerbosity
   )
 import Distribution.Simple.Utils
   ( copyDirectoryRecursive
@@ -106,11 +103,6 @@ import Distribution.Types.PackageName (unPackageName)
 import Distribution.Types.UnitId (unUnitId)
 import Distribution.Types.Version (mkVersion)
 import Distribution.Types.VersionRange (orLaterVersion)
-import Distribution.Verbosity as Verbosity
-  ( defaultVerbosityHandles
-  , mkVerbosity
-  , normal
-  )
 
 import Distribution.Client.Errors
 import System.Directory (doesDirectoryExist, doesFileExist)
@@ -362,10 +354,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
   where
     -- build all packages with appropriate haddock flags
     commonFlags = haddockProjectCommonFlags flags
-
-    verbosity =
-      mkVerbosity defaultVerbosityHandles $
-        fromFlagOrDefault normal (setupVerbosity commonFlags)
+    DefaultCommonSetupVerbosity verbosity = commonFlags
 
     haddockFlags =
       defaultHaddockFlags

--- a/cabal-install/src/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/src/Distribution/Client/CmdLegacy.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
@@ -19,20 +20,12 @@ import Distribution.Client.SetupWrapper
   , setupWrapper
   )
 import Distribution.Simple.Command
+import Distribution.Simple.Setup (pattern DefaultCommonSetupVerbosity)
 import qualified Distribution.Simple.Setup as Setup
-import Distribution.Simple.Utils
-  ( wrapText
-  )
-import Distribution.Verbosity
-  ( VerbosityFlags
-  , defaultVerbosityHandles
-  , mkVerbosity
-  , normal
-  )
+import Distribution.Simple.Utils (wrapText)
+import Distribution.Verbosity (VerbosityFlags, normal)
 
-import Control.Exception
-  ( try
-  )
+import Control.Exception (try)
 import qualified Data.Text as T
 
 -- Tweaked versions of code from Main.
@@ -60,9 +53,7 @@ wrapperAction command getCommonFlags =
       }
     $ \flags extraArgs globalFlags -> do
       let common = getCommonFlags flags
-          verbosity' =
-            mkVerbosity defaultVerbosityHandles $
-              Setup.fromFlagOrDefault normal (Setup.setupVerbosity common)
+          DefaultCommonSetupVerbosity verbosity' = common
           mbWorkDir = Setup.flagToMaybe $ Setup.setupWorkingDir common
 
       load <- try (loadConfigOrSandboxConfig verbosity' globalFlags)

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -88,6 +88,7 @@ import Distribution.Simple.Setup
   , fromFlagOrDefault
   , hscolourCommand
   , toFlag
+  , pattern DefaultCommonSetupVerbosity
   , pattern Flag
   , pattern NoFlag
   )
@@ -550,10 +551,7 @@ wrapperAction command getCommonFlags =
       }
     $ \flags extraArgs globalFlags -> do
       let common = getCommonFlags flags
-          verbosity =
-            mkVerbosity defaultVerbosityHandles $
-              fromFlagOrDefault normal $
-                setupVerbosity common
+          DefaultCommonSetupVerbosity verbosity = common
           mbWorkDir = flagToMaybe $ setupWorkingDir common
       load <- try (loadConfigOrSandboxConfig verbosity globalFlags)
       let config = either (\(SomeException _) -> mempty) id load
@@ -579,10 +577,7 @@ configureAction
   -> Action
 configureAction (configFlags, configExFlags) extraArgs globalFlags = do
   let common = configCommonFlags configFlags
-      verbosity =
-        mkVerbosity defaultVerbosityHandles $
-          fromFlagOrDefault normal $
-            setupVerbosity common
+      DefaultCommonSetupVerbosity verbosity = common
 
   config <-
     updateInstallDirs (configUserInstall configFlags)
@@ -621,9 +616,7 @@ reconfigureAction
   -> Action
 reconfigureAction flags@(configFlags, _) _ globalFlags = do
   let common = configCommonFlags configFlags
-      verbosity =
-        mkVerbosity defaultVerbosityHandles $
-          fromFlagOrDefault normal (setupVerbosity common)
+      DefaultCommonSetupVerbosity verbosity = common
   config <-
     updateInstallDirs (configUserInstall configFlags)
       <$> loadConfigOrSandboxConfig verbosity globalFlags
@@ -654,10 +647,7 @@ reconfigureAction flags@(configFlags, _) _ globalFlags = do
 buildAction :: BuildFlags -> [String] -> Action
 buildAction buildFlags extraArgs globalFlags = do
   let common = buildCommonFlags buildFlags
-      verbosity =
-        mkVerbosity defaultVerbosityHandles $
-          fromFlagOrDefault normal $
-            setupVerbosity common
+      DefaultCommonSetupVerbosity verbosity = common
   config <- loadConfigOrSandboxConfig verbosity globalFlags
   distPref <- findSavedDistPref config (setupDistPref common)
   -- Calls 'configureAction' to do the real work, so nothing special has to be
@@ -736,10 +726,7 @@ filterBuildFlags' version config buildFlags
 replAction :: ReplFlags -> [String] -> Action
 replAction replFlags extraArgs globalFlags = do
   let common = replCommonFlags replFlags
-      verbosity =
-        mkVerbosity defaultVerbosityHandles $
-          fromFlagOrDefault normal $
-            setupVerbosity common
+      DefaultCommonSetupVerbosity verbosity = common
   config <- loadConfigOrSandboxConfig verbosity globalFlags
   distPref <- findSavedDistPref config (setupDistPref common)
   pkgDesc <- findPackageDesc Nothing
@@ -819,9 +806,7 @@ installAction
 installAction (configFlags, _, installFlags, _, _, _) _ globalFlags
   | fromFlagOrDefault False (installOnly installFlags) = do
       let common = configCommonFlags configFlags
-          verb =
-            mkVerbosity defaultVerbosityHandles $
-              fromFlagOrDefault normal (setupVerbosity common)
+          DefaultCommonSetupVerbosity verb = common
       config <- loadConfigOrSandboxConfig verb globalFlags
       dist <- findSavedDistPref config (setupDistPref common)
       let setupOpts = defaultSetupScriptOptions{useDistPref = dist}
@@ -845,10 +830,7 @@ installAction
   extraArgs
   globalFlags = do
     let common = configCommonFlags configFlags
-        verb =
-          mkVerbosity defaultVerbosityHandles $
-            fromFlagOrDefault normal $
-              setupVerbosity common
+        DefaultCommonSetupVerbosity verb = common
     config <-
       updateInstallDirs (configUserInstall configFlags)
         <$> loadConfigOrSandboxConfig verb globalFlags
@@ -1136,10 +1118,7 @@ benchmarkAction
 haddockAction :: HaddockFlags -> [String] -> Action
 haddockAction haddockFlags extraArgs globalFlags = do
   let common = haddockCommonFlags haddockFlags
-      verbosity =
-        mkVerbosity defaultVerbosityHandles $
-          fromFlag $
-            setupVerbosity common
+      DefaultCommonSetupVerbosity verbosity = common
   config <- loadConfigOrSandboxConfig verbosity globalFlags
   distPref <- findSavedDistPref config (setupDistPref common)
   config' <-
@@ -1189,10 +1168,7 @@ haddockAction haddockFlags extraArgs globalFlags = do
 cleanAction :: CleanFlags -> [String] -> Action
 cleanAction cleanFlags extraArgs globalFlags = do
   let common = cleanCommonFlags cleanFlags
-      verbosity =
-        mkVerbosity defaultVerbosityHandles $
-          fromFlagOrDefault normal $
-            setupVerbosity common
+      DefaultCommonSetupVerbosity verbosity = common
   load <- try (loadConfigOrSandboxConfig verbosity globalFlags)
   let config = either (\(SomeException _) -> mempty) id load
   distPref <- findSavedDistPref config $ setupDistPref common
@@ -1461,10 +1437,7 @@ reportAction reportFlags extraArgs globalFlags = do
 runAction :: BuildFlags -> [String] -> Action
 runAction buildFlags extraArgs globalFlags = do
   let common = buildCommonFlags buildFlags
-      verbosity =
-        mkVerbosity defaultVerbosityHandles $
-          fromFlagOrDefault normal $
-            setupVerbosity common
+      DefaultCommonSetupVerbosity verbosity = common
   config <- loadConfigOrSandboxConfig verbosity globalFlags
   distPref <- findSavedDistPref config $ setupDistPref common
   config' <-


### PR DESCRIPTION
Fixes #11777.

- Adds `CommonSetupVerbosity` and `DefaultCommonSetupVerbosity` pattern synonyms exported from `Distribution.Simple.Setup`.
- Adds a `ConfigVerbosity` pattern synonym private to `Distribution.Simple.Configure`.

> [!NOTE]
>  The `FlagVerbosity` pattern and its 9 uses are no longer needed now that `Distribution.Make` was deleted in #11894. Thanks for removing that module @Bodigrim.
> - Adds a `FlagVerbosity` pattern synonym private to `Distribution.Make`,

This replaces longer repetitive code with shorter pattern matches. The more intricate code, moved inside the pattern synonyms, is not repeated.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
