### PR TITLE
Bump validate workflow ghc versions

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -8,7 +8,7 @@ on:
         type: string
       ghc:
         type: string
-        default: 9.10.2
+        default: 9.10.3
       # speed up installation by skipping docs
       # starting with GHC 9.10.x, we also need to pass the 'install_extra' target
       ghc_targets:
@@ -24,9 +24,10 @@ on:
 env:
   GHC_VERSION: ${{ inputs.ghc }}
   GHC_TARGETS: ${{ inputs.ghc_targets }}
-  # This shouldn't be necessary, but cabal developers
-  # want to build with 9.10.2, which causes test failures
-  # when used as runtime GHC version as well.
+  # This shouldn't be necessary, but cabal developers want to build with 9.10.3,
+  # which causes test failures when used as runtime GHC version as well. For
+  # more detail, please see the note and link to the issue in
+  # .github/scripts/test.bash
   GHC_TEST_VERSION: 9.6.7
   GHC_TEST_TARGETS: "install_bin install_lib update_package_db"
   CABAL_VERSION: ${{ inputs.cabal }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,10 +32,10 @@ on:
 env:
   # We choose a stable ghc version across all os's
   # which will be used to do the next release
-  GHC_FOR_RELEASE: "9.10.2"
+  GHC_FOR_RELEASE: "9.10.3"
   # Ideally we should use the version about to be released for hackage tests and benchmarks
-  GHC_FOR_SOLVER_BENCHMARKS: "9.10.2"
-  GHC_FOR_COMPLETE_HACKAGE_TESTS: "9.10.2"
+  GHC_FOR_SOLVER_BENCHMARKS: "9.10.3"
+  GHC_FOR_COMPLETE_HACKAGE_TESTS: "9.10.3"
   COMMON_FLAGS: "-j 2 -v"
 
   # See https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#hackage-revisions
@@ -61,8 +61,8 @@ jobs:
             # Also a removed GHC from here means that we are actually dropping
             # support, so the PR *must* have a changelog entry.
             "9.14.1",
-            "9.12.2",
-            "9.10.2",
+            "9.12.4",
+            "9.10.3",
             "9.8.4",
             "9.6.7",
             "9.4.8",

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   # Commit of ghc/ci-images repository from which to pull Docker images
   DOCKER_REV: "be4ac2cd18f38e63b263e2a27c76a7c279385796"
 
-  GHC_VERSION: 9.10.2
+  GHC_VERSION: 9.10.3
   CABAL_INSTALL_VERSION: 3.14.2.0
 
 workflow:


### PR DESCRIPTION
Bumps the validate workflow to use `ghc-9.10.3` (up from `ghc-9.10.2`) and `ghc-9.12.4` (up from `ghc-9.12.2`).

Also includes commits to do the same for the reusable release workflow and the gitlab one.

I've not touched the bootstrap workflow but note it is on `ghc-9.12.2`:

https://github.com/haskell/cabal/blob/e6ff0ccf6f2761f1d3d82b4383b053c21f816e27/.github/workflows/bootstrap.yml#L22

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
