### PR TITLE
Add program prefix and suffix to `BuildOptions`

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,10 +27,14 @@ tests = testGroup "Distribution.Utils.Structured"
 md5Check :: Structured a => Proxy a -> Integer -> Assertion
 md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 
+-- NB: if you need to update these values locally, you can run:
+--
+-- > cabal run Cabal-tests:unit-tests -- -p "/Structured/"
+
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
     0xfbca1c1f2a700fb3a174ec5346e86cbb
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x3bf7bf1420847ce5fdaf6e36e33aecb2
+    0xd9542841ab7584d348aa142053fe934f

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -914,6 +914,8 @@ buildOptionsFromConfigFlags verbosity cfg comp = do
         , exeCoverage = False
         , libCoverage = False
         , relocatable = fromFlagOrDefault False $ configRelocatable cfg
+        , programPrefix = flagToMaybe $ configProgPrefix cfg
+        , programSuffix = flagToMaybe $ configProgSuffix cfg
         }
 
 -- | Adjust 'LBC.BuildOptions' to be compatible with the given 'Compiler' and

--- a/Cabal/src/Distribution/Types/LocalBuildConfig.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildConfig.hs
@@ -188,6 +188,10 @@ data BuildOptions = BuildOptions
   -- ^ Whether to enable library program coverage
   , relocatable :: Bool
   -- ^ Whether to build a relocatable package
+  , programPrefix :: Maybe PathTemplate
+  -- ^ Installed executable prefix
+  , programSuffix :: Maybe PathTemplate
+  -- ^ Installed executable suffix
   }
   deriving (Eq, Generic, Read, Show)
 
@@ -229,4 +233,6 @@ buildOptionsConfigFlags (BuildOptions{..}) =
     , configStripExes = toFlag stripExes
     , configStripLibs = toFlag stripLibs
     , configDebugInfo = toFlag withDebugInfo
+    , configProgPrefix = maybeToFlag programPrefix
+    , configProgSuffix = maybeToFlag programSuffix
     }

--- a/Cabal/src/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildInfo.hs
@@ -47,6 +47,8 @@ module Distribution.Types.LocalBuildInfo
       , libCoverage
       , extraCoverageFor
       , relocatable
+      , programPrefix
+      , programSuffix
       , ..
       )
 
@@ -188,6 +190,8 @@ pattern LocalBuildInfo
   -> Bool
   -> [UnitId]
   -> Bool
+  -> Maybe PathTemplate
+  -> Maybe PathTemplate
   -> LocalBuildInfo
 pattern LocalBuildInfo
   { configFlags
@@ -227,6 +231,8 @@ pattern LocalBuildInfo
   , libCoverage
   , extraCoverageFor
   , relocatable
+  , programPrefix
+  , programSuffix
   } =
   NewLocalBuildInfo
     { localBuildDescr =
@@ -279,6 +285,8 @@ pattern LocalBuildInfo
             , exeCoverage
             , libCoverage
             , relocatable
+            , programPrefix
+            , programSuffix
             }
         }
     }
@@ -316,10 +324,13 @@ packageRoot cfg =
     mbWorkDir = flagToMaybe $ setupWorkingDir cfg
 
 progPrefix, progSuffix :: LocalBuildInfo -> PathTemplate
-progPrefix (LocalBuildInfo{configFlags = cfg}) =
-  fromFlag $ configProgPrefix cfg
-progSuffix (LocalBuildInfo{configFlags = cfg}) =
-  fromFlag $ configProgSuffix cfg
+-- NB: make sure to read from 'BuildOptions' rather than the 'ConfigFlags'
+-- stored in 'PackageBuildDescr', as the latter are the original command-line
+-- input and are not updated by 'SetupHooks' configure hooks.
+progPrefix (LocalBuildInfo{programPrefix = pfix}) =
+  fromMaybe (toPathTemplate "") pfix
+progSuffix (LocalBuildInfo{programSuffix = sfix}) =
+  fromMaybe (toPathTemplate "") sfix
 
 -- TODO: Get rid of these functions, as much as possible.  They are
 -- a bit useful in some cases, but you should be very careful!

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2405,6 +2405,8 @@ elaborateInstallPlan
                 , relocatable = perPkgOptionFlag pkgid False packageConfigRelocatable
                 , withProfLibDetail = elabProfExeDetail
                 , withProfExeDetail = elabProfLibDetail
+                , programPrefix = elabProgPrefix
+                , programSuffix = elabProgSuffix
                 }
             okProfDyn = profilingDynamicSupportedOrUnknown compiler
             profExe = perPkgOptionFlag pkgid False packageConfigProf

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/Main.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = return ()

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/Setup.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/Setup.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Distribution.Simple ( defaultMainWithSetupHooks )
+import SetupHooks ( setupHooks )
+
+main :: IO ()
+main = defaultMainWithSetupHooks setupHooks

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/SetupHooks.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/SetupHooks.hs
@@ -1,0 +1,18 @@
+module SetupHooks where
+
+import Distribution.Simple.SetupHooks
+import Distribution.Simple.InstallDirs ( toPathTemplate )
+import Distribution.Types.LocalBuildConfig ( BuildOptions (..) )
+
+setupHooks :: SetupHooks
+setupHooks =
+  noSetupHooks
+    { configureHooks =
+        noConfigureHooks
+          { preConfPackageHook = Just preConfPkg }
+    }
+
+preConfPkg :: PreConfPackageHook
+preConfPkg inputs =
+  let outputs@PreConfPackageOutputs{buildOptions = opts} = noPreConfPackageOutputs inputs
+  in return outputs{buildOptions = opts{programPrefix = Just (toPathTemplate "pre-")}}

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/cabal.project
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/setup-hooks-prog-prefix.cabal
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/setup-hooks-prog-prefix.cabal
@@ -1,0 +1,13 @@
+cabal-version:       3.14
+name:                setup-hooks-prog-prefix
+version:             0.1.0.0
+license:             BSD-3-Clause
+build-type:          Hooks
+
+custom-setup
+  setup-depends: Cabal, Cabal-hooks, base
+
+executable myexe
+  main-is:             Main.hs
+  build-depends:       base
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/setup.test.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksProgramPrefix/setup.test.hs
@@ -1,0 +1,15 @@
+import Test.Cabal.Prelude
+import Distribution.System ( buildPlatform )
+import Distribution.Simple.BuildPaths ( exeExtension )
+
+-- Test that SetupHooks can set the programPrefix (#11168).
+main = setupTest $ do
+  env <- getTestEnv
+  withPackageDb $ recordMode DoNotRecord $ do
+    setup "configure" []
+    setup "build" []
+    setup "copy" []
+    let binDir = testPrefixDir env </> "bin"
+        exeExt = exeExtension buildPlatform
+    shouldExist    (binDir </> "pre-myexe" <.> exeExt)
+    shouldNotExist (binDir </> "myexe"     <.> exeExt)

--- a/changelog.d/hooks-prefix.md
+++ b/changelog.d/hooks-prefix.md
@@ -1,0 +1,10 @@
+---
+synopsis: Add program prefix and suffix to `BuildOptions`
+packages: [Cabal, Cabal-hooks]
+prs: 11787
+issues: 11168
+---
+
+Two new fields of `BuildOptions`, `programPrefix` and `programSuffix`, have
+been added. This allows the installed executable program prefix and suffix to
+be set by `SetupHooks` for packages with `build-type: Hooks`.


### PR DESCRIPTION
This commits adds two new fields of `BuildOptions`, namely `programPrefix` and `programSuffix`. This allows the installed executable program prefix and suffix to be set by `SetupHooks` for packages with `build-type: Hooks`.

---

**Template Α: This PR modifies [behaviour or interface](CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
