### PR TITLE
Group installed multilib packages

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -45,6 +45,7 @@ data InstalledPackageInfo = InstalledPackageInfo
   , installedSublibs :: [InstalledPackageInfo]
   , libVisibility :: LibraryVisibility
   , installedUnitId :: UnitId
+  , installedInstanceUnitId :: InstanceUnitId
   , -- INVARIANT: if this package is definite, OpenModule's
     -- OpenUnitId directly records UnitId.  If it is
     -- indefinite, OpenModule is always an OpenModuleVar
@@ -136,6 +137,7 @@ emptyInstalledPackageInfo =
     , sourceLibName = LMainLibName
     , installedComponentId_ = mkComponentId ""
     , installedUnitId = mkUnitId ""
+    , installedInstanceUnitId = mkInstanceUnitId $ mkUnitId ""
     , installedSublibs = mempty
     , instantiatedWith = []
     , compatPackageKey = ""

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -42,6 +42,7 @@ data InstalledPackageInfo = InstalledPackageInfo
     sourcePackageId :: PackageId
   , sourceLibName :: LibraryName
   , installedComponentId_ :: ComponentId
+  , installedSublibs :: [InstalledPackageInfo]
   , libVisibility :: LibraryVisibility
   , installedUnitId :: UnitId
   , -- INVARIANT: if this package is definite, OpenModule's
@@ -135,6 +136,7 @@ emptyInstalledPackageInfo =
     , sourceLibName = LMainLibName
     , installedComponentId_ = mkComponentId ""
     , installedUnitId = mkUnitId ""
+    , installedSublibs = mempty
     , instantiatedWith = []
     , compatPackageKey = ""
     , license = Left SPDX.NONE

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -44,6 +44,7 @@ data InstalledPackageInfo = InstalledPackageInfo
   , installedSublibs :: [InstalledPackageInfo]
   , libVisibility :: LibraryVisibility
   , installedUnitId :: UnitId
+  , installedInstanceUnitId :: InstanceUnitId
   , -- INVARIANT: if this package is definite, OpenModule's
     -- OpenUnitId directly records UnitId.  If it is
     -- indefinite, OpenModule is always an OpenModuleVar
@@ -135,6 +136,7 @@ emptyInstalledPackageInfo =
     , sourceLibName = LMainLibName
     , installedComponentId_ = mkComponentId ""
     , installedUnitId = mkUnitId ""
+    , installedInstanceUnitId = mkInstanceUnitId $ mkUnitId ""
     , installedSublibs = mempty
     , instantiatedWith = []
     , compatPackageKey = ""

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -41,6 +41,7 @@ data InstalledPackageInfo = InstalledPackageInfo
     sourcePackageId :: PackageId
   , sourceLibName :: LibraryName
   , installedComponentId_ :: ComponentId
+  , installedSublibs :: [InstalledPackageInfo]
   , libVisibility :: LibraryVisibility
   , installedUnitId :: UnitId
   , -- INVARIANT: if this package is definite, OpenModule's
@@ -134,6 +135,7 @@ emptyInstalledPackageInfo =
     , sourceLibName = LMainLibName
     , installedComponentId_ = mkComponentId ""
     , installedUnitId = mkUnitId ""
+    , installedSublibs = mempty
     , instantiatedWith = []
     , compatPackageKey = ""
     , license = Left SPDX.NONE

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -61,6 +61,7 @@ ipiFieldGrammar
      , c (Identity LibraryVisibility)
      , c (Identity PackageName)
      , c (Identity UnitId)
+     , c (Identity InstanceUnitId)
      , c (Identity UnqualComponentName)
      , c (List FSep (Identity AbiDependency) AbiDependency)
      , c (List FSep (Identity UnitId) UnitId)
@@ -85,6 +86,7 @@ ipiFieldGrammar =
     <@> blurFieldGrammar basic basicFieldGrammar
     -- Basic fields
     <@> optionalFieldDef "id" L.installedUnitId (mkUnitId "")
+    <@> optionalFieldDef "instance-id" L.installedInstanceUnitId (mkInstanceUnitId $ mkUnitId "")
     <@> optionalFieldDefAla "instantiated-with" InstWith L.instantiatedWith []
     <@> optionalFieldDefAla "key" CompatPackageKey L.compatPackageKey ""
     <@> optionalFieldDefAla "license" SpecLicenseLenient L.license (Left SPDX.NONE)

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -134,6 +134,7 @@ ipiFieldGrammar =
         (PackageIdentifier pn _basicVersion)
         (combineLibraryName ln _basicLibName)
         (mkComponentId "") -- installedComponentId_, not in use
+        mempty -- installedSublibs
         _basicLibVisibility
       where
         MungedPackageName pn ln = _basicName

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -56,6 +56,7 @@ ipiFieldGrammar
      , c (Identity LibraryVisibility)
      , c (Identity PackageName)
      , c (Identity UnitId)
+     , c (Identity InstanceUnitId)
      , c (Identity UnqualComponentName)
      , c (List FSep (Identity AbiDependency) AbiDependency)
      , c (List FSep (Identity UnitId) UnitId)
@@ -80,6 +81,7 @@ ipiFieldGrammar =
     <@> blurFieldGrammar basic basicFieldGrammar
     -- Basic fields
     <@> optionalFieldDef "id" L.installedUnitId (mkUnitId "")
+    <@> optionalFieldDef "instance-id" L.installedInstanceUnitId (mkInstanceUnitId $ mkUnitId "")
     <@> optionalFieldDefAla "instantiated-with" InstWith L.instantiatedWith []
     <@> optionalFieldDefAla "key" CompatPackageKey L.compatPackageKey ""
     <@> optionalFieldDefAla "license" SpecLicenseLenient L.license (Left SPDX.NONE)

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -129,6 +129,7 @@ ipiFieldGrammar =
         (PackageIdentifier pn _basicVersion)
         (combineLibraryName ln _basicLibName)
         (mkComponentId "") -- installedComponentId_, not in use
+        mempty -- installedSublibs
         _basicLibVisibility
       where
         MungedPackageName pn ln = _basicName

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -10,7 +10,7 @@ import Prelude ()
 import Distribution.Backpack (OpenModule)
 import Distribution.License (License)
 import Distribution.ModuleName (ModuleName)
-import Distribution.Package (AbiHash, ComponentId, PackageIdentifier, UnitId)
+import Distribution.Package (AbiHash, ComponentId, InstanceUnitId, PackageIdentifier, UnitId)
 import Distribution.Types.InstalledPackageInfo (AbiDependency, ExposedModule, InstalledPackageInfo)
 import Distribution.Types.LibraryName (LibraryName)
 import Distribution.Types.LibraryVisibility (LibraryVisibility)
@@ -26,6 +26,10 @@ sourcePackageId f s = fmap (\x -> s{T.sourcePackageId = x}) (f (T.sourcePackageI
 installedUnitId :: Lens' InstalledPackageInfo UnitId
 installedUnitId f s = fmap (\x -> s{T.installedUnitId = x}) (f (T.installedUnitId s))
 {-# INLINE installedUnitId #-}
+
+installedInstanceUnitId :: Lens' InstalledPackageInfo InstanceUnitId
+installedInstanceUnitId f s = fmap (\x -> s{T.installedInstanceUnitId = x}) (f (T.installedInstanceUnitId s))
+{-# INLINE installedInstanceUnitId #-}
 
 installedComponentId_ :: Lens' InstalledPackageInfo ComponentId
 installedComponentId_ f s = fmap (\x -> s{T.installedComponentId_ = x}) (f (T.installedComponentId_ s))

--- a/Cabal-syntax/src/Distribution/Types/UnitId.hs
+++ b/Cabal-syntax/src/Distribution/Types/UnitId.hs
@@ -13,6 +13,9 @@ module Distribution.Types.UnitId
   , newSimpleUnitId
   , mkLegacyUnitId
   , getHSLibraryName
+  , InstanceUnitId
+  , mkInstanceUnitId
+  , unInstanceUnitId
   ) where
 
 import Distribution.Compat.Prelude
@@ -131,3 +134,16 @@ instance Parsec DefUnitId where
 -- is to ensure that the 'DefUnitId' invariant holds.
 unsafeMkDefUnitId :: UnitId -> DefUnitId
 unsafeMkDefUnitId = DefUnitId
+
+-- | A 'UnitId' for an instance (group of components). Typically
+-- this matches a main library 'UnitId'
+newtype InstanceUnitId = InstanceUnitId {unInstanceUnitId :: UnitId}
+  deriving (Generic, Read, Show, Eq, Ord, Data, Binary, NFData, Pretty)
+
+instance Structured InstanceUnitId
+
+instance Parsec InstanceUnitId where
+  parsec = InstanceUnitId <$> parsec
+
+mkInstanceUnitId :: UnitId -> InstanceUnitId
+mkInstanceUnitId = InstanceUnitId

--- a/Cabal-syntax/src/Distribution/Types/UnitId.hs
+++ b/Cabal-syntax/src/Distribution/Types/UnitId.hs
@@ -8,6 +8,9 @@ module Distribution.Types.UnitId
   , newSimpleUnitId
   , mkLegacyUnitId
   , getHSLibraryName
+  , InstanceUnitId
+  , mkInstanceUnitId
+  , unInstanceUnitId
   ) where
 
 import Distribution.Compat.Prelude
@@ -126,3 +129,16 @@ instance Parsec DefUnitId where
 -- is to ensure that the 'DefUnitId' invariant holds.
 unsafeMkDefUnitId :: UnitId -> DefUnitId
 unsafeMkDefUnitId = DefUnitId
+
+-- | A 'UnitId' for an instance (group of components). Typically
+-- this matches a main library 'UnitId'
+newtype InstanceUnitId = InstanceUnitId {unInstanceUnitId :: UnitId}
+  deriving (Generic, Read, Show, Eq, Ord, Data, Binary, NFData, Pretty)
+
+instance Structured InstanceUnitId
+
+instance Parsec InstanceUnitId where
+  parsec = InstanceUnitId <$> parsec
+
+mkInstanceUnitId :: UnitId -> InstanceUnitId
+mkInstanceUnitId = InstanceUnitId

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.cabal
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.cabal
@@ -1,6 +1,7 @@
 name: z-Includes2-z-mylib
 version: 0.1.0.0
 id: Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
+instance-id: Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
 instantiated-with: Database=Includes2-0.1.0.0-inplace-mysql:Database.MySQL
 package-name: Includes2
 lib-name: mylib

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
@@ -14,6 +14,8 @@ InstalledPackageInfo {
   LibraryVisibilityPrivate,
   installedUnitId = UnitId
     "Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n",
+  installedInstanceUnitId = InstanceUnitId
+    (UnitId "Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n"),
   instantiatedWith = [
     _×_
       (ModuleName "Database")

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
@@ -9,6 +9,7 @@ InstalledPackageInfo {
     (UnqualComponentName "mylib"),
   installedComponentId_ =
   ComponentId "",
+  installedSublibs = [],
   libVisibility =
   LibraryVisibilityPrivate,
   installedUnitId = UnitId

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.format
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.format
@@ -3,6 +3,7 @@ version:              0.1.0.0
 package-name:         Includes2
 lib-name:             mylib
 id:                   Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
+instance-id:          Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
 instantiated-with:    Database=Includes2-0.1.0.0-inplace-mysql:Database.MySQL
 key:                  Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
 license:              BSD3

--- a/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
@@ -13,6 +13,8 @@ InstalledPackageInfo {
   LibraryVisibilityPublic,
   installedUnitId = UnitId
     "internal-preprocessor-test-0.1.0.0",
+  installedInstanceUnitId = InstanceUnitId
+    (UnitId ""),
   instantiatedWith = [],
   compatPackageKey =
   "internal-preprocessor-test-0.1.0.0",

--- a/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
@@ -8,6 +8,7 @@ InstalledPackageInfo {
   sourceLibName = LMainLibName,
   installedComponentId_ =
   ComponentId "",
+  installedSublibs = [],
   libVisibility =
   LibraryVisibilityPublic,
   installedUnitId = UnitId

--- a/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
@@ -13,6 +13,8 @@ InstalledPackageInfo {
   LibraryVisibilityPublic,
   installedUnitId = UnitId
     "transformers-0.5.2.0",
+  installedInstanceUnitId = InstanceUnitId
+    (UnitId ""),
   instantiatedWith = [],
   compatPackageKey =
   "transformers-0.5.2.0",

--- a/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
@@ -8,6 +8,7 @@ InstalledPackageInfo {
   sourceLibName = LMainLibName,
   installedComponentId_ =
   ComponentId "",
+  installedSublibs = [],
   libVisibility =
   LibraryVisibilityPublic,
   installedUnitId = UnitId

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.cabal
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.cabal
@@ -1,6 +1,7 @@
 name: transformers
 version: 0.5.2.0
 id: transformers-0.5.2.0
+instance-id: transformers-0.5.2.0
 key: transformers-0.5.2.0
 license: BSD3
 maintainer: Ross Paterson <R.Paterson@city.ac.uk>

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.expr
@@ -8,6 +8,7 @@ InstalledPackageInfo {
   sourceLibName = LMainLibName,
   installedComponentId_ =
   ComponentId "",
+  installedSublibs = [],
   libVisibility =
   LibraryVisibilityPublic,
   installedUnitId = UnitId

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.expr
@@ -13,6 +13,8 @@ InstalledPackageInfo {
   LibraryVisibilityPublic,
   installedUnitId = UnitId
     "transformers-0.5.2.0",
+  installedInstanceUnitId = InstanceUnitId
+    (UnitId "transformers-0.5.2.0"),
   instantiatedWith = [],
   compatPackageKey =
   "transformers-0.5.2.0",

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.format
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.format
@@ -2,6 +2,7 @@ name:                 transformers
 version:              0.5.2.0
 visibility:           public
 id:                   transformers-0.5.2.0
+instance-id:          transformers-0.5.2.0
 key:                  transformers-0.5.2.0
 license:              BSD3
 maintainer:           Ross Paterson <R.Paterson@city.ac.uk>

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,4 +33,4 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x31137cc4853f0380d1f18eb165d746df
+    0xe394537933f4b964768db669ff128aa7

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,4 +33,4 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x78979713e08179ab070d6ab10cd5ef6c
+    0x31137cc4853f0380d1f18eb165d746df

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -37,4 +37,4 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x31137cc4853f0380d1f18eb165d746df
+    0x5b4761bb5af40e56ecc76def2c692f78

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -37,4 +37,4 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x3398bd7f316ecb8f535cbe78498a89a4
+    0x31137cc4853f0380d1f18eb165d746df

--- a/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
+++ b/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
@@ -27,7 +27,7 @@ import Distribution.Types.AbiHash                  (AbiHash)
 import Distribution.Types.ComponentId              (ComponentId)
 import Distribution.Types.DumpBuildInfo            (DumpBuildInfo)
 import Distribution.Types.PackageVersionConstraint
-import Distribution.Types.UnitId                   (DefUnitId, UnitId)
+import Distribution.Types.UnitId                   (DefUnitId, InstanceUnitId, UnitId)
 import Distribution.Utils.NubList                  (NubList)
 import Distribution.Utils.Path                     (SymbolicPathX)
 import Distribution.Utils.ShortText                (ShortText, fromShortText)
@@ -113,6 +113,7 @@ instance ToExpr ForeignLibOption
 instance ToExpr ForeignLibType
 instance ToExpr HaddockTarget
 instance ToExpr IncludeRenaming
+instance ToExpr InstanceUnitId
 instance ToExpr InstalledPackageInfo
 instance ToExpr KnownRepoType
 instance ToExpr LegacyExeDependency

--- a/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
+++ b/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
@@ -26,7 +26,7 @@ import Distribution.Types.AbiHash                  (AbiHash)
 import Distribution.Types.ComponentId              (ComponentId)
 import Distribution.Types.DumpBuildInfo            (DumpBuildInfo)
 import Distribution.Types.PackageVersionConstraint
-import Distribution.Types.UnitId                   (DefUnitId, UnitId)
+import Distribution.Types.UnitId                   (DefUnitId, InstanceUnitId, UnitId)
 import Distribution.Utils.NubList                  (NubList)
 import Distribution.Utils.Path                     (SymbolicPathX)
 import Distribution.Verbosity
@@ -111,6 +111,7 @@ instance ToExpr ForeignLibOption
 instance ToExpr ForeignLibType
 instance ToExpr HaddockTarget
 instance ToExpr IncludeRenaming
+instance ToExpr InstanceUnitId
 instance ToExpr InstalledPackageInfo
 instance ToExpr KnownRepoType
 instance ToExpr LegacyExeDependency

--- a/Cabal/src/Distribution/Backpack/Configure.hs
+++ b/Cabal/src/Distribution/Backpack/Configure.hs
@@ -67,6 +67,7 @@ configureComponentLocalBuildInfos
   -> Bool -- deterministic
   -> Flag String -- configIPID
   -> Flag ComponentId -- configCID
+  -> Flag InstanceUnitId -- configIUID
   -> PackageDescription
   -> ([PreExistingComponent], [ConfiguredPromisedComponent])
   -> FlagAssignment -- configConfigurationsFlags
@@ -81,6 +82,7 @@ configureComponentLocalBuildInfos
   deterministic
   ipid_flag
   cid_flag
+  iuid_flag
   pkg_descr
   (prePkgDeps, promisedPkgDeps)
   flags
@@ -127,6 +129,7 @@ configureComponentLocalBuildInfos
         deterministic
         ipid_flag
         cid_flag
+        iuid_flag
         pkg_descr
         conf_pkg_map
         (map fst graph0)
@@ -391,6 +394,7 @@ mkLinkedComponentsLocalBuildInfo comp rcs = map go rcs
            in LibComponentLocalBuildInfo
                 { componentPackageDeps = cpds
                 , componentUnitId = this_uid
+                , componentInstanceUnitId = this_instance_uid
                 , componentComponentId = this_cid
                 , componentInstantiatedWith = insts
                 , componentIsIndefinite_ = is_indefinite
@@ -445,6 +449,7 @@ mkLinkedComponentsLocalBuildInfo comp rcs = map go rcs
             }
       where
         this_uid = rc_uid rc
+        this_instance_uid = rc_instance_id rc
         this_open_uid = rc_open_uid rc
         this_cid = rc_cid rc
         cname = componentName (rc_component rc)

--- a/Cabal/src/Distribution/Backpack/Configure.hs
+++ b/Cabal/src/Distribution/Backpack/Configure.hs
@@ -66,6 +66,7 @@ configureComponentLocalBuildInfos
   -> Bool -- deterministic
   -> Flag String -- configIPID
   -> Flag ComponentId -- configCID
+  -> Flag InstanceUnitId -- configIUID
   -> PackageDescription
   -> ([PreExistingComponent], [ConfiguredPromisedComponent])
   -> FlagAssignment -- configConfigurationsFlags
@@ -80,6 +81,7 @@ configureComponentLocalBuildInfos
   deterministic
   ipid_flag
   cid_flag
+  iuid_flag
   pkg_descr
   (prePkgDeps, promisedPkgDeps)
   flags
@@ -126,6 +128,7 @@ configureComponentLocalBuildInfos
         deterministic
         ipid_flag
         cid_flag
+        iuid_flag
         pkg_descr
         conf_pkg_map
         (map fst graph0)
@@ -452,6 +455,7 @@ mkLinkedComponentsLocalBuildInfo comp rcs = map go rcs
            in LibComponentLocalBuildInfo
                 { componentPackageDeps = cpds
                 , componentUnitId = this_uid
+                , componentInstanceUnitId = this_instance_uid
                 , componentComponentId = this_cid
                 , componentInstantiatedWith = insts
                 , componentIsIndefinite_ = is_indefinite
@@ -506,6 +510,7 @@ mkLinkedComponentsLocalBuildInfo comp rcs = map go rcs
             }
       where
         this_uid = rc_uid rc
+        this_instance_uid = rc_instance_id rc
         this_open_uid = rc_open_uid rc
         this_cid = rc_cid rc
         cname = componentName (rc_component rc)

--- a/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- | See <https://github.com/ezyang/ghc-proposals/blob/backpack/proposals/0000-backpack.rst>
 module Distribution.Backpack.ConfiguredComponent
   ( ConfiguredComponent (..)
@@ -22,7 +24,7 @@ import Distribution.CabalSpecVersion
 import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.Simple.BuildToolDepends
-import Distribution.Simple.Flag (Flag)
+import Distribution.Simple.Flag (Flag, pattern Flag, pattern NoFlag)
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Types.AnnotatedId
 import Distribution.Types.ComponentInclude
@@ -43,6 +45,7 @@ import qualified Text.PrettyPrint as PP
 data ConfiguredComponent = ConfiguredComponent
   { cc_ann_id :: AnnotatedId ComponentId
   -- ^ Unique identifier of component, plus extra useful info.
+  , cc_instance_unit_id :: InstanceUnitId
   , cc_component :: Component
   -- ^ The fragment of syntax from the Cabal file describing this
   -- component.
@@ -98,11 +101,12 @@ dispConfiguredComponent cc =
 mkConfiguredComponent
   :: PackageDescription
   -> ComponentId
+  -> InstanceUnitId
   -> [AnnotatedId ComponentId] -- lib deps
   -> [AnnotatedId ComponentId] -- exe deps
   -> Component
   -> LogProgress ConfiguredComponent
-mkConfiguredComponent pkg_descr this_cid lib_deps exe_deps component = do
+mkConfiguredComponent pkg_descr this_cid this_iuid lib_deps exe_deps component = do
   -- Resolve each @mixins@ into the actual dependency
   -- from @lib_deps@.
   explicit_includes <- forM (mixins bi) $ \(Mixin pn ln rns) -> do
@@ -142,6 +146,7 @@ mkConfiguredComponent pkg_descr this_cid lib_deps exe_deps component = do
             , ann_pid = package pkg_descr
             , ann_cname = componentName component
             }
+      , cc_instance_unit_id = this_iuid
       , cc_component = component
       , cc_public = is_public
       , cc_exe_deps = exe_deps
@@ -170,11 +175,12 @@ type ConfiguredComponentMap =
 toConfiguredComponent
   :: PackageDescription
   -> ComponentId
+  -> InstanceUnitId
   -> ConfiguredComponentMap
   -> ConfiguredComponentMap
   -> Component
   -> LogProgress ConfiguredComponent
-toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
+toConfiguredComponent pkg_descr this_cid this_iuid lib_dep_map exe_dep_map component = do
   lib_deps <-
     if newPackageDepsBehaviour pkg_descr
       then fmap concat $
@@ -202,6 +208,7 @@ toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
   mkConfiguredComponent
     pkg_descr
     this_cid
+    this_iuid
     lib_deps
     exe_deps
     component
@@ -246,6 +253,7 @@ toConfiguredComponent'
   -> Bool -- deterministic
   -> Flag String -- configIPID (todo: remove me)
   -> Flag ComponentId -- configCID
+  -> Flag InstanceUnitId -- configIUID
   -> ConfiguredComponentMap
   -> Component
   -> LogProgress ConfiguredComponent
@@ -256,12 +264,14 @@ toConfiguredComponent'
   deterministic
   ipid_flag
   cid_flag
+  iuid_flag
   dep_map
   component = do
     cc <-
       toConfiguredComponent
         pkg_descr
         this_cid
+        this_iuid
         dep_map
         dep_map
         component
@@ -279,6 +289,10 @@ toConfiguredComponent'
           (package pkg_descr)
           (componentName component)
           (Just (deps, flags))
+      this_iuid =
+        case iuid_flag of
+          Flag iuid -> iuid
+          NoFlag -> mkInstanceUnitId $ mkUnitId $ unComponentId this_cid
       deps =
         [ ann_id aid | m <- Map.elems dep_map, aid <- Map.elems m
         ]
@@ -308,6 +322,7 @@ toConfiguredComponents
   -> Bool -- deterministic
   -> Flag String -- configIPID
   -> Flag ComponentId -- configCID
+  -> Flag InstanceUnitId -- configIUID
   -> PackageDescription
   -> ConfiguredComponentMap
   -> [Component]
@@ -318,6 +333,7 @@ toConfiguredComponents
   deterministic
   ipid_flag
   cid_flag
+  iuid_flag
   pkg_descr
   dep_map
   comps =
@@ -332,6 +348,7 @@ toConfiguredComponents
             deterministic
             ipid_flag
             cid_flag
+            iuid_flag
             m
             component
         return (extendConfiguredComponentMap cc m, cc)

--- a/Cabal/src/Distribution/Backpack/LinkedComponent.hs
+++ b/Cabal/src/Distribution/Backpack/LinkedComponent.hs
@@ -50,6 +50,8 @@ import Text.PrettyPrint (Doc, hang, hsep, quotes, text, vcat, ($+$))
 data LinkedComponent = LinkedComponent
   { lc_ann_id :: AnnotatedId ComponentId
   -- ^ Uniquely identifies linked component
+  , lc_instance_id :: InstanceUnitId
+  -- ^ Uniquely identifies instance (group of components)
   , lc_component :: Component
   -- ^ Corresponds to 'cc_component'.
   , lc_exe_deps :: [AnnotatedId OpenUnitId]
@@ -128,6 +130,7 @@ toLinkedComponent
   pkg_map
   ConfiguredComponent
     { cc_ann_id = aid@AnnotatedId{ann_id = this_cid}
+    , cc_instance_unit_id = iuid
     , cc_component = component
     , cc_exe_deps = exe_deps
     , cc_public = is_public
@@ -378,6 +381,7 @@ toLinkedComponent
     return $
       LinkedComponent
         { lc_ann_id = aid
+        , lc_instance_id = iuid
         , lc_component = component
         , lc_public = is_public
         , -- These must be executables

--- a/Cabal/src/Distribution/Backpack/LinkedComponent.hs
+++ b/Cabal/src/Distribution/Backpack/LinkedComponent.hs
@@ -49,6 +49,8 @@ import Text.PrettyPrint (Doc, hang, hsep, quotes, text, vcat, ($+$))
 data LinkedComponent = LinkedComponent
   { lc_ann_id :: AnnotatedId ComponentId
   -- ^ Uniquely identifies linked component
+  , lc_instance_id :: InstanceUnitId
+  -- ^ Uniquely identifies instance (group of components)
   , lc_component :: Component
   -- ^ Corresponds to 'cc_component'.
   , lc_exe_deps :: [AnnotatedId OpenUnitId]
@@ -127,6 +129,7 @@ toLinkedComponent
   pkg_map
   ConfiguredComponent
     { cc_ann_id = aid@AnnotatedId{ann_id = this_cid}
+    , cc_instance_unit_id = iuid
     , cc_component = component
     , cc_exe_deps = exe_deps
     , cc_public = is_public
@@ -377,6 +380,7 @@ toLinkedComponent
     return $
       LinkedComponent
         { lc_ann_id = aid
+        , lc_instance_id = iuid
         , lc_component = component
         , lc_public = is_public
         , -- These must be executables

--- a/Cabal/src/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ReadyComponent.hs
@@ -55,6 +55,8 @@ import Distribution.Version
 -- for every way these packages can be fully instantiated.
 data ReadyComponent = ReadyComponent
   { rc_ann_id :: AnnotatedId UnitId
+  , rc_instance_id :: InstanceUnitId
+  -- ^ Uniquely identifies instance (group of components)
   , rc_open_uid :: OpenUnitId
   -- ^ The 'OpenUnitId' for this package.  At the moment, this
   -- is used in only one case, which is to determine if an
@@ -319,6 +321,7 @@ toReadyComponents pid_map subst0 comps =
             Just
               ReadyComponent
                 { rc_ann_id = (lc_ann_id lc){ann_id = uid}
+                , rc_instance_id = lc_instance_id lc
                 , rc_open_uid = DefiniteUnitId (unsafeMkDefUnitId uid)
                 , rc_cid = lc_cid lc
                 , rc_component = lc_component lc
@@ -387,6 +390,7 @@ toReadyComponents pid_map subst0 comps =
             Just
               ReadyComponent
                 { rc_ann_id = (lc_ann_id lc){ann_id = uid}
+                , rc_instance_id = lc_instance_id lc
                 , rc_cid = lc_cid lc
                 , rc_open_uid = lc_uid lc
                 , rc_component = lc_component lc

--- a/Cabal/src/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ReadyComponent.hs
@@ -53,6 +53,8 @@ import Distribution.Version
 -- for every way these packages can be fully instantiated.
 data ReadyComponent = ReadyComponent
   { rc_ann_id :: AnnotatedId UnitId
+  , rc_instance_id :: InstanceUnitId
+  -- ^ Uniquely identifies instance (group of components)
   , rc_open_uid :: OpenUnitId
   -- ^ The 'OpenUnitId' for this package.  At the moment, this
   -- is used in only one case, which is to determine if an
@@ -316,6 +318,7 @@ toReadyComponents pid_map subst0 comps =
             Just
               ReadyComponent
                 { rc_ann_id = (lc_ann_id lc){ann_id = uid}
+                , rc_instance_id = lc_instance_id lc
                 , rc_open_uid = DefiniteUnitId (unsafeMkDefUnitId uid)
                 , rc_cid = lc_cid lc
                 , rc_component = lc_component lc
@@ -384,6 +387,7 @@ toReadyComponents pid_map subst0 comps =
             Just
               ReadyComponent
                 { rc_ann_id = (lc_ann_id lc){ann_id = uid}
+                , rc_instance_id = lc_instance_id lc
                 , rc_cid = lc_cid lc
                 , rc_open_uid = lc_uid lc
                 , rc_component = lc_component lc

--- a/Cabal/src/Distribution/Simple/Build.hs
+++ b/Cabal/src/Distribution/Simple/Build.hs
@@ -851,6 +851,7 @@ testSuiteLibV09AsLibAndExe
           , componentIsPublic = False
           , componentIncludes = componentIncludes clbi
           , componentUnitId = componentUnitId clbi
+          , componentInstanceUnitId = mkInstanceUnitId $ componentUnitId clbi
           , componentComponentId = componentComponentId clbi
           , componentInstantiatedWith = []
           , componentCompatPackageName = compat_name

--- a/Cabal/src/Distribution/Simple/Build.hs
+++ b/Cabal/src/Distribution/Simple/Build.hs
@@ -846,6 +846,7 @@ testSuiteLibV09AsLibAndExe
           , componentIsPublic = False
           , componentIncludes = componentIncludes clbi
           , componentUnitId = componentUnitId clbi
+          , componentInstanceUnitId = mkInstanceUnitId $ componentUnitId clbi
           , componentComponentId = componentComponentId clbi
           , componentInstantiatedWith = []
           , componentCompatPackageName = compat_name

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -721,6 +721,10 @@ preConfigurePackage verbHandles cfg g_pkg_descr = do
   when (isJust (flagToMaybe (configCID cfg)) && isNothing mb_cname) $
     dieWithException verbosity ConfigCIDValidForPreComponent
 
+  -- configIUID is only valid for per-component configure
+  when (isJust (flagToMaybe (configIUID cfg)) && isNothing mb_cname) $
+    dieWithException verbosity ConfigIUIDValidForPreComponent
+
   -- Make a data structure describing what components are enabled.
   let enabled :: ComponentRequestedSpec
       enabled =
@@ -1427,7 +1431,7 @@ configureComponents
       -- components (which may build-depends on each other) and form a graph.
       -- From there, we build a ComponentLocalBuildInfo for each of the
       -- components, which lets us actually build each component.
-      ( buildComponents :: [ComponentLocalBuildInfo]
+      ( buildComponents0 :: [ComponentLocalBuildInfo]
         , packageDependsIndex :: InstalledPackageIndex
         ) <-
         runLogProgress verbosity $
@@ -1438,12 +1442,54 @@ configureComponents
             (fromFlagOrDefault False (configDeterministic cfg))
             (configIPID cfg)
             (configCID cfg)
+            (configIUID cfg)
             pkg_descr
             externalPkgDeps
             (configConfigurationsFlags cfg)
             (configInstantiateWith cfg)
             installedPackageSet
             comp
+
+      -- Set a common 'InstanceUnitId' for all components so they can be
+      -- identified as belonging to the same group.
+      --
+      -- If the package has a main library, its 'InstanceUnitId' is used.
+      -- Otherwise, an arbitrary component's 'InstanceUnitId' is used.
+      --
+      -- Only for 'ComponentRequestedSpec'.
+      -- For 'OneComponentRequestedSpec', 'InstanceUnitId' is passed via 'configIUID' flag.
+      let maybeSetCommonInstanceUnitId =
+            case enabled of
+              -- Whole package configure, set InstanceUnitIDs
+              ComponentRequestedSpec{} ->
+                let
+                  setCommonInstanceUnitId
+                    :: [ComponentLocalBuildInfo]
+                    -> [ComponentLocalBuildInfo]
+                  setCommonInstanceUnitId [] = []
+                  setCommonInstanceUnitId [single] = [single]
+                  setCommonInstanceUnitId comps@(fstComp : _rest) =
+                    let
+                      assignOne newId LibComponentLocalBuildInfo{..} = LibComponentLocalBuildInfo{componentInstanceUnitId = newId, ..}
+                      assignOne _newId other = other
+
+                      assignAll newId = map (assignOne newId) comps
+
+                      matchMainLib lclbi@(LibComponentLocalBuildInfo{}) = componentLocalName lclbi == CLibName LMainLibName
+                      matchMainLib _ = False
+                     in
+                      case find matchMainLib comps of
+                        Nothing ->
+                          -- no main library, use arbitrary (first one) for componentInstanceUnitId assignment
+                          assignAll (componentInstanceUnitId fstComp)
+                        Just mainLib ->
+                          assignAll (componentInstanceUnitId mainLib)
+                 in
+                  setCommonInstanceUnitId
+              -- Component configure, InstanceUnitID passed via flag
+              OneComponentRequestedSpec{} -> id
+
+      let buildComponents = maybeSetCommonInstanceUnitId buildComponents0
 
       let buildComponentsMap =
             foldl'

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -725,6 +725,10 @@ preConfigurePackage verbHandles cfg g_pkg_descr = do
   when (isJust (flagToMaybe (configCID cfg)) && isNothing mb_cname) $
     dieWithException verbosity ConfigCIDValidForPreComponent
 
+  -- configIUID is only valid for per-component configure
+  when (isJust (flagToMaybe (configIUID cfg)) && isNothing mb_cname) $
+    dieWithException verbosity ConfigIUIDValidForPreComponent
+
   -- Make a data structure describing what components are enabled.
   let enabled :: ComponentRequestedSpec
       enabled =
@@ -1445,7 +1449,7 @@ configureComponents
       -- components (which may build-depends on each other) and form a graph.
       -- From there, we build a ComponentLocalBuildInfo for each of the
       -- components, which lets us actually build each component.
-      ( buildComponents :: [ComponentLocalBuildInfo]
+      ( buildComponents0 :: [ComponentLocalBuildInfo]
         , packageDependsIndex :: InstalledPackageIndex
         ) <-
         runLogProgress verbosity $
@@ -1456,12 +1460,54 @@ configureComponents
             (fromFlagOrDefault False (configDeterministic cfg))
             (configIPID cfg)
             (configCID cfg)
+            (configIUID cfg)
             pkg_descr
             externalPkgDeps
             (configConfigurationsFlags cfg)
             (configInstantiateWith cfg)
             installedPackageSet
             comp
+
+      -- Set a common 'InstanceUnitId' for all components so they can be
+      -- identified as belonging to the same group.
+      --
+      -- If the package has a main library, its 'InstanceUnitId' is used.
+      -- Otherwise, an arbitrary component's 'InstanceUnitId' is used.
+      --
+      -- Only for 'ComponentRequestedSpec'.
+      -- For 'OneComponentRequestedSpec', 'InstanceUnitId' is passed via 'configIUID' flag.
+      let maybeSetCommonInstanceUnitId =
+            case enabled of
+              -- Whole package configure, set InstanceUnitIDs
+              ComponentRequestedSpec{} ->
+                let
+                  setCommonInstanceUnitId
+                    :: [ComponentLocalBuildInfo]
+                    -> [ComponentLocalBuildInfo]
+                  setCommonInstanceUnitId [] = []
+                  setCommonInstanceUnitId [single] = [single]
+                  setCommonInstanceUnitId comps@(fstComp : _rest) =
+                    let
+                      assignOne newId LibComponentLocalBuildInfo{..} = LibComponentLocalBuildInfo{componentInstanceUnitId = newId, ..}
+                      assignOne _newId other = other
+
+                      assignAll newId = map (assignOne newId) comps
+
+                      matchMainLib lclbi@(LibComponentLocalBuildInfo{}) = componentLocalName lclbi == CLibName LMainLibName
+                      matchMainLib _ = False
+                     in
+                      case find matchMainLib comps of
+                        Nothing ->
+                          -- no main library, use arbitrary (first one) for componentInstanceUnitId assignment
+                          assignAll (componentInstanceUnitId fstComp)
+                        Just mainLib ->
+                          assignAll (componentInstanceUnitId mainLib)
+                 in
+                  setCommonInstanceUnitId
+              -- Component configure, InstanceUnitID passed via flag
+              OneComponentRequestedSpec{} -> id
+
+      let buildComponents = maybeSetCommonInstanceUnitId buildComponents0
 
       let buildComponentsMap =
             foldl'

--- a/Cabal/src/Distribution/Simple/Errors.hs
+++ b/Cabal/src/Distribution/Simple/Errors.hs
@@ -115,6 +115,7 @@ data CabalException
   | NoValidComponent
   | ConfigureEitherSingleOrAll
   | ConfigCIDValidForPreComponent
+  | ConfigIUIDValidForPreComponent
   | SanityCheckForEnableComponents
   | SanityCheckForDynamicStaticLinking
   | UnsupportedLanguages PackageIdentifier CompilerId [String]
@@ -249,6 +250,7 @@ exceptionCode e = case e of
   NoValidComponent{} -> 5680
   ConfigureEitherSingleOrAll{} -> 2001
   ConfigCIDValidForPreComponent{} -> 7006
+  ConfigIUIDValidForPreComponent{} -> 7007
   SanityCheckForEnableComponents{} -> 5004
   SanityCheckForDynamicStaticLinking{} -> 4007
   UnsupportedLanguages{} -> 8074
@@ -510,6 +512,7 @@ exceptionMessage e = case e of
   NoValidComponent -> "No valid component targets found"
   ConfigureEitherSingleOrAll -> "Can only configure either a single component or all of them"
   ConfigCIDValidForPreComponent -> "--cid is only supported for per-component configure"
+  ConfigIUIDValidForPreComponent -> "--iuid is only supported for per-component configure"
   SanityCheckForEnableComponents ->
     "--enable-tests/--enable-benchmarks are incompatible with"
       ++ " explicitly specifying a component to configure."

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -501,6 +501,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
   IPI.InstalledPackageInfo
     { IPI.sourcePackageId = packageId pkg
     , IPI.installedUnitId = componentUnitId clbi
+    , IPI.installedInstanceUnitId = componentInstanceUnitId clbi
     , IPI.installedComponentId_ = componentComponentId clbi
     , IPI.installedSublibs = mempty
     , IPI.instantiatedWith = expectLibraryComponent (maybeComponentInstantiatedWith clbi)

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -502,6 +502,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     { IPI.sourcePackageId = packageId pkg
     , IPI.installedUnitId = componentUnitId clbi
     , IPI.installedComponentId_ = componentComponentId clbi
+    , IPI.installedSublibs = mempty
     , IPI.instantiatedWith = expectLibraryComponent (maybeComponentInstantiatedWith clbi)
     , IPI.sourceLibName = libName lib
     , IPI.compatPackageKey = expectLibraryComponent (maybeComponentCompatPackageKey clbi)

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -497,6 +497,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
   IPI.InstalledPackageInfo
     { IPI.sourcePackageId = packageId pkg
     , IPI.installedUnitId = componentUnitId clbi
+    , IPI.installedInstanceUnitId = componentInstanceUnitId clbi
     , IPI.installedComponentId_ = componentComponentId clbi
     , IPI.installedSublibs = mempty
     , IPI.instantiatedWith = expectLibraryComponent (maybeComponentInstantiatedWith clbi)

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -498,6 +498,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     { IPI.sourcePackageId = packageId pkg
     , IPI.installedUnitId = componentUnitId clbi
     , IPI.installedComponentId_ = componentComponentId clbi
+    , IPI.installedSublibs = mempty
     , IPI.instantiatedWith = expectLibraryComponent (maybeComponentInstantiatedWith clbi)
     , IPI.sourceLibName = libName lib
     , IPI.compatPackageKey = expectLibraryComponent (maybeComponentCompatPackageKey clbi)

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -164,6 +164,8 @@ data ConfigFlags = ConfigFlags
   -- ^ explicit IPID to be used
   , configCID :: Flag ComponentId
   -- ^ explicit CID to be used
+  , configIUID :: Flag InstanceUnitId
+  -- ^ explicit InstanceUnitID to be used
   , configDeterministic :: Flag Bool
   -- ^ be as deterministic as possible
   -- (e.g., invariant over GHC, database,

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -160,6 +160,8 @@ data ConfigFlags = ConfigFlags
   -- ^ explicit IPID to be used
   , configCID :: Flag ComponentId
   -- ^ explicit CID to be used
+  , configIUID :: Flag InstanceUnitId
+  -- ^ explicit InstanceUnitID to be used
   , configDeterministic :: Flag Bool
   -- ^ be as deterministic as possible
   -- (e.g., invariant over GHC, database,

--- a/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
@@ -39,6 +39,9 @@ data ComponentLocalBuildInfo
       , componentUnitId :: UnitId
       -- ^ The computed 'UnitId' which uniquely identifies this
       -- component.  Might be hashed.
+      , componentInstanceUnitId :: InstanceUnitId
+      -- ^ The 'InstanceUnitId' which uniquely identifies package instance
+      -- (equal to componentUnitId for main component, sub components inherit it from main)
       , componentIsIndefinite_ :: Bool
       -- ^ Is this an indefinite component (i.e. has unfilled holes)?
       , componentInstantiatedWith :: [(ModuleName, OpenModule)]

--- a/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
@@ -24,7 +24,6 @@ import Distribution.Types.UnitId
 
 import qualified Distribution.InstalledPackageInfo as Installed
 
--- | The first five fields are common across all algebraic variants.
 data ComponentLocalBuildInfo
   = LibComponentLocalBuildInfo
       { componentLocalName :: ComponentName

--- a/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
@@ -23,7 +23,6 @@ import Distribution.Types.UnitId
 
 import qualified Distribution.InstalledPackageInfo as Installed
 
--- | The first five fields are common across all algebraic variants.
 data ComponentLocalBuildInfo
   = LibComponentLocalBuildInfo
       { componentLocalName :: ComponentName

--- a/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
@@ -38,6 +38,9 @@ data ComponentLocalBuildInfo
       , componentUnitId :: UnitId
       -- ^ The computed 'UnitId' which uniquely identifies this
       -- component.  Might be hashed.
+      , componentInstanceUnitId :: InstanceUnitId
+      -- ^ The 'InstanceUnitId' which uniquely identifies package instance
+      -- (equal to componentUnitId for main component, sub components inherit it from main)
       , componentIsIndefinite_ :: Bool
       -- ^ Is this an indefinite component (i.e. has unfilled holes)?
       , componentInstantiatedWith :: [(ModuleName, OpenModule)]

--- a/cabal-install-solver/src/Distribution/Solver/Modular/ConfiguredConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/ConfiguredConversion.hs
@@ -5,8 +5,11 @@ module Distribution.Solver.Modular.ConfiguredConversion
 import Data.Maybe
 import Prelude hiding (pi)
 import Data.Either (partitionEithers)
+import Data.Set (Set)
+import qualified Data.Set as S
 
 import Distribution.Package (UnitId, packageId)
+import Distribution.Types.InstalledPackageInfo (InstalledPackageInfo(installedSublibs))
 
 import qualified Distribution.Simple.PackageIndex as SI
 
@@ -30,9 +33,10 @@ convCP :: SI.InstalledPackageIndex ->
           CP QPN -> ResolverPackage loc
 convCP iidx sidx (CP qpi fa es ds) =
   case convPI qpi of
-    Left  pi -> PreExisting $
+    Left (pi, subPis) ->
+                PreExisting $
                   InstSolverPackage {
-                    instSolverPkgIPI = fromJust $ SI.lookupUnitId iidx pi,
+                    instSolverPkgIPI = addSublibs iidx subPis $ fromJust $ SI.lookupUnitId iidx pi,
                     instSolverPkgLibDeps = fmap fst ds',
                     instSolverPkgExeDeps = fmap snd ds'
                   }
@@ -50,15 +54,29 @@ convCP iidx sidx (CP qpi fa es ds) =
     ds' :: ComponentDeps ([SolverId] {- lib -}, [SolverId] {- exe -})
     ds' = fmap (partitionEithers . map convConfId) ds
 
-convPI :: PI QPN -> Either UnitId PackageId
-convPI (PI _ (I _ (Inst pi))) = Left pi
-convPI pi                     = Right (packageId (either id id (convConfId pi)))
+    addSublibs
+      :: SI.InstalledPackageIndex
+      -> Set UnitId
+      -> InstalledPackageInfo
+      -> InstalledPackageInfo
+    addSublibs idx subPis info =
+      info { installedSublibs =
+               mapMaybe
+                 (SI.lookupUnitId idx)
+                 (S.toList subPis)
+           }
+
+convPI :: PI QPN -> Either (UnitId, Set UnitId) PackageId
+convPI (PI _ (I _ (Inst pi)))             = Left (pi, mempty)
+convPI (PI _ (I _ (InstGroup pi subPis))) = Left (pi, subPis)
+convPI pi                                 = Right (packageId (either id id (convConfId pi)))
 
 convConfId :: PI QPN -> Either SolverId {- is lib -} SolverId {- is exe -}
 convConfId (PI (Q (PackagePath _ q) pn) (I v loc)) =
     case loc of
         Inst pi -> Left (PreExistingId sourceId pi)
-        _otherwise
+        InstGroup pi _subPis -> Left (PreExistingId sourceId pi)
+        InRepo
           | QualExe _ pn' <- q
           -- NB: the dependencies of the executable are also
           -- qualified.  So the way to tell if this is an executable

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Distribution.Solver.Modular.Dependency (
     -- * Variables
     Var(..)
@@ -94,6 +95,8 @@ data FlaggedDep qpn =
     -- | Dependencies which are always enabled, for the component 'comp'.
   | Simple (LDep qpn) Component
 
+deriving instance Show qpn => Show (FlaggedDep qpn)
+
 -- | Conservatively flatten out flagged dependencies
 --
 -- NOTE: We do not filter out duplicates.
@@ -115,6 +118,7 @@ type FalseFlaggedDeps qpn = FlaggedDeps qpn
 -- depending; having a 'Functor' instance makes bugs where we don't distinguish
 -- these two far too likely. (By rights 'LDep' ought to have two type variables.)
 data LDep qpn = LDep (DependencyReason qpn) (Dep qpn)
+  deriving Show
 
 -- | A dependency (constraint) associates a package name with a constrained
 -- instance. It can also represent other types of dependencies, such as
@@ -123,7 +127,7 @@ data Dep qpn = Dep (PkgComponent qpn) CI  -- ^ dependency on a package component
              | Ext Extension              -- ^ dependency on a language extension
              | Lang Language              -- ^ dependency on a language version
              | Pkg PkgconfigName PkgconfigVersionRange  -- ^ dependency on a pkg-config package
-  deriving Functor
+  deriving (Functor, Show)
 
 -- | An exposed component within a package. This type is used to represent
 -- build-depends and build-tool-depends dependencies.

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Distribution.Solver.Modular.Dependency (
     -- * Variables
     Var(..)
@@ -93,6 +94,8 @@ data FlaggedDep qpn =
     -- | Dependencies which are always enabled, for the component 'comp'.
   | Simple (LDep qpn) Component
 
+deriving instance Show qpn => Show (FlaggedDep qpn)
+
 -- | Conservatively flatten out flagged dependencies
 --
 -- NOTE: We do not filter out duplicates.
@@ -114,6 +117,7 @@ type FalseFlaggedDeps qpn = FlaggedDeps qpn
 -- depending; having a 'Functor' instance makes bugs where we don't distinguish
 -- these two far too likely. (By rights 'LDep' ought to have two type variables.)
 data LDep qpn = LDep (DependencyReason qpn) (Dep qpn)
+  deriving Show
 
 -- | A dependency (constraint) associates a package name with a constrained
 -- instance. It can also represent other types of dependencies, such as
@@ -122,7 +126,7 @@ data Dep qpn = Dep (PkgComponent qpn) CI  -- ^ dependency on a package component
              | Ext Extension              -- ^ dependency on a language extension
              | Lang Language              -- ^ dependency on a language version
              | Pkg PkgconfigName PkgconfigVersionRange  -- ^ dependency on a pkg-config package
-  deriving Functor
+  deriving (Functor, Show)
 
 -- | An exposed component within a package. This type is used to represent
 -- build-depends and build-tool-depends dependencies.

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Index.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Index.hs
@@ -36,6 +36,7 @@ data PInfo = PInfo (FlaggedDeps PN)
                    (Map ExposedComponent ComponentInfo)
                    FlagInfo
                    (Maybe FailReason)
+  deriving Show
 
 -- | Info associated with each library and executable in a package instance.
 data ComponentInfo = ComponentInfo {

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -19,8 +19,6 @@ import Distribution.Types.ExeDependency              -- from Cabal
 import Distribution.Types.PkgconfigDependency        -- from Cabal
 import Distribution.Types.ComponentName              -- from Cabal
 import Distribution.Types.CondTree                   -- from Cabal
-import Distribution.Types.MungedPackageId            -- from Cabal
-import Distribution.Types.MungedPackageName          -- from Cabal
 import Distribution.PackageDescription               -- from Cabal
 import Distribution.PackageDescription.Configuration
 import qualified Distribution.Simple.PackageIndex as SI
@@ -145,8 +143,7 @@ convIPI' (ShadowPkgs sip) idx =
     -- apply shadowing whenever there are multiple installed packages with
     -- the same version
     [ maybeShadow (convIP idx pkg)
-    -- IMPORTANT to get internal libraries. See
-    -- Note [Index conversion with internal libraries]
+    -- IMPORTANT to use @allPackagesBySourcePackageIdAndLibName@ to get internal libraries
     | (_, pkgs) <- SI.allPackagesBySourcePackageIdAndLibName idx
     , (maybeShadow, pkg) <- zip (id : repeat shadow) pkgs ]
   where
@@ -158,14 +155,10 @@ convIPI' (ShadowPkgs sip) idx =
 
 -- | Extract/recover the package ID from an installed package info, and convert it to a solver's I.
 convId :: IPI.InstalledPackageInfo -> (PN, I)
-convId ipi = (pn, I ver $ Inst $ IPI.installedUnitId ipi)
---  where (MungedPackageId (MungedPackageName pn _) ver) = mungedId ipi
-  where MungedPackageId mpn ver = mungedId ipi
-        -- HACK. See Note [Index conversion with internal libraries]
-        pn = case IPI.libVisibility ipi of
---          LibraryVisibilityPrivate -> encodeCompatPackageName mpn
-          LibraryVisibilityPrivate -> pkgName $ IPI.sourcePackageId ipi
-          LibraryVisibilityPublic -> pkgName $ IPI.sourcePackageId ipi
+convId ipi = ( pkgName spi
+             , I (pkgVersion spi) $ Inst $ IPI.installedUnitId ipi
+             )
+ where spi = IPI.sourcePackageId ipi
 
 -- | Convert a single installed package into the solver-specific format.
 convIP
@@ -190,33 +183,6 @@ convIP idx ipi =
   -- primary libs anyways
   comp = componentNameToComponent $ CLibName $ IPI.sourceLibName ipi
 -- TODO: Installed packages should also store their encapsulations!
-
--- Note [Index conversion with internal libraries]
--- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--- Something very interesting happens when we have internal libraries
--- in our index.  In this case, we maybe have p-0.1, which itself
--- depends on the internal library p-internal ALSO from p-0.1.
--- Here's the danger:
---
---      - If we treat both of these packages as having PN "p",
---        then the solver will try to pick one or the other,
---        but never both.
---
---      - If we drop the internal packages, now p-0.1 has a
---        dangling dependency on an "installed" package we know
---        nothing about. Oops.
---
--- An expedient hack is to put p-internal into cabal-install's
--- index as a MUNGED package name, so that it doesn't conflict
--- with anyone else (except other instances of itself).  But
--- yet, we ought NOT to say that PNs in the solver are munged
--- package names, because they're not; for source packages,
--- we really will never see munged package names.
---
--- The tension here is that the installed package index is actually
--- per library, but the solver is per package.  We need to smooth
--- it over, and munging the package names is a pretty good way to
--- do it.
 
 -- | Convert dependencies specified by an installed package id into
 -- flagged dependencies of the solver.

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -68,18 +68,19 @@ convPIs os arch comp constraints sip strfl solveExes iidx sidx =
 -- merge their sub-libraries and dependencies so we get
 -- a similar looking package as if it came from repository.
 groupInstalledSublibs
-  :: [(PN, I, PInfo)]
+  :: [(PN, I, InstanceUnitId, PInfo)]
   -> [(PN, I, PInfo)]
 groupInstalledSublibs xs =
     remapPInfoDepsToInstGroups
   $ M.elems
+  $ M.map (\(pn, i, _instId, pInfo) -> (pn, i, pInfo))
   $ foldl
-      (\acc x@(pn, I ver _, _) ->
+      (\acc x@(pn, I ver _, instId, _) ->
         M.insertWith
-          (\(_, newI, newInfo) (_, oldI, oldInfo) ->
-            (pn, mergeIs oldI newI, mergeInfos oldInfo newInfo)
+          (\(_, newI, newInstId, newInfo) (_, oldI, _oldInstId, oldInfo) ->
+            (pn, mergeIs oldI newI, newInstId, mergeInfos oldInfo newInfo)
           )
-          (pn, ver)
+          (pn, ver, instId)
           x
           acc
       )
@@ -138,7 +139,7 @@ groupInstalledSublibs xs =
 
 -- | Convert a Cabal installed package index to the simpler,
 -- more uniform index format of the solver.
-convIPI' :: ShadowPkgs -> SI.InstalledPackageIndex -> [(PN, I, PInfo)]
+convIPI' :: ShadowPkgs -> SI.InstalledPackageIndex -> [(PN, I, InstanceUnitId, PInfo)]
 convIPI' (ShadowPkgs sip) idx =
     -- apply shadowing whenever there are multiple installed packages with
     -- the same version
@@ -149,8 +150,8 @@ convIPI' (ShadowPkgs sip) idx =
   where
 
     -- shadowing is recorded in the package info
-    shadow (pn, i, PInfo fdeps comps fds _)
-      | sip = (pn, i, PInfo fdeps comps fds (Just Shadowed))
+    shadow (pn, i, instId, PInfo fdeps comps fds _)
+      | sip = (pn, i, instId, PInfo fdeps comps fds (Just Shadowed))
     shadow x                                     = x
 
 -- | Extract/recover the package ID from an installed package info, and convert it to a solver's I.
@@ -164,11 +165,11 @@ convId ipi = ( pkgName spi
 convIP
   :: SI.InstalledPackageIndex
   -> IPI.InstalledPackageInfo
-  -> (PN, I, PInfo)
+  -> (PN, I, InstanceUnitId, PInfo)
 convIP idx ipi =
   case traverse (convIPId (DependencyReason pn M.empty S.empty) comp idx) (IPI.depends ipi) of
-        Left u    -> (pn, i, PInfo [] M.empty M.empty (Just (Broken u)))
-        Right fds -> (pn, i, PInfo fds components M.empty Nothing)
+        Left u    -> (pn, i, IPI.installedInstanceUnitId ipi, PInfo [] M.empty M.empty (Just (Broken u)))
+        Right fds -> (pn, i, IPI.installedInstanceUnitId ipi, PInfo fds components M.empty Nothing)
  where
   components =
       M.singleton (ExposedLib $ IPI.sourceLibName ipi)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -6,6 +6,7 @@ import Distribution.Solver.Compat.Prelude
 import Prelude ()
 
 import qualified Data.List as L
+import qualified Data.Maybe
 import qualified Data.Map.Strict as M
 import qualified Distribution.Compat.NonEmptySet as NonEmptySet
 import qualified Data.Set as S
@@ -62,7 +63,80 @@ convPIs :: OS -> Arch -> CompilerInfo -> Map PN [LabeledPackageConstraint]
         -> Index
 convPIs os arch comp constraints sip strfl solveExes iidx sidx =
   mkIndex $
-  convIPI' sip iidx ++ convSPI' os arch comp constraints strfl solveExes sidx
+       groupInstalledSublibs (convIPI' sip iidx)
+    ++ (convSPI' os arch comp constraints strfl solveExes sidx)
+
+-- | Group packages with the same package name and version,
+-- merge their sub-libraries and dependencies so we get
+-- a similar looking package as if it came from repository.
+groupInstalledSublibs
+  :: [(PN, I, PInfo)]
+  -> [(PN, I, PInfo)]
+groupInstalledSublibs xs =
+    remapPInfoDepsToInstGroups
+  $ M.elems
+  $ foldl
+      (\acc x@(pn, I ver _, _) ->
+        M.insertWith
+          (\(_, newI, newInfo) (_, oldI, oldInfo) ->
+            (pn, mergeIs oldI newI, mergeInfos oldInfo newInfo)
+          )
+          (pn, ver)
+          x
+          acc
+      )
+      M.empty
+      xs
+  where
+  -- flags are probably safe to ignore here as they are fixed for installed anyway
+  mergeInfos :: PInfo -> PInfo -> PInfo
+  mergeInfos (PInfo deps comps flagNfo fr) (PInfo deps' comps' _flagNfo _fr) =
+    PInfo
+      (deps <> deps')
+      (comps <> comps')
+      flagNfo
+      fr
+
+  -- this pass creates InstGroup(s)
+  mergeIs :: I -> I -> I
+  mergeIs (I ver (Inst pId)) (I _ver (Inst subPId)) =
+    I ver (InstGroup pId (S.singleton subPId))
+  mergeIs (I ver (InstGroup pId subPIds)) (I _ver (Inst subPId)) =
+    I ver (InstGroup pId (S.insert subPId subPIds))
+  -- XXX/srk, can't really happen as they are lexicographically ordered
+  mergeIs a b = error $ "Absurd mergeIs" <> show (a,b)
+
+  -- now some deps from convIP/convIPId pass refer to Inst when they should refer to InstGroup
+  remapPInfoDepsToInstGroups :: [(PN, I, PInfo)] -> [(PN, I, PInfo)]
+  remapPInfoDepsToInstGroups ps =
+    let
+      -- Inst -> InstGroup mapping, other Loc(s) are preserved
+      locMap :: Map Loc Loc
+      locMap =
+          M.fromList
+        $ concatMap
+            (\(_pn, I _ver loc, _pInfo) -> case loc of
+              ip@(Inst _pId) ->
+                pure (ip, ip)
+              g@(InstGroup pId subPIds) ->
+                (Inst pId, g):(map (\x -> (Inst x, g)) (S.toList subPIds))
+              InRepo ->
+                pure (InRepo, InRepo)
+            )
+            ps
+
+      remapDep :: FlaggedDep PN -> FlaggedDep PN
+      remapDep (D.Simple (LDep dr (Dep depComp (Fixed (I ver loc)))) comp) =
+        let newLoc = Data.Maybe.fromJust $ M.lookup loc locMap
+        in  (D.Simple (LDep dr (Dep depComp (Fixed (I ver newLoc)))) comp)
+      remapDep x = x
+
+    in map
+        (\(pn, i, PInfo deps comps flagNfo fr) ->
+          (pn, i, PInfo (map remapDep deps) comps flagNfo fr)
+        )
+        ps
+
 
 -- | Convert a Cabal installed package index to the simpler,
 -- more uniform index format of the solver.
@@ -85,20 +159,26 @@ convIPI' (ShadowPkgs sip) idx =
 -- | Extract/recover the package ID from an installed package info, and convert it to a solver's I.
 convId :: IPI.InstalledPackageInfo -> (PN, I)
 convId ipi = (pn, I ver $ Inst $ IPI.installedUnitId ipi)
+--  where (MungedPackageId (MungedPackageName pn _) ver) = mungedId ipi
   where MungedPackageId mpn ver = mungedId ipi
         -- HACK. See Note [Index conversion with internal libraries]
-        pn = encodeCompatPackageName mpn
+        pn = case IPI.libVisibility ipi of
+--          LibraryVisibilityPrivate -> encodeCompatPackageName mpn
+          LibraryVisibilityPrivate -> pkgName $ IPI.sourcePackageId ipi
+          LibraryVisibilityPublic -> pkgName $ IPI.sourcePackageId ipi
 
 -- | Convert a single installed package into the solver-specific format.
-convIP :: SI.InstalledPackageIndex -> IPI.InstalledPackageInfo -> (PN, I, PInfo)
+convIP
+  :: SI.InstalledPackageIndex
+  -> IPI.InstalledPackageInfo
+  -> (PN, I, PInfo)
 convIP idx ipi =
   case traverse (convIPId (DependencyReason pn M.empty S.empty) comp idx) (IPI.depends ipi) of
         Left u    -> (pn, i, PInfo [] M.empty M.empty (Just (Broken u)))
         Right fds -> (pn, i, PInfo fds components M.empty Nothing)
  where
-  -- TODO: Handle sub-libraries and visibility.
   components =
-      M.singleton (ExposedLib LMainLibName)
+      M.singleton (ExposedLib $ IPI.sourceLibName ipi)
                   ComponentInfo {
                       compIsVisible = IsVisible True
                     , compIsBuildable = IsBuildable True
@@ -144,12 +224,16 @@ convIP idx ipi =
 -- May return Nothing if the package can't be found in the index. That
 -- indicates that the original package having this dependency is broken
 -- and should be ignored.
-convIPId :: DependencyReason PN -> Component -> SI.InstalledPackageIndex -> UnitId -> Either UnitId (FlaggedDep PN)
+convIPId :: DependencyReason PN
+  -> Component
+  -> SI.InstalledPackageIndex
+  -> UnitId
+  -> Either UnitId (FlaggedDep PN)
 convIPId dr comp idx ipid =
   case SI.lookupUnitId idx ipid of
     Nothing  -> Left ipid
     Just ipi -> let (pn, i) = convId ipi
-                    name = ExposedLib LMainLibName  -- TODO: Handle sub-libraries.
+                    name = ExposedLib $ IPI.sourceLibName ipi
                 in  Right (D.Simple (LDep dr (Dep (PkgComponent pn name) (Fixed i))) comp)
                 -- NB: something we pick up from the
                 -- InstalledPackageIndex is NEVER an executable

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -62,7 +62,7 @@ convPIs :: OS -> Arch -> CompilerInfo -> Map PN [LabeledPackageConstraint]
 convPIs os arch comp constraints sip strfl solveExes iidx sidx =
   mkIndex $
        groupInstalledSublibs (convIPI' sip iidx)
-    ++ (convSPI' os arch comp constraints strfl solveExes sidx)
+    ++ convSPI' os arch comp constraints strfl solveExes sidx
 
 -- | Group packages with the same package name and version,
 -- merge their sub-libraries and dependencies so we get
@@ -118,7 +118,7 @@ groupInstalledSublibs xs =
               ip@(Inst _pId) ->
                 pure (ip, ip)
               g@(InstGroup pId subPIds) ->
-                (Inst pId, g):(map (\x -> (Inst x, g)) (S.toList subPIds))
+                (Inst pId, g) : map (\x -> (Inst x, g)) (S.toList subPIds)
               InRepo ->
                 pure (InRepo, InRepo)
             )
@@ -127,7 +127,7 @@ groupInstalledSublibs xs =
       remapDep :: FlaggedDep PN -> FlaggedDep PN
       remapDep (D.Simple (LDep dr (Dep depComp (Fixed (I ver loc)))) comp) =
         let newLoc = Data.Maybe.fromJust $ M.lookup loc locMap
-        in  (D.Simple (LDep dr (Dep depComp (Fixed (I ver newLoc)))) comp)
+         in D.Simple (LDep dr (Dep depComp (Fixed (I ver newLoc)))) comp
       remapDep x = x
 
     in map

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -19,8 +19,6 @@ import Distribution.Types.ExeDependency              -- from Cabal
 import Distribution.Types.PkgconfigDependency        -- from Cabal
 import Distribution.Types.ComponentName              -- from Cabal
 import Distribution.Types.CondTree                   -- from Cabal
-import Distribution.Types.MungedPackageId            -- from Cabal
-import Distribution.Types.MungedPackageName          -- from Cabal
 import Distribution.PackageDescription               -- from Cabal
 import Distribution.PackageDescription.Configuration
 import qualified Distribution.Simple.PackageIndex as SI
@@ -144,8 +142,7 @@ convIPI' (ShadowPkgs sip) idx =
     -- apply shadowing whenever there are multiple installed packages with
     -- the same version
     [ maybeShadow (convIP idx pkg)
-    -- IMPORTANT to get internal libraries. See
-    -- Note [Index conversion with internal libraries]
+    -- IMPORTANT to use @allPackagesBySourcePackageIdAndLibName@ to get internal libraries
     | (_, pkgs) <- SI.allPackagesBySourcePackageIdAndLibName idx
     , (maybeShadow, pkg) <- zip (id : repeat shadow) pkgs ]
   where
@@ -157,14 +154,10 @@ convIPI' (ShadowPkgs sip) idx =
 
 -- | Extract/recover the package ID from an installed package info, and convert it to a solver's I.
 convId :: IPI.InstalledPackageInfo -> (PN, I)
-convId ipi = (pn, I ver $ Inst $ IPI.installedUnitId ipi)
---  where (MungedPackageId (MungedPackageName pn _) ver) = mungedId ipi
-  where MungedPackageId mpn ver = mungedId ipi
-        -- HACK. See Note [Index conversion with internal libraries]
-        pn = case IPI.libVisibility ipi of
---          LibraryVisibilityPrivate -> encodeCompatPackageName mpn
-          LibraryVisibilityPrivate -> pkgName $ IPI.sourcePackageId ipi
-          LibraryVisibilityPublic -> pkgName $ IPI.sourcePackageId ipi
+convId ipi = ( pkgName spi
+             , I (pkgVersion spi) $ Inst $ IPI.installedUnitId ipi
+             )
+ where spi = IPI.sourcePackageId ipi
 
 -- | Convert a single installed package into the solver-specific format.
 convIP
@@ -189,33 +182,6 @@ convIP idx ipi =
   -- primary libs anyways
   comp = componentNameToComponent $ CLibName $ IPI.sourceLibName ipi
 -- TODO: Installed packages should also store their encapsulations!
-
--- Note [Index conversion with internal libraries]
--- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--- Something very interesting happens when we have internal libraries
--- in our index.  In this case, we maybe have p-0.1, which itself
--- depends on the internal library p-internal ALSO from p-0.1.
--- Here's the danger:
---
---      - If we treat both of these packages as having PN "p",
---        then the solver will try to pick one or the other,
---        but never both.
---
---      - If we drop the internal packages, now p-0.1 has a
---        dangling dependency on an "installed" package we know
---        nothing about. Oops.
---
--- An expedient hack is to put p-internal into cabal-install's
--- index as a MUNGED package name, so that it doesn't conflict
--- with anyone else (except other instances of itself).  But
--- yet, we ought NOT to say that PNs in the solver are munged
--- package names, because they're not; for source packages,
--- we really will never see munged package names.
---
--- The tension here is that the installed package index is actually
--- per library, but the solver is per package.  We need to smooth
--- it over, and munging the package names is a pretty good way to
--- do it.
 
 -- | Convert dependencies specified by an installed package id into
 -- flagged dependencies of the solver.

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -68,18 +68,19 @@ convPIs os arch comp constraints sip strfl solveExes iidx sidx =
 -- merge their sub-libraries and dependencies so we get
 -- a similar looking package as if it came from repository.
 groupInstalledSublibs
-  :: [(PN, I, PInfo)]
+  :: [(PN, I, InstanceUnitId, PInfo)]
   -> [(PN, I, PInfo)]
 groupInstalledSublibs xs =
     remapPInfoDepsToInstGroups
   $ M.elems
+  $ M.map (\(pn, i, _instId, pInfo) -> (pn, i, pInfo))
   $ foldl
-      (\acc x@(pn, I ver _, _) ->
+      (\acc x@(pn, I ver _, instId, _) ->
         M.insertWith
-          (\(_, newI, newInfo) (_, oldI, oldInfo) ->
-            (pn, mergeIs oldI newI, mergeInfos oldInfo newInfo)
+          (\(_, newI, newInstId, newInfo) (_, oldI, _oldInstId, oldInfo) ->
+            (pn, mergeIs oldI newI, newInstId, mergeInfos oldInfo newInfo)
           )
-          (pn, ver)
+          (pn, ver, instId)
           x
           acc
       )
@@ -137,7 +138,7 @@ groupInstalledSublibs xs =
 
 -- | Convert a Cabal installed package index to the simpler,
 -- more uniform index format of the solver.
-convIPI' :: ShadowPkgs -> SI.InstalledPackageIndex -> [(PN, I, PInfo)]
+convIPI' :: ShadowPkgs -> SI.InstalledPackageIndex -> [(PN, I, InstanceUnitId, PInfo)]
 convIPI' (ShadowPkgs sip) idx =
     -- apply shadowing whenever there are multiple installed packages with
     -- the same version
@@ -148,8 +149,8 @@ convIPI' (ShadowPkgs sip) idx =
   where
 
     -- shadowing is recorded in the package info
-    shadow (pn, i, PInfo fdeps comps fds _)
-      | sip = (pn, i, PInfo fdeps comps fds (Just Shadowed))
+    shadow (pn, i, instId, PInfo fdeps comps fds _)
+      | sip = (pn, i, instId, PInfo fdeps comps fds (Just Shadowed))
     shadow x                                     = x
 
 -- | Extract/recover the package ID from an installed package info, and convert it to a solver's I.
@@ -163,11 +164,11 @@ convId ipi = ( pkgName spi
 convIP
   :: SI.InstalledPackageIndex
   -> IPI.InstalledPackageInfo
-  -> (PN, I, PInfo)
+  -> (PN, I, InstanceUnitId, PInfo)
 convIP idx ipi =
   case traverse (convIPId (DependencyReason pn M.empty S.empty) comp idx) (IPI.depends ipi) of
-        Left u    -> (pn, i, PInfo [] M.empty M.empty (Just (Broken u)))
-        Right fds -> (pn, i, PInfo fds components M.empty Nothing)
+        Left u    -> (pn, i, IPI.installedInstanceUnitId ipi, PInfo [] M.empty M.empty (Just (Broken u)))
+        Right fds -> (pn, i, IPI.installedInstanceUnitId ipi, PInfo fds components M.empty Nothing)
  where
   components =
       M.singleton (ExposedLib $ IPI.sourceLibName ipi)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -6,6 +6,7 @@ import Distribution.Solver.Compat.Prelude
 import Prelude ()
 
 import qualified Data.List as L
+import qualified Data.Maybe
 import qualified Data.Map.Strict as M
 import qualified Distribution.Compat.NonEmptySet as NonEmptySet
 import qualified Data.Set as S
@@ -62,7 +63,79 @@ convPIs :: OS -> Arch -> CompilerInfo -> Map PN [LabeledPackageConstraint]
         -> Index
 convPIs os arch comp constraints sip strfl solveExes iidx sidx =
   mkIndex $
-  convIPI' sip iidx ++ convSPI' os arch comp constraints strfl solveExes sidx
+       groupInstalledSublibs (convIPI' sip iidx)
+    ++ (convSPI' os arch comp constraints strfl solveExes sidx)
+
+-- | Group packages with the same package name and version,
+-- merge their sub-libraries and dependencies so we get
+-- a similar looking package as if it came from repository.
+groupInstalledSublibs
+  :: [(PN, I, PInfo)]
+  -> [(PN, I, PInfo)]
+groupInstalledSublibs xs =
+    remapPInfoDepsToInstGroups
+  $ M.elems
+  $ foldl
+      (\acc x@(pn, I ver _, _) ->
+        M.insertWith
+          (\(_, newI, newInfo) (_, oldI, oldInfo) ->
+            (pn, mergeIs oldI newI, mergeInfos oldInfo newInfo)
+          )
+          (pn, ver)
+          x
+          acc
+      )
+      M.empty
+      xs
+  where
+  -- flags are probably safe to ignore here as they are fixed for installed anyway
+  mergeInfos :: PInfo -> PInfo -> PInfo
+  mergeInfos (PInfo deps comps flagNfo fr) (PInfo deps' comps' _flagNfo _fr) =
+    PInfo
+      (deps <> deps')
+      (comps <> comps')
+      flagNfo
+      fr
+
+  -- this pass creates InstGroup(s)
+  mergeIs :: I -> I -> I
+  mergeIs (I ver (Inst pId)) (I _ver (Inst subPId)) =
+    I ver (InstGroup pId (S.singleton subPId))
+  mergeIs (I ver (InstGroup pId subPIds)) (I _ver (Inst subPId)) =
+    I ver (InstGroup pId (S.insert subPId subPIds))
+  -- can't really happen as they are lexicographically ordered
+  mergeIs a b = error $ "Absurd mergeIs " <> show (a,b)
+
+  -- now some deps from convIP/convIPId pass refer to Inst when they should refer to InstGroup
+  remapPInfoDepsToInstGroups :: [(PN, I, PInfo)] -> [(PN, I, PInfo)]
+  remapPInfoDepsToInstGroups ps =
+    let
+      -- Inst -> InstGroup mapping, other Loc(s) are preserved
+      locMap :: Map Loc Loc
+      locMap =
+          M.fromList
+        $ concatMap
+            (\(_pn, I _ver loc, _pInfo) -> case loc of
+              ip@(Inst _pId) ->
+                pure (ip, ip)
+              g@(InstGroup pId subPIds) ->
+                (Inst pId, g):(map (\x -> (Inst x, g)) (S.toList subPIds))
+              InRepo ->
+                pure (InRepo, InRepo)
+            )
+            ps
+
+      remapDep :: FlaggedDep PN -> FlaggedDep PN
+      remapDep (D.Simple (LDep dr (Dep depComp (Fixed (I ver loc)))) comp) =
+        let newLoc = Data.Maybe.fromJust $ M.lookup loc locMap
+        in  (D.Simple (LDep dr (Dep depComp (Fixed (I ver newLoc)))) comp)
+      remapDep x = x
+
+    in map
+        (\(pn, i, PInfo deps comps flagNfo fr) ->
+          (pn, i, PInfo (map remapDep deps) comps flagNfo fr)
+        )
+        ps
 
 -- | Convert a Cabal installed package index to the simpler,
 -- more uniform index format of the solver.
@@ -85,20 +158,26 @@ convIPI' (ShadowPkgs sip) idx =
 -- | Extract/recover the package ID from an installed package info, and convert it to a solver's I.
 convId :: IPI.InstalledPackageInfo -> (PN, I)
 convId ipi = (pn, I ver $ Inst $ IPI.installedUnitId ipi)
+--  where (MungedPackageId (MungedPackageName pn _) ver) = mungedId ipi
   where MungedPackageId mpn ver = mungedId ipi
         -- HACK. See Note [Index conversion with internal libraries]
-        pn = encodeCompatPackageName mpn
+        pn = case IPI.libVisibility ipi of
+--          LibraryVisibilityPrivate -> encodeCompatPackageName mpn
+          LibraryVisibilityPrivate -> pkgName $ IPI.sourcePackageId ipi
+          LibraryVisibilityPublic -> pkgName $ IPI.sourcePackageId ipi
 
 -- | Convert a single installed package into the solver-specific format.
-convIP :: SI.InstalledPackageIndex -> IPI.InstalledPackageInfo -> (PN, I, PInfo)
+convIP
+  :: SI.InstalledPackageIndex
+  -> IPI.InstalledPackageInfo
+  -> (PN, I, PInfo)
 convIP idx ipi =
   case traverse (convIPId (DependencyReason pn M.empty S.empty) comp idx) (IPI.depends ipi) of
         Left u    -> (pn, i, PInfo [] M.empty M.empty (Just (Broken u)))
         Right fds -> (pn, i, PInfo fds components M.empty Nothing)
  where
-  -- TODO: Handle sub-libraries and visibility.
   components =
-      M.singleton (ExposedLib LMainLibName)
+      M.singleton (ExposedLib $ IPI.sourceLibName ipi)
                   ComponentInfo {
                       compIsVisible = IsVisible True
                     , compIsBuildable = IsBuildable True
@@ -144,12 +223,16 @@ convIP idx ipi =
 -- May return Nothing if the package can't be found in the index. That
 -- indicates that the original package having this dependency is broken
 -- and should be ignored.
-convIPId :: DependencyReason PN -> Component -> SI.InstalledPackageIndex -> UnitId -> Either UnitId (FlaggedDep PN)
+convIPId :: DependencyReason PN
+  -> Component
+  -> SI.InstalledPackageIndex
+  -> UnitId
+  -> Either UnitId (FlaggedDep PN)
 convIPId dr comp idx ipid =
   case SI.lookupUnitId idx ipid of
     Nothing  -> Left ipid
     Just ipi -> let (pn, i) = convId ipi
-                    name = ExposedLib LMainLibName  -- TODO: Handle sub-libraries.
+                    name = ExposedLib $ IPI.sourceLibName ipi
                 in  Right (D.Simple (LDep dr (Dep (PkgComponent pn name) (Fixed i))) comp)
                 -- NB: something we pick up from the
                 -- InstalledPackageIndex is NEVER an executable

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -289,7 +289,7 @@ showOptions q [x] = showOption q x
 showOptions q xs = showQPN q ++ "; " ++ (L.intercalate ", "
   [if isJust linkedTo
     then showOption q x
-    else showI i -- Don't show the package, just the version
+    else showI q i -- Don't show the package, just the version
   | x@(POption i linkedTo) <- xs
   ])
 
@@ -351,7 +351,7 @@ showConflictingDep (ConflictingDep dr (PkgComponent qpn comp) ci) =
                        ExposedLib (LSubLibName lib) -> " (lib " ++ unUnqualComponentName lib ++ ")"
   in case ci of
        Fixed i        -> (if qpn /= qpn' then showDependencyReason dr ++ " => " else "") ++
-                         showQPN qpn ++ componentStr ++ "==" ++ showI i
+                         showQPN qpn ++ componentStr ++ "==" ++ showI qpn i
        Constrained vr -> showDependencyReason dr ++ " => " ++ showQPN qpn ++
                          componentStr ++ showVR vr
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -287,7 +287,7 @@ showOptions q [x] = showOption q x
 showOptions q xs = showQPN q ++ "; " ++ L.intercalate ", "
   [if isJust linkedTo
     then showOption q x
-    else showI i -- Don't show the package, just the version
+    else showI q i -- Don't show the package, just the version
   | x@(POption i linkedTo) <- xs
   ]
 
@@ -349,7 +349,7 @@ showConflictingDep (ConflictingDep dr (PkgComponent qpn comp) ci) =
                        ExposedLib (LSubLibName lib) -> " (lib " ++ unUnqualComponentName lib ++ ")"
   in case ci of
        Fixed i        -> (if qpn /= qpn' then showDependencyReason dr ++ " => " else "") ++
-                         showQPN qpn ++ componentStr ++ "==" ++ showI i
+                         showQPN qpn ++ componentStr ++ "==" ++ showI qpn i
        Constrained vr -> showDependencyReason dr ++ " => " ++ showQPN qpn ++
                          componentStr ++ showVR vr
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
@@ -22,11 +22,15 @@ module Distribution.Solver.Modular.Package
 import Prelude ()
 import Distribution.Solver.Compat.Prelude
 
+import qualified Data.List as L
+import qualified Data.Set as S
+
 import Distribution.Package -- from Cabal
 import Distribution.Pretty (prettyShow)
 
 import Distribution.Solver.Modular.Version
 import Distribution.Solver.Types.PackagePath
+
 
 -- | A package name.
 type PN = PackageName
@@ -49,7 +53,10 @@ type PId = UnitId
 -- package instance via its 'PId'.
 --
 -- TODO: More information is needed about the repo.
-data Loc = Inst PId | InRepo
+data Loc
+  = Inst PId
+  | InstGroup PId (Set PId)
+  | InRepo
   deriving (Eq, Ord, Show)
 
 -- | Instance. A version number and a location.
@@ -57,14 +64,29 @@ data I = I Ver Loc
   deriving (Eq, Ord, Show)
 
 -- | String representation of an instance.
-showI :: I -> String
-showI (I v InRepo)   = showVer v
-showI (I v (Inst uid)) = showVer v ++ "/installed" ++ extractPackageAbiHash uid
-  where
-    extractPackageAbiHash xs =
-      case first reverse $ break (=='-') $ reverse (prettyShow xs) of
-        (ys, []) -> ys
-        (ys, _)  -> '-' : ys
+showI :: QPN -> I -> String
+showI _qpn (I v InRepo)   = showVer v
+showI qpn (I v (Inst uid)) =
+  let
+    uidPrefix = showQPN qpn <> "-" <> showVer v <> "-"
+    renderUid u =
+      case L.stripPrefix uidPrefix (prettyShow u) of
+        Nothing -> showVer v
+        Just stripped -> stripped
+  in
+    showVer v <> "/installed-" <> renderUid uid
+showI qpn (I v (InstGroup uid subUids)) =
+  let
+    uidPrefix = showQPN qpn <> "-" <> showVer v <> "-"
+    renderUid u =
+      case L.stripPrefix uidPrefix (prettyShow u) of
+        Nothing -> prettyShow u
+        Just stripped -> stripped
+  in
+     showI qpn (I v (Inst uid))
+  <> " installed package group ["
+  <> unwords (map renderUid $ S.toList subUids)
+  <> "]"
 
 -- | Package instance. A package name and an instance.
 data PI qpn = PI qpn I
@@ -72,7 +94,7 @@ data PI qpn = PI qpn I
 
 -- | String representation of a package instance.
 showPI :: PI QPN -> String
-showPI (PI qpn i) = showQPN qpn ++ "-" ++ showI i
+showPI (PI qpn i) = showQPN qpn ++ "-" ++ showI qpn i
 
 instI :: I -> Bool
 instI (I _ (Inst _)) = True

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
@@ -21,11 +21,15 @@ module Distribution.Solver.Modular.Package
 import Prelude ()
 import Distribution.Solver.Compat.Prelude
 
+import qualified Data.List as L
+import qualified Data.Set as S
+
 import Distribution.Package -- from Cabal
 import Distribution.Pretty (prettyShow)
 
 import Distribution.Solver.Modular.Version
 import Distribution.Solver.Types.PackagePath
+
 
 -- | A package name.
 type PN = PackageName
@@ -48,7 +52,13 @@ type PId = UnitId
 -- package instance via its 'PId'.
 --
 -- TODO: More information is needed about the repo.
-data Loc = Inst PId | InRepo
+data Loc
+  = Inst PId
+  -- ^ Simple installed package
+  | InstGroup PId (Set PId)
+  -- ^ Group of installed packages (main component 'PId' plus a set of sub-component 'PId's)
+  | InRepo
+  -- ^ Available in repository
   deriving (Eq, Ord, Show)
 
 -- | Instance. A version number and a location.
@@ -56,14 +66,29 @@ data I = I Ver Loc
   deriving (Eq, Ord, Show)
 
 -- | String representation of an instance.
-showI :: I -> String
-showI (I v InRepo)   = showVer v
-showI (I v (Inst uid)) = showVer v ++ "/installed" ++ extractPackageAbiHash uid
-  where
-    extractPackageAbiHash xs =
-      case first reverse $ break (=='-') $ reverse (prettyShow xs) of
-        (ys, []) -> ys
-        (ys, _)  -> '-' : ys
+showI :: QPN -> I -> String
+showI _qpn (I v InRepo)   = showVer v
+showI qpn (I v (Inst uid)) =
+  let
+    uidPrefix = showQPN qpn <> "-" <> showVer v <> "-"
+    renderUid u =
+      case L.stripPrefix uidPrefix (prettyShow u) of
+        Nothing -> showVer v
+        Just stripped -> stripped
+  in
+    showVer v <> "/installed-" <> renderUid uid
+showI qpn (I v (InstGroup uid subUids)) =
+  let
+    uidPrefix = showQPN qpn <> "-" <> showVer v <> "-"
+    renderUid u =
+      case L.stripPrefix uidPrefix (prettyShow u) of
+        Nothing -> prettyShow u
+        Just stripped -> stripped
+  in
+     showI qpn (I v (Inst uid))
+  <> " installed package group ["
+  <> unwords (map renderUid $ S.toList subUids)
+  <> "]"
 
 -- | Package instance. A package name and an instance.
 data PI qpn = PI qpn I
@@ -71,7 +96,7 @@ data PI qpn = PI qpn I
 
 -- | String representation of a package instance.
 showPI :: PI QPN -> String
-showPI (PI qpn i) = showQPN qpn ++ "-" ++ showI i
+showPI (PI qpn i) = showQPN qpn ++ "-" ++ showI qpn i
 
 instI :: I -> Bool
 instI (I _ (Inst _)) = True

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Validate.hs
@@ -129,6 +129,7 @@ type PPreAssignment = Map QPN MergedPkgDep
 
 -- | A dependency on a component, including its DependencyReason.
 data PkgDep = PkgDep (DependencyReason QPN) (PkgComponent QPN) CI
+  deriving Show
 
 -- | Map from component name to one of the reasons that the component is
 -- required.
@@ -146,6 +147,7 @@ type ComponentDependencyReasons = Map ExposedComponent (DependencyReason QPN)
 data MergedPkgDep =
     MergedDepFixed ExposedComponent (DependencyReason QPN) I
   | MergedDepConstrained [VROrigin]
+  deriving Show
 
 -- | Version ranges paired with origins.
 type VROrigin = (VR, ExposedComponent, DependencyReason QPN)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Validate.hs
@@ -127,6 +127,7 @@ type PPreAssignment = Map QPN MergedPkgDep
 
 -- | A dependency on a component, including its DependencyReason.
 data PkgDep = PkgDep (DependencyReason QPN) (PkgComponent QPN) CI
+  deriving Show
 
 -- | Map from component name to one of the reasons that the component is
 -- required.
@@ -144,6 +145,7 @@ type ComponentDependencyReasons = Map ExposedComponent (DependencyReason QPN)
 data MergedPkgDep =
     MergedDepFixed ExposedComponent (DependencyReason QPN) I
   | MergedDepConstrained [VROrigin]
+  deriving Show
 
 -- | Version ranges paired with origins.
 type VROrigin = (VR, ExposedComponent, DependencyReason QPN)

--- a/cabal-install-solver/src/Distribution/Solver/Types/InstSolverPackage.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/InstSolverPackage.hs
@@ -6,12 +6,9 @@ module Distribution.Solver.Types.InstSolverPackage
 import Distribution.Solver.Compat.Prelude
 import Prelude ()
 
-import Distribution.Package ( Package(..), HasMungedPackageId(..), HasUnitId(..) )
+import Distribution.Package ( Package(..), HasUnitId(..) )
 import Distribution.Solver.Types.ComponentDeps ( ComponentDeps )
 import Distribution.Solver.Types.SolverId
-import Distribution.Types.MungedPackageId
-import Distribution.Types.PackageId
-import Distribution.Types.MungedPackageName
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 
 -- | An 'InstSolverPackage' is a pre-existing installed package
@@ -27,13 +24,7 @@ instance Binary InstSolverPackage
 instance Structured InstSolverPackage
 
 instance Package InstSolverPackage where
-    packageId i =
-        -- HACK! See Note [Index conversion with internal libraries]
-        let MungedPackageId mpn v = mungedId i
-        in PackageIdentifier (encodeCompatPackageName mpn) v
-
-instance HasMungedPackageId InstSolverPackage where
-    mungedId = mungedId . instSolverPkgIPI
+    packageId = packageId . instSolverPkgIPI
 
 instance HasUnitId InstSolverPackage where
     installedUnitId = installedUnitId . instSolverPkgIPI

--- a/cabal-install-solver/src/Distribution/Solver/Types/InstSolverPackage.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/InstSolverPackage.hs
@@ -5,12 +5,9 @@ module Distribution.Solver.Types.InstSolverPackage
 import Distribution.Solver.Compat.Prelude
 import Prelude ()
 
-import Distribution.Package ( Package(..), HasMungedPackageId(..), HasUnitId(..) )
+import Distribution.Package ( Package(..), HasUnitId(..) )
 import Distribution.Solver.Types.ComponentDeps ( ComponentDeps )
 import Distribution.Solver.Types.SolverId
-import Distribution.Types.MungedPackageId
-import Distribution.Types.PackageId
-import Distribution.Types.MungedPackageName
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 
 -- | An 'InstSolverPackage' is a pre-existing installed package
@@ -26,13 +23,7 @@ instance Binary InstSolverPackage
 instance Structured InstSolverPackage
 
 instance Package InstSolverPackage where
-    packageId i =
-        -- HACK! See Note [Index conversion with internal libraries]
-        let MungedPackageId mpn v = mungedId i
-        in PackageIdentifier (encodeCompatPackageName mpn) v
-
-instance HasMungedPackageId InstSolverPackage where
-    mungedId = mungedId . instSolverPkgIPI
+    packageId = packageId . instSolverPkgIPI
 
 instance HasUnitId InstSolverPackage where
     installedUnitId = installedUnitId . instSolverPkgIPI

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -527,6 +527,7 @@ instance Semigroup SavedConfig where
           , configDeterministic = combine configDeterministic
           , configIPID = combine configIPID
           , configCID = combine configCID
+          , configIUID = combine configIUID
           , configUserInstall = combine configUserInstall
           , -- TODO: NubListify
             configPackageDBs = lastNonEmpty configPackageDBs

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -519,6 +519,7 @@ instance Semigroup SavedConfig where
           , configDeterministic = combine configDeterministic
           , configIPID = combine configIPID
           , configCID = combine configCID
+          , configIUID = combine configIUID
           , configUserInstall = combine configUserInstall
           , -- TODO: NubListify
             configPackageDBs = lastNonEmpty configPackageDBs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1105,6 +1105,7 @@ convertToLegacyAllPackageConfig
           , configDeterministic = mempty
           , configIPID = mempty
           , configCID = mempty
+          , configIUID = mempty
           , configConfigurationsFlags = mempty
           , configTests = mempty
           , configCoverage = mempty -- TODO: don't merge
@@ -1182,6 +1183,7 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , configExtraIncludeDirs = fmap makeSymbolicPath packageConfigExtraIncludeDirs
         , configIPID = mempty
         , configCID = mempty
+        , configIUID = mempty
         , configDeterministic = mempty
         , configConfigurationsFlags = packageConfigFlagAssignment
         , configTests = packageConfigTests

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1090,6 +1090,7 @@ convertToLegacyAllPackageConfig
           , configDeterministic = mempty
           , configIPID = mempty
           , configCID = mempty
+          , configIUID = mempty
           , configConfigurationsFlags = mempty
           , configTests = mempty
           , configCoverage = mempty -- TODO: don't merge
@@ -1167,6 +1168,7 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , configExtraIncludeDirs = fmap makeSymbolicPath packageConfigExtraIncludeDirs
         , configIPID = mempty
         , configCID = mempty
+        , configIUID = mempty
         , configDeterministic = mempty
         , configConfigurationsFlags = packageConfigFlagAssignment
         , configTests = packageConfigTests

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1707,7 +1707,28 @@ elaborateInstallPlan
                         <+> text "package"
                         <+> quotes (pretty (packageId pkg))
                     )
-                    $ map InstallPlan.Configured <$> elaborateSolverToComponents mapDep pkg
+                    $ map InstallPlan.Configured . setCommonInstanceUnitId <$> elaborateSolverToComponents mapDep pkg
+
+      -- Set a common 'InstanceUnitId' for all components so they can be
+      -- identified as belonging to the same group.
+      --
+      -- If the package has a main library, its 'InstanceUnitId' is used.
+      -- Otherwise, an arbitrary component's 'InstanceUnitId' is used.
+      setCommonInstanceUnitId
+        :: [ElaboratedConfiguredPackage]
+        -> [ElaboratedConfiguredPackage]
+      setCommonInstanceUnitId [] = []
+      setCommonInstanceUnitId [single] = [single]
+      setCommonInstanceUnitId elabPkgs@(elabPkg : _rest) =
+        let
+          assignAll instanceUnitId = map (\x -> x{elabInstanceUnitId = instanceUnitId}) elabPkgs
+         in
+          case find (matchElabPkg (== (CLibName LMainLibName))) elabPkgs of
+            Nothing ->
+              -- no main library, use arbitrary (first one) for elabInstanceUnitID assignment
+              assignAll (elabInstanceUnitId elabPkg)
+            Just mainLib ->
+              assignAll (elabInstanceUnitId mainLib)
 
       -- NB: We don't INSTANTIATE packages at this point.  That's
       -- a post-pass.  This makes it simpler to compute dependencies.
@@ -1822,6 +1843,7 @@ elaborateInstallPlan
                   elab0
                     { elabModuleShape = emptyModuleShape
                     , elabUnitId = notImpl "elabUnitId"
+                    , elabInstanceUnitId = notImpl "elabInstanceUnitId"
                     , elabComponentId = notImpl "elabComponentId"
                     , elabLinkedInstantiatedWith = Map.empty
                     , elabInstallDirs = notImpl "elabInstallDirs"
@@ -1881,6 +1903,7 @@ elaborateInstallPlan
                   toConfiguredComponent
                     pd
                     (error "Distribution.Client.ProjectPlanning.cc_cid: filled in later")
+                    (error "Distribution.Client.ProjectPlanning.cc_instance_unit_id: filled in later")
                     (Map.unionWith Map.union external_lib_cc_map cc_map)
                     (Map.unionWith Map.union external_exe_cc_map cc_map)
                     comp
@@ -1930,7 +1953,11 @@ elaborateInstallPlan
                               elaboratedSharedConfig
                               elab1 -- knot tied
                           )
-                    cc = cc0{cc_ann_id = fmap (const cid) (cc_ann_id cc0)}
+                    cc =
+                      cc0
+                        { cc_ann_id = fmap (const cid) (cc_ann_id cc0)
+                        , cc_instance_unit_id = mkInstanceUnitId $ mkUnitId $ unComponentId cid
+                        }
                 infoProgress $ dispConfiguredComponent cc
 
                 -- 4. Perform mix-in linking
@@ -1958,6 +1985,7 @@ elaborateInstallPlan
                     elab1
                       { elabModuleShape = lc_shape lc
                       , elabUnitId = abstractUnitId (lc_uid lc)
+                      , elabInstanceUnitId = lc_instance_id lc
                       , elabComponentId = lc_cid lc
                       , elabLinkedInstantiatedWith = Map.fromList (lc_insts lc)
                       , elabPkgOrComp =
@@ -2126,6 +2154,7 @@ elaborateInstallPlan
               elab0
                 { elabUnitId = newSimpleUnitId pkgInstalledId
                 , elabComponentId = pkgInstalledId
+                , elabInstanceUnitId = mkInstanceUnitId $ newSimpleUnitId pkgInstalledId
                 , elabLinkedInstantiatedWith = Map.empty
                 , elabPkgOrComp = ElabPackage $ ElaboratedPackage{..}
                 , elabModuleShape = modShape
@@ -2230,6 +2259,7 @@ elaborateInstallPlan
 
             -- These get filled in later
             elabUnitId = error "elaborateSolverToCommon: elabUnitId"
+            elabInstanceUnitId = error "elaborateSolverToCommon: elabInstanceUnitId"
             elabComponentId = error "elaborateSolverToCommon: elabComponentId"
             elabInstantiatedWith = Map.empty
             elabLinkedInstantiatedWith = error "elaborateSolverToCommon: elabLinkedInstantiatedWith"
@@ -4121,6 +4151,7 @@ setupHsConfigureFlags
       configCID = case elabPkgOrComp of
         ElabPackage _ -> mempty
         ElabComponent _ -> toFlag elabComponentId
+      configIUID = toFlag elabInstanceUnitId
 
       configProgramPaths = Map.toList elabProgramPaths
       configProgramArgs = Map.toList elabProgramArgs

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2679,12 +2679,7 @@ shouldBeLocal (SpecificSourcePackage pkg) = case srcpkgSource pkg of
 
 -- | Given a 'ElaboratedPlanPackage', report if it matches a 'ComponentName'.
 matchPlanPkg :: (ComponentName -> Bool) -> ElaboratedPlanPackage -> Bool
-matchPlanPkg p = InstallPlan.foldPlanPackage (p . ipiComponentName) (matchElabPkg p)
-
--- | Get the appropriate 'ComponentName' which identifies an installed
--- component.
-ipiComponentName :: IPI.InstalledPackageInfo -> ComponentName
-ipiComponentName = CLibName . IPI.sourceLibName
+matchPlanPkg p = InstallPlan.foldPlanPackage (p . IPI.sourceComponentName) (matchElabPkg p)
 
 -- | Given a 'ElaboratedConfiguredPackage', report if it matches a
 -- 'ComponentName'.
@@ -2716,7 +2711,7 @@ mkCCMapping =
     ( \ipkg ->
         ( packageName ipkg
         , Map.singleton
-            (ipiComponentName ipkg)
+            (IPI.sourceComponentName ipkg)
             -- TODO: libify
             ( AnnotatedId
                 { ann_id = IPI.installedComponentId ipkg

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1673,18 +1673,19 @@ elaborateInstallPlan
 
       preexistingInstantiatedPkgs :: Map UnitId FullUnitId
       preexistingInstantiatedPkgs =
-        Map.fromList (mapMaybe f (SolverInstallPlan.toList solverPlan))
+        Map.fromList (concat $ mapMaybe f (SolverInstallPlan.toList solverPlan))
         where
           f (SolverInstallPlan.PreExisting inst)
             | let ipkg = instSolverPkgIPI inst
             , not (IPI.indefinite ipkg) =
-                Just
-                  ( IPI.installedUnitId ipkg
-                  , ( FullUnitId
-                        (IPI.installedComponentId ipkg)
-                        (Map.fromList (IPI.instantiatedWith ipkg))
-                    )
-                  )
+                let mkEntry x =
+                      ( IPI.installedUnitId x
+                      , ( FullUnitId
+                            (IPI.installedComponentId x)
+                            (Map.fromList (IPI.instantiatedWith x))
+                        )
+                      )
+                 in Just $ (mkEntry ipkg) : (map mkEntry (IPI.installedSublibs ipkg))
           f _ = Nothing
 
       elaboratedInstallPlan
@@ -1693,7 +1694,9 @@ elaborateInstallPlan
         flip InstallPlan.fromSolverInstallPlanWithProgress solverPlan $ \mapDep planpkg ->
           case planpkg of
             SolverInstallPlan.PreExisting pkg ->
-              return [InstallPlan.PreExisting (instSolverPkgIPI pkg)]
+              return $
+                [InstallPlan.PreExisting (instSolverPkgIPI pkg)]
+                  ++ map InstallPlan.PreExisting (IPI.installedSublibs (instSolverPkgIPI pkg))
             SolverInstallPlan.Configured pkg ->
               let inplace_doc
                     | shouldBuildInplaceOnly pkg = text "inplace"
@@ -3175,7 +3178,7 @@ availableInstalledTargets ipkg =
       status = TargetBuildable (unitid, cname) TargetRequestedByDefault
       target = AvailableTarget (packageId ipkg) cname status False
       fake = False
-   in [(packageId ipkg, cname, fake, target)]
+   in (packageId ipkg, cname, fake, target) : (concatMap availableInstalledTargets (IPI.installedSublibs ipkg))
 
 availableSourceTargets
   :: ElaboratedConfiguredPackage
@@ -3637,10 +3640,11 @@ pruneInstallPlanPass1 pkgs
         ]
 
     availablePkgs =
-      Set.fromList
-        [ installedUnitId pkg
-        | InstallPlan.PreExisting pkg <- pkgs
-        ]
+      Set.fromList $
+        concat
+          [ (installedUnitId pkg) : (map installedUnitId (IPI.installedSublibs pkg))
+          | InstallPlan.PreExisting pkg <- pkgs
+          ]
 
 {-
 Note [Pruning for Multi Repl]

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1721,7 +1721,28 @@ elaborateInstallPlan
                         <+> text "package"
                         <+> quotes (pretty (packageId pkg))
                     )
-                    $ map InstallPlan.Configured <$> elaborateSolverToComponents mapDep pkg
+                    $ map InstallPlan.Configured . setCommonInstanceUnitId <$> elaborateSolverToComponents mapDep pkg
+
+      -- Set a common 'InstanceUnitId' for all components so they can be
+      -- identified as belonging to the same group.
+      --
+      -- If the package has a main library, its 'InstanceUnitId' is used.
+      -- Otherwise, an arbitrary component's 'InstanceUnitId' is used.
+      setCommonInstanceUnitId
+        :: [ElaboratedConfiguredPackage]
+        -> [ElaboratedConfiguredPackage]
+      setCommonInstanceUnitId [] = []
+      setCommonInstanceUnitId [single] = [single]
+      setCommonInstanceUnitId elabPkgs@(elabPkg : _rest) =
+        let
+          assignAll instanceUnitId = map (\x -> x{elabInstanceUnitId = instanceUnitId}) elabPkgs
+         in
+          case find (matchElabPkg (== (CLibName LMainLibName))) elabPkgs of
+            Nothing ->
+              -- no main library, use arbitrary (first one) for elabInstanceUnitID assignment
+              assignAll (elabInstanceUnitId elabPkg)
+            Just mainLib ->
+              assignAll (elabInstanceUnitId mainLib)
 
       -- NB: We don't INSTANTIATE packages at this point.  That's
       -- a post-pass.  This makes it simpler to compute dependencies.
@@ -1836,6 +1857,7 @@ elaborateInstallPlan
                   elab0
                     { elabModuleShape = emptyModuleShape
                     , elabUnitId = notImpl "elabUnitId"
+                    , elabInstanceUnitId = notImpl "elabInstanceUnitId"
                     , elabComponentId = notImpl "elabComponentId"
                     , elabLinkedInstantiatedWith = Map.empty
                     , elabInstallDirs = notImpl "elabInstallDirs"
@@ -1895,6 +1917,7 @@ elaborateInstallPlan
                   toConfiguredComponent
                     pd
                     (error "Distribution.Client.ProjectPlanning.cc_cid: filled in later")
+                    (error "Distribution.Client.ProjectPlanning.cc_instance_unit_id: filled in later")
                     (Map.unionWith Map.union external_lib_cc_map cc_map)
                     (Map.unionWith Map.union external_exe_cc_map cc_map)
                     comp
@@ -1944,7 +1967,11 @@ elaborateInstallPlan
                               elaboratedSharedConfig
                               elab1 -- knot tied
                           )
-                    cc = cc0{cc_ann_id = fmap (const cid) (cc_ann_id cc0)}
+                    cc =
+                      cc0
+                        { cc_ann_id = fmap (const cid) (cc_ann_id cc0)
+                        , cc_instance_unit_id = mkInstanceUnitId $ mkUnitId $ unComponentId cid
+                        }
                 infoProgress $ dispConfiguredComponent cc
 
                 -- 4. Perform mix-in linking
@@ -1972,6 +1999,7 @@ elaborateInstallPlan
                     elab1
                       { elabModuleShape = lc_shape lc
                       , elabUnitId = abstractUnitId (lc_uid lc)
+                      , elabInstanceUnitId = lc_instance_id lc
                       , elabComponentId = lc_cid lc
                       , elabLinkedInstantiatedWith = Map.fromList (lc_insts lc)
                       , elabPkgOrComp =
@@ -2140,6 +2168,7 @@ elaborateInstallPlan
               elab0
                 { elabUnitId = newSimpleUnitId pkgInstalledId
                 , elabComponentId = pkgInstalledId
+                , elabInstanceUnitId = mkInstanceUnitId $ newSimpleUnitId pkgInstalledId
                 , elabLinkedInstantiatedWith = Map.empty
                 , elabPkgOrComp = ElabPackage $ ElaboratedPackage{..}
                 , elabModuleShape = modShape
@@ -2244,6 +2273,7 @@ elaborateInstallPlan
 
             -- These get filled in later
             elabUnitId = error "elaborateSolverToCommon: elabUnitId"
+            elabInstanceUnitId = error "elaborateSolverToCommon: elabInstanceUnitId"
             elabComponentId = error "elaborateSolverToCommon: elabComponentId"
             elabInstantiatedWith = Map.empty
             elabLinkedInstantiatedWith = error "elaborateSolverToCommon: elabLinkedInstantiatedWith"
@@ -4112,6 +4142,7 @@ setupHsConfigureFlags
       configCID = case elabPkgOrComp of
         ElabPackage _ -> mempty
         ElabComponent _ -> toFlag elabComponentId
+      configIUID = toFlag elabInstanceUnitId
 
       configProgramPaths = Map.toList elabProgramPaths
       configProgramArgs = Map.toList elabProgramArgs

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1700,7 +1700,7 @@ elaborateInstallPlan
                           (IPI.installedComponentId x)
                           (Map.fromList (IPI.instantiatedWith x))
                       )
-                 in Just $ (mkEntry ipkg) : (map mkEntry (IPI.installedSublibs ipkg))
+                 in Just $ mkEntry ipkg : map mkEntry (IPI.installedSublibs ipkg)
           f _ = Nothing
 
       elaboratedInstallPlan :: LogProgress ElaboratedInstallPlan
@@ -1737,7 +1737,7 @@ elaborateInstallPlan
         let
           assignAll instanceUnitId = map (\x -> x{elabInstanceUnitId = instanceUnitId}) elabPkgs
          in
-          case find (matchElabPkg (== (CLibName LMainLibName))) elabPkgs of
+          case find (matchElabPkg (== CLibName LMainLibName)) elabPkgs of
             Nothing ->
               -- no main library, use arbitrary (first one) for elabInstanceUnitID assignment
               assignAll (elabInstanceUnitId elabPkg)
@@ -3194,7 +3194,7 @@ availableInstalledTargets ipkg =
       status = TargetBuildable (unitid, cname) TargetRequestedByDefault
       target = AvailableTarget (packageId ipkg) cname status False
       fake = False
-   in (packageId ipkg, cname, fake, target) : (concatMap availableInstalledTargets (IPI.installedSublibs ipkg))
+   in (packageId ipkg, cname, fake, target) : concatMap availableInstalledTargets (IPI.installedSublibs ipkg)
 
 availableSourceTargets
   :: ElaboratedConfiguredPackage
@@ -3658,7 +3658,7 @@ pruneInstallPlanPass1 pkgs
     availablePkgs =
       Set.fromList $
         concat
-          [ (installedUnitId pkg) : (map installedUnitId (IPI.installedSublibs pkg))
+          [ installedUnitId pkg : map installedUnitId (IPI.installedSublibs pkg)
           | InstallPlan.PreExisting pkg <- pkgs
           ]
 

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1689,17 +1689,18 @@ elaborateInstallPlan
 
       preexistingInstantiatedPkgs :: Map UnitId FullUnitId
       preexistingInstantiatedPkgs =
-        Map.fromList (mapMaybe f (SolverInstallPlan.toList solverPlan))
+        Map.fromList (concat $ mapMaybe f (SolverInstallPlan.toList solverPlan))
         where
           f (SolverInstallPlan.PreExisting inst)
             | let ipkg = instSolverPkgIPI inst
             , not (IPI.indefinite ipkg) =
-                Just
-                  ( IPI.installedUnitId ipkg
-                  , FullUnitId
-                      (IPI.installedComponentId ipkg)
-                      (Map.fromList (IPI.instantiatedWith ipkg))
-                  )
+                let mkEntry x =
+                      ( IPI.installedUnitId x
+                      , FullUnitId
+                          (IPI.installedComponentId x)
+                          (Map.fromList (IPI.instantiatedWith x))
+                      )
+                 in Just $ (mkEntry ipkg) : (map mkEntry (IPI.installedSublibs ipkg))
           f _ = Nothing
 
       elaboratedInstallPlan :: LogProgress ElaboratedInstallPlan
@@ -1707,7 +1708,9 @@ elaborateInstallPlan
         flip InstallPlan.fromSolverInstallPlanWithProgress solverPlan $ \mapDep planpkg ->
           case planpkg of
             SolverInstallPlan.PreExisting pkg ->
-              return [InstallPlan.PreExisting (instSolverPkgIPI pkg)]
+              return $
+                [InstallPlan.PreExisting (instSolverPkgIPI pkg)]
+                  ++ map InstallPlan.PreExisting (IPI.installedSublibs (instSolverPkgIPI pkg))
             SolverInstallPlan.Configured pkg ->
               let inplace_doc
                     | shouldBuildInplaceOnly pkg = text "inplace"
@@ -3166,7 +3169,7 @@ availableInstalledTargets ipkg =
       status = TargetBuildable (unitid, cname) TargetRequestedByDefault
       target = AvailableTarget (packageId ipkg) cname status False
       fake = False
-   in [(packageId ipkg, cname, fake, target)]
+   in (packageId ipkg, cname, fake, target) : (concatMap availableInstalledTargets (IPI.installedSublibs ipkg))
 
 availableSourceTargets
   :: ElaboratedConfiguredPackage
@@ -3628,10 +3631,11 @@ pruneInstallPlanPass1 pkgs
         ]
 
     availablePkgs =
-      Set.fromList
-        [ installedUnitId pkg
-        | InstallPlan.PreExisting pkg <- pkgs
-        ]
+      Set.fromList $
+        concat
+          [ (installedUnitId pkg) : (map installedUnitId (IPI.installedSublibs pkg))
+          | InstallPlan.PreExisting pkg <- pkgs
+          ]
 
 {-
 Note [Pruning for Multi Repl]

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2675,12 +2675,7 @@ shouldBeLocal (SpecificSourcePackage pkg) = case srcpkgSource pkg of
 
 -- | Given a 'ElaboratedPlanPackage', report if it matches a 'ComponentName'.
 matchPlanPkg :: (ComponentName -> Bool) -> ElaboratedPlanPackage -> Bool
-matchPlanPkg p = InstallPlan.foldPlanPackage (p . ipiComponentName) (matchElabPkg p)
-
--- | Get the appropriate 'ComponentName' which identifies an installed
--- component.
-ipiComponentName :: IPI.InstalledPackageInfo -> ComponentName
-ipiComponentName = CLibName . IPI.sourceLibName
+matchPlanPkg p = InstallPlan.foldPlanPackage (p . IPI.sourceComponentName) (matchElabPkg p)
 
 -- | Given a 'ElaboratedConfiguredPackage', report if it matches a
 -- 'ComponentName'.
@@ -2712,7 +2707,7 @@ mkCCMapping =
     ( \ipkg ->
         ( packageName ipkg
         , Map.singleton
-            (ipiComponentName ipkg)
+            (IPI.sourceComponentName ipkg)
             -- TODO: libify
             ( AnnotatedId
                 { ann_id = IPI.installedComponentId ipkg

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -203,6 +203,9 @@ instance Structured ElaboratedSharedConfig
 data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
   { elabUnitId :: UnitId
   -- ^ The 'UnitId' which uniquely identifies this item in a build plan
+  , elabInstanceUnitId :: InstanceUnitId
+  -- ^ The 'InstanceUnitId' which uniquely identifies package instance
+  -- (equal to elabUnitId for main component, sub components inherit it from main)
   , elabComponentId :: ComponentId
   , elabInstantiatedWith :: Map ModuleName Module
   , elabLinkedInstantiatedWith :: Map ModuleName OpenModule

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -198,6 +198,9 @@ instance Structured ElaboratedSharedConfig
 data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
   { elabUnitId :: UnitId
   -- ^ The 'UnitId' which uniquely identifies this item in a build plan
+  , elabInstanceUnitId :: InstanceUnitId
+  -- ^ The 'InstanceUnitId' which uniquely identifies package instance
+  -- (equal to elabUnitId for main component, sub components inherit it from main)
   , elabComponentId :: ComponentId
   , elabInstantiatedWith :: Map ModuleName Module
   , elabLinkedInstantiatedWith :: Map ModuleName OpenModule

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -719,6 +719,7 @@ filterConfigureFlags' flags cabalLibVersion
       flags_latest
         { configBytecodeLib = NoFlag
         , configInstallDirs = (configInstallDirs flags){bytecodelibdir = NoFlag}
+        , configIUID = NoFlag
         }
 
     flags_3_13_0 =

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -722,6 +722,7 @@ filterConfigureFlags' flags cabalLibVersion
       flags_latest
         { configBytecodeLib = NoFlag
         , configInstallDirs = (configInstallDirs flags){bytecodelibdir = NoFlag}
+        , configIUID = NoFlag
         }
 
     flags_3_13_0 =

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -932,7 +932,7 @@ tests =
       , runTest $
           let db =
                 [ Right $ exAv "my-package" 1 [ExFix "other-package" 3]
-                , Left $ exInst "other-package" 2 "other-package-AbCdEfGhIj0123456789" []
+                , Left $ exInst "other-package" 2 "other-package-2-AbCdEfGhIj0123456789" []
                 ]
               msg = "rejecting: other-package-2/installed-AbCdEfGhIj0123456789"
            in mkTest db "show full installed package ABI hash (issue #5892)" ["my-package"] $

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -942,7 +942,7 @@ tests =
       , runTest $
           let db =
                 [ Right $ exAv "my-package" 1 [ExFix "other-package" 3]
-                , Left $ exInst "other-package" 2 "other-package-AbCdEfGhIj0123456789" []
+                , Left $ exInst "other-package" 2 "other-package-2-AbCdEfGhIj0123456789" []
                 ]
               msg = "rejecting: other-package-2/installed-AbCdEfGhIj0123456789"
            in mkTest db "show full installed package ABI hash (issue #5892)" ["my-package"] $

--- a/cabal.project
+++ b/cabal.project
@@ -12,3 +12,5 @@ package cabal-install
 
 package Cabal
   flags: +git-rev
+
+multi-repl: True

--- a/changelog.d/pr-11788.md
+++ b/changelog.d/pr-11788.md
@@ -1,0 +1,11 @@
+---
+synopsis: Group installed multilib packages
+packages: [Cabal, Cabal-syntax, cabal-install, cabal-install-solver]
+prs: 11788
+---
+
+Introduce `InstanceUnitId` (`instance-id`) field for `InstalledPackageInfo` uniquely identifying
+group of components.
+
+Group components in solvers index conversion pass, allowing us to treat installed packages
+similar to source packages.


### PR DESCRIPTION
Before this patch, sub-libraries (either public or private) of installed
packages are treated as top level separate packages from solvers point of view.

This differs from how source packages are handled, which are treated as
a single package.

Sub-libraries of installed packages needed munging to prevent conflicts
like described in `Note [Index conversion with internal libraries]`.

Due to package name munging, top level library we are trying to build,
cannot depend on public sub-libraries, more precisely - it can, but
the installed packages are never used. Instead they are always
rebuilt from source (as only source package index exposes public
sub-libs correctly).

The idea is to make packages coming from *installed* package index look
similar to packages coming from *source* - appearing as a single package
instead of multiple.

The approach we choose is adding a grouping pass to solvers installed package
index conversion. After the index is converted, we group installed
packages by name and version and adjust all dependencies to point to
newly built groups instead of split sub-lib packages. This way, solver
only sees a single package (similar to how source packages are treated).

This is done by means of adding
* `InstGroup` `Loc` to solver
* `installedSublibs` field to `InstalledPackageInfo`
* and finally expanding `installedSublibs` in `ProjectPlanning`

Now the sub-libs are handled correctly and build process
picks installed public sub-libs when available. It also
allows us to drop package name munging hacks from solver
completely.

See #6039

---

**Template Α: This PR modifies [behaviour or interface](CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
