### PR TITLE
HLint: map once & with tuple-section

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -27,8 +27,6 @@
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
-- ignore: {name: "Use map once"} # 6 hints
-- ignore: {name: "Use map with tuple-section"} # 3 hints
 - ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints

--- a/Cabal/src/Distribution/Simple/SrcDist.hs
+++ b/Cabal/src/Distribution/Simple/SrcDist.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
 
 -----------------------------------------------------------------------------
 
@@ -311,7 +312,7 @@ prepareTree
   -> IO ()
 prepareTree verbosity mbWorkDir pkg_descr0 targetDir pps = do
   ordinary <- listPackageSources verbosity mbWorkDir pkg_descr pps
-  installOrdinaryFiles verbosity targetDir (zip (repeat []) $ map i ordinary)
+  installOrdinaryFiles verbosity targetDir (map (([],) . i) ordinary)
   maybeCreateDefaultSetupScript targetDir
   where
     i = interpretSymbolicPath mbWorkDir -- See Note [Symbolic paths] in Distribution.Utils.Path

--- a/Cabal/src/Distribution/Simple/Test.hs
+++ b/Cabal/src/Distribution/Simple/Test.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -----------------------------------------------------------------------------
@@ -132,7 +133,7 @@ test args verbHandles pkg_descr lbi0 flags = do
     dieWithException verbosity NoTestSuitesEnabled
 
   testsToRun <- case testNames of
-    [] -> return $ zip enabledTests $ repeat Nothing
+    [] -> return $ map (,Nothing) enabledTests
     names -> for names $ \tName ->
       let testMap = zip enabledNames enabledTests
           enabledNames = map (PD.testName . fst) enabledTests

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -231,9 +231,7 @@ buildLib verbosity pkg_descr lbi lib clbi = do
           -- source files
           -- suboptimal: UHC does not understand module names, so
           -- we replace periods by path separators
-          ++ map
-            (map (\c -> if c == '.' then pathSeparator else c))
-            (map prettyShow (allLibModules lib clbi))
+          ++ map (map (\c -> if c == '.' then pathSeparator else c) . prettyShow) (allLibModules lib clbi)
 
   runUhcProg uhcArgs
 

--- a/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
@@ -82,17 +82,16 @@ readPkgConfigDb verbosity progdb = handle ioErrorHandler $ do
               . filter (either (const True) (not . null))
               -- Try decoding strictly; if it fails, put the lenient
               -- decoding in a Left for later reporting.
-              . map (\bsname ->
-                       let sbsname = LBS.toStrict bsname
-                       in case T.decodeUtf8' sbsname of
-                            Left _ -> Left (T.unpack (decodeUtf8LenientCompat sbsname))
-                            Right name -> Right (T.unpack name))
               -- The output of @pkg-config --list-all@ also includes a
               -- description for each package, which we do not need.
               -- We don't use Data.Char.isSpace because that would also
               -- include 0xA0, the non-breaking space, which can occur
               -- in multi-byte UTF-8 sequences.
-              . map (LBS.takeWhile (not . isAsciiSpace))
+              . map ((\bsname ->
+                       let sbsname = LBS.toStrict bsname
+                       in case T.decodeUtf8' sbsname of
+                            Left _ -> Left (T.unpack (decodeUtf8LenientCompat sbsname))
+                            Right name -> Right (T.unpack name)) . LBS.takeWhile (not . isAsciiSpace))
               $ pkgList
         unless (null failedPkgNames) $
           info verbosity ("Some pkg-config packages have names containing invalid unicode: " ++ intercalate ", " failedPkgNames)

--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -194,7 +194,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
                     J.object $
                       [ comp2str c
                         J..= J.object
-                          ( [ "depends" J..= map (jdisplay . confInstId) (map fst ldeps)
+                          ( [ "depends" J..= map ((jdisplay . confInstId) . fst) ldeps
                             , "exe-depends" J..= map (jdisplay . confInstId) edeps
                             ]
                               ++ bin_file c
@@ -207,7 +207,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
                       ]
                in ["components" J..= components]
             ElabComponent comp ->
-              [ "depends" J..= map (jdisplay . confInstId) (map fst $ elabLibDependencies elab)
+              [ "depends" J..= map ((jdisplay . confInstId) . fst) (elabLibDependencies elab)
               , "exe-depends" J..= map jdisplay (elabExeDependencies elab)
               , "component-name" J..= J.String (comp2str (compSolverName comp))
               ]
@@ -642,7 +642,7 @@ postBuildProjectStatus
           ]
 
       elabLibDeps :: ElaboratedConfiguredPackage -> [UnitId]
-      elabLibDeps = map (newSimpleUnitId . confInstId) . map fst . elabLibDependencies
+      elabLibDeps = map ((newSimpleUnitId . confInstId) . fst) . elabLibDependencies
 
       -- Was a build was attempted for this package?
       -- If it doesn't have both a build status and outcome then the answer is no.

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -3305,8 +3305,7 @@ nubComponentTargets =
   concatMap (wholeComponentOverrides . map snd)
     . groupBy ((==) `on` fst)
     . sortBy (compare `on` fst)
-    . map (\t@((ComponentTarget cname _, _)) -> (cname, t))
-    . map compatSubComponentTargets
+    . map ((\t@((ComponentTarget cname _, _)) -> (cname, t)) . compatSubComponentTargets)
   where
     -- If we're building the whole component then that the only target all we
     -- need, otherwise we can have several targets within the component.

--- a/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoMonoLocalBinds #-}
 
@@ -136,7 +137,7 @@ isReversePartialTopologicalOrder g vs =
     | let ixs =
             array
               (bounds g)
-              ( zip (range (bounds g)) (repeat Nothing)
+              ( map (,Nothing) (range (bounds g))
                   ++ zip vs (map Just [0 :: Int ..])
               )
     , (u, v) <- edges g


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use map once"  and "use map with tuple-section" suggestions so that these will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
