### PR TITLE
Run doctests with doctest, not cabal-doctest

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -15,7 +15,7 @@ on:
       - created
 
 env:
-  GHC_FOR_QUICK_JOBS: 9.10.3
+  GHC_FOR_QUICK_JOBS: 9.12.4
 
 jobs:
   meta:

--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,11 @@ doctest: ## Run doctests.
 	cd cabal-install-solver && $(DOCTEST)
 	cd cabal-install && $(DOCTEST)
 
-# We don't use the cabal-doctest external command but we install it anyway along
-# with doctest.
-# SEE: https://github.com/haskell/cabal/issues/11493
+# Pinning to doctest-0.25.0 to avoid failures with doctest-0.24.3.
+# SEE: https://github.com/haskell/cabal/issues/11493#issuecomment-4615438425
 .PHONY: doctest-install
 doctest-install: ## Install doctest tool needed for running doctests.
-	cabal install doctest-0.24.3 --overwrite-policy=always --ignore-project --flag cabal-doctest
+	cabal install doctest-0.25.0 --overwrite-policy=always --ignore-project --flag cabal-doctest
 
 # tests
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 CABALBUILD := cabal build
 CABALRUN   := cabal run
 
-DOCTEST := cabal repl --with-compiler=doctest --build-depends=QuickCheck --verbose=0 --repl-options='-w -Wdefault -Wno-inconsistent-flags'
+DOCTEST := cabal doctest
 
 # default rules
 
@@ -151,6 +151,7 @@ ghcid-cli: ## Run ghcid for the cabal-install executable.
 
 .PHONY: doctest
 doctest: ## Run doctests.
+	cabal --numeric-version
 	cd Cabal-syntax && $(DOCTEST)
 	cd Cabal-described && $(DOCTEST)
 	cd Cabal && $(DOCTEST)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 CABALBUILD := cabal build
 CABALRUN   := cabal run
 
-DOCTEST := cabal doctest
+DOCTEST := cabal repl --with-compiler=doctest --build-depends=QuickCheck --verbose=0 --repl-options='-w -Wdefault -Wno-inconsistent-flags'
 
 # default rules
 
@@ -157,9 +157,12 @@ doctest: ## Run doctests.
 	cd cabal-install-solver && $(DOCTEST)
 	cd cabal-install && $(DOCTEST)
 
+# We don't use the cabal-doctest external command but we install it anyway along
+# with doctest.
+# SEE: https://github.com/haskell/cabal/issues/11493
 .PHONY: doctest-install
 doctest-install: ## Install doctest tool needed for running doctests.
-	cabal install doctest --overwrite-policy=always --ignore-project --flag cabal-doctest
+	cabal install doctest-0.24.3 --overwrite-policy=always --ignore-project --flag cabal-doctest
 
 # tests
 


### PR DESCRIPTION
Fixes #11493.

- Uses the recommended way of running doctests with the `doctest` tool, not the way using the experimental  `cabal-doctest` external command.
- Runs `cabal repl` in quiet mode so that we only see the doctests summary output.
- Adds a `-Wno-inconsistent-flags` warning suppression that only seems to be triggered by `Cabal-syntax`.

> [!NOTE]
> - Doctest content changes, I've split from this pull request.
>   Moved to #11797.
> - The `doctest-%` pattern rule, I've split from this pull request.
>   Moved to #11799.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
