### PR TITLE
Remove doctest-cli makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,11 +157,6 @@ doctest: ## Run doctests.
 	cd cabal-install-solver && $(DOCTEST)
 	cd cabal-install && $(DOCTEST)
 
-# This is not run as part of validate.sh (we need hackage-security, which is tricky to get).
-.PHONY: doctest-cli
-doctest-cli :
-	doctest -D__DOCTEST__ --fast cabal-install/src cabal-install-solver/src cabal-install-solver/src-assertion
-
 .PHONY: doctest-install
 doctest-install: ## Install doctest tool needed for running doctests.
 	cabal install doctest --overwrite-policy=always --ignore-project --flag cabal-doctest


### PR DESCRIPTION
Fixes #11794 and also fixes #10607 by removing `doctest-cli`.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
