### PR TITLE
-XCPP doctest expectations for ghc-9.14 and above

### DIFF
--- a/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
@@ -4,30 +4,36 @@
 
 -- | This module provides @newtype@ wrappers to be used with "Distribution.FieldGrammar".
 module Distribution.FieldGrammar.Newtypes
-  ( -- * List
-    alaList
+  ( -- * Types
+    List
+  , Set'
+  , NonEmpty'
+
+    -- * List
+  -- $alaList
+  -- $alaListFSepTokenDoctest
+  -- $alaListFSepTokenDoctestBroken
+  , alaList
   , alaList'
 
-    -- ** Modifiers
+    -- * Set
+  -- $alaSet
+  -- $alaSetFSepTokenDoctest
+  -- $alaSetFSepTokenDoctestBroken
+  , alaSet
+  , alaSet'
+
+    -- * NonEmpty
+  , alaNonEmpty
+  , alaNonEmpty'
+
+    -- * Modifiers
   , CommaVCat (..)
   , CommaFSep (..)
   , VCat (..)
   , FSep (..)
   , NoCommaFSep (..)
   , Sep (..)
-
-    -- ** Type
-  , List
-
-    -- ** Set
-  , alaSet
-  , alaSet'
-  , Set'
-
-    -- ** NonEmpty
-  , alaNonEmpty
-  , alaNonEmpty'
-  , NonEmpty'
 
     -- * Version & License
   , SpecVersion (..)
@@ -131,15 +137,6 @@ instance Sep NoCommaFSep where
 -- type @a@ are parsed and pretty-printed as @b@.
 newtype List sep b a = List {_getList :: [a]}
 
-{- FOURMOLU_DISABLE -}
--- | 'alaList' and 'alaList'' are simply 'List', with additional phantom
--- arguments to constrain the resulting type
---
--- >>> :t alaList VCat
--- alaList VCat :: [a] -> List VCat (Identity a) a
---
--- $alaListFSepTokenDoctest
-{- FOURMOLU_ENABLE -}
 alaList :: sep -> [a] -> List sep (Identity a) a
 alaList _ = List
 
@@ -155,27 +152,12 @@ instance (Newtype a b, Sep sep, Parsec b) => Parsec (List sep b a) where
 instance (Newtype a b, Sep sep, Pretty b) => Pretty (List sep b a) where
   pretty = prettySep (Proxy :: Proxy sep) . map (pretty . (pack :: a -> b)) . unpack
 
---
-
 -- | Like 'List', but for 'Set'.
 --
 -- @since 3.2.0.0
 newtype Set' sep b a = Set' {_getSet :: Set a}
 
-{- FOURMOLU_DISABLE -}
--- | 'alaSet' and 'alaSet'' are simply 'Set'' constructor, with additional phantom
--- arguments to constrain the resulting type
---
--- >>> :t alaSet VCat
--- alaSet VCat :: Set a -> Set' VCat (Identity a) a
---
--- $alaSetFSepTokenDoctest
---
--- >>> unpack' (alaSet' FSep Token) <$> eitherParsec "foo bar foo"
--- Right (fromList ["bar","foo"])
---
--- @since 3.2.0.0
-{- FOURMOLU_ENABLE -}
+-- | @since 3.2.0.0
 alaSet :: sep -> Set a -> Set' sep (Identity a) a
 alaSet _ = Set'
 
@@ -192,8 +174,6 @@ instance (Newtype a b, Ord a, Sep sep, Parsec b) => Parsec (Set' sep b a) where
 
 instance (Newtype a b, Sep sep, Pretty b) => Pretty (Set' sep b a) where
   pretty = prettySep (Proxy :: Proxy sep) . map (pretty . (pack :: a -> b)) . Set.toList . unpack
-
---
 
 -- | Like 'List', but for 'NonEmpty'.
 --
@@ -452,19 +432,42 @@ parsecTestedWith = do
   ver <- parsec <|> pure anyVersion
   return (name, ver)
 
+-- $alaSet
+-- 'alaSet' and 'alaSet'' are simply 'Set'' constructor, with additional phantom
+-- arguments to constrain the resulting type
+
+-- $alaSetFSepTokenDoctest
+-- >>> :t alaSet VCat
+-- alaSet VCat :: Set a -> Set' VCat (Identity a) a
+--
+-- >>> unpack' (alaSet' FSep Token) <$> eitherParsec "foo bar foo"
+-- Right (fromList ["bar","foo"])
+
+-- $alaList
+-- 'alaList' and 'alaList'' are simply 'List', with additional phantom arguments
+-- to constrain the resulting type
+
+-- $alaListFSepTokenDoctest
+-- >>> :t alaList VCat
+-- alaList VCat :: [a] -> List VCat (Identity a) a
+--
+-- $alaListFSepTokenDoctest
+
 -- TODO: Find out why GHCi stops using the String type alias.
 #if MIN_VERSION_base(4,22,0)
--- $alaListFSepTokenDoctest
+-- $alaListFSepTokenDoctestBroken
 -- >>> :t alaList' FSep Token
 -- alaList' FSep Token :: [[Char]] -> List FSep Token [Char]
--- $alaSetFSepTokenDoctest
+
+-- $alaSetFSepTokenDoctestBroken
 -- >>> :t alaSet' FSep Token
 -- alaSet' FSep Token :: Set [Char] -> Set' FSep Token [Char]
 #else
--- $alaListFSepTokenDoctest
+-- $alaListFSepTokenDoctestBroken
 -- >>> :t alaList' FSep Token
 -- alaList' FSep Token :: [String] -> List FSep Token String
--- $alaSetFSepTokenDoctest
+
+-- $alaSetFSepTokenDoctestBroken
 -- >>> :t alaSet' FSep Token
 -- alaSet' FSep Token :: Set String -> Set' FSep Token String
 #endif

--- a/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -130,14 +131,15 @@ instance Sep NoCommaFSep where
 -- type @a@ are parsed and pretty-printed as @b@.
 newtype List sep b a = List {_getList :: [a]}
 
+{- FOURMOLU_DISABLE -}
 -- | 'alaList' and 'alaList'' are simply 'List', with additional phantom
 -- arguments to constrain the resulting type
 --
 -- >>> :t alaList VCat
 -- alaList VCat :: [a] -> List VCat (Identity a) a
 --
--- >>> :t alaList' FSep Token
--- alaList' FSep Token :: [String] -> List FSep Token String
+-- $alaListFSepTokenDoctest
+{- FOURMOLU_ENABLE -}
 alaList :: sep -> [a] -> List sep (Identity a) a
 alaList _ = List
 
@@ -160,19 +162,20 @@ instance (Newtype a b, Sep sep, Pretty b) => Pretty (List sep b a) where
 -- @since 3.2.0.0
 newtype Set' sep b a = Set' {_getSet :: Set a}
 
+{- FOURMOLU_DISABLE -}
 -- | 'alaSet' and 'alaSet'' are simply 'Set'' constructor, with additional phantom
 -- arguments to constrain the resulting type
 --
 -- >>> :t alaSet VCat
 -- alaSet VCat :: Set a -> Set' VCat (Identity a) a
 --
--- >>> :t alaSet' FSep Token
--- alaSet' FSep Token :: Set String -> Set' FSep Token String
+-- $alaSetFSepTokenDoctest
 --
 -- >>> unpack' (alaSet' FSep Token) <$> eitherParsec "foo bar foo"
 -- Right (fromList ["bar","foo"])
 --
 -- @since 3.2.0.0
+{- FOURMOLU_ENABLE -}
 alaSet :: sep -> Set a -> Set' sep (Identity a) a
 alaSet _ = Set'
 
@@ -448,3 +451,20 @@ parsecTestedWith = do
   name <- lexemeParsec
   ver <- parsec <|> pure anyVersion
   return (name, ver)
+
+-- TODO: Find out why GHCi stops using the String type alias.
+#if MIN_VERSION_base(4,22,0)
+-- $alaListFSepTokenDoctest
+-- >>> :t alaList' FSep Token
+-- alaList' FSep Token :: [[Char]] -> List FSep Token [Char]
+-- $alaSetFSepTokenDoctest
+-- >>> :t alaSet' FSep Token
+-- alaSet' FSep Token :: Set [Char] -> Set' FSep Token [Char]
+#else
+-- $alaListFSepTokenDoctest
+-- >>> :t alaList' FSep Token
+-- alaList' FSep Token :: [String] -> List FSep Token String
+-- $alaSetFSepTokenDoctest
+-- >>> :t alaSet' FSep Token
+-- alaSet' FSep Token :: Set String -> Set' FSep Token String
+#endif

--- a/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
@@ -10,16 +10,16 @@ module Distribution.FieldGrammar.Newtypes
   , NonEmpty'
 
     -- * List
-  -- $alaList
-  -- $alaListFSepTokenDoctest
-  -- $alaListFSepTokenDoctestBroken
+    -- $alaList
+    -- $alaListFSepTokenDoctest
+    -- $alaListFSepTokenDoctestBroken
   , alaList
   , alaList'
 
     -- * Set
-  -- $alaSet
-  -- $alaSetFSepTokenDoctest
-  -- $alaSetFSepTokenDoctestBroken
+    -- $alaSet
+    -- $alaSetFSepTokenDoctest
+    -- $alaSetFSepTokenDoctestBroken
   , alaSet
   , alaSet'
 
@@ -450,8 +450,6 @@ parsecTestedWith = do
 -- $alaListFSepTokenDoctest
 -- >>> :t alaList VCat
 -- alaList VCat :: [a] -> List VCat (Identity a) a
---
--- $alaListFSepTokenDoctest
 
 -- TODO: Find out why GHCi stops using the String type alias.
 #if MIN_VERSION_base(4,22,0)

--- a/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
@@ -79,10 +79,10 @@ import qualified Data.Set as Set
 import qualified Distribution.Compat.CharParsing as P
 import qualified Distribution.SPDX as SPDX
 
--- | Vertical list with commas. Displayed with 'vcat'
+-- | Vertical list with commas. Displayed with 'vcat'.
 data CommaVCat = CommaVCat
 
--- | Paragraph fill list with commas. Displayed with 'fsep'
+-- | Paragraph fill list with commas. Displayed with 'fsep'.
 data CommaFSep = CommaFSep
 
 -- | Vertical list with optional commas. Displayed with 'vcat'.
@@ -180,8 +180,8 @@ instance (Newtype a b, Sep sep, Pretty b) => Pretty (Set' sep b a) where
 -- @since 3.2.0.0
 newtype NonEmpty' sep b a = NonEmpty' {_getNonEmpty :: NonEmpty a}
 
--- | 'alaNonEmpty' and 'alaNonEmpty'' are simply 'NonEmpty'' constructor, with additional phantom
--- arguments to constrain the resulting type
+-- | 'alaNonEmpty' and 'alaNonEmpty'' are simply 'NonEmpty'' constructor, with
+-- additional phantom arguments to constrain the resulting type.
 --
 -- >>> :t alaNonEmpty VCat
 -- alaNonEmpty VCat :: NonEmpty a -> NonEmpty' VCat (Identity a) a
@@ -211,7 +211,7 @@ instance (Newtype a b, Sep sep, Pretty b) => Pretty (NonEmpty' sep b a) where
 -- Identifiers
 -------------------------------------------------------------------------------
 
--- | Haskell string or @[^ ,]+@
+-- | Haskell string or @[^ ,]+@.
 newtype Token = Token {getToken :: String}
 
 instance Newtype String Token
@@ -222,7 +222,7 @@ instance Parsec Token where
 instance Pretty Token where
   pretty = showToken . unpack
 
--- | Haskell string or @[^ ]+@
+-- | Haskell string or @[^ ]+@.
 newtype Token' = Token' {getToken' :: String}
 
 instance Newtype String Token'
@@ -275,9 +275,10 @@ instance Parsec (SymbolicPathNT from to) where
 instance Pretty (SymbolicPathNT from to) where
   pretty = showFilePath . getSymbolicPath . getSymbolicPathNT
 
--- | Newtype for 'RelativePath', with a different 'Parsec' instance
--- to disallow empty paths but allow non-relative paths (which get rejected
--- later with a different error message, see 'Distribution.PackageDescription.Check.Paths.checkPath')
+-- | Newtype for 'RelativePath', with a different 'Parsec' instance to disallow
+-- empty paths but allow non-relative paths (which get rejected later with a
+-- different error message, see
+-- 'Distribution.PackageDescription.Check.Paths.checkPath').
 newtype RelativePathNT from to = RelativePathNT {getRelativePathNT :: RelativePath from to}
 
 instance Newtype (RelativePath from to) (RelativePathNT from to)
@@ -298,14 +299,17 @@ instance Pretty (RelativePathNT from to) where
 -- SpecVersion
 -------------------------------------------------------------------------------
 
--- | Version range or just version, i.e. @cabal-version@ field.
+-- | An exact version of the Cabal specification as a value of the
+-- @cabal-version@ field. Earlier Cabal specifications allowed a version range
+-- here. For more details, see the
+-- [cabal-version](https://cabal.readthedocs.io/en/latest/cabal-package-description-file.html#pkg-field-cabal-version)
+-- section of the Cabal User Guide and
+-- [issue #4899](https://github.com/haskell/cabal/issues/4899).
 --
--- There are few things to consider:
+-- For @cabal-version: v@:
 --
--- * Starting with 2.2 the cabal-version field should be the first field in the
---   file and only exact version is accepted. Therefore if we get e.g.
---   @>= 2.2@, we fail.
---   See <https://github.com/haskell/cabal/issues/4899>
+--  * the @cabal-version@ field should be the first field in the file,
+--  * only an exact version is accepted for @v@.
 --
 -- We have this newtype, as writing Parsec and Pretty instances
 -- for CabalSpecVersion would cause cycle in modules:
@@ -394,7 +398,7 @@ instance Pretty SpecVersion where
 -- SpecLicense
 -------------------------------------------------------------------------------
 
--- | SPDX License expression or legacy license
+-- | SPDX License expression or legacy license.
 newtype SpecLicense = SpecLicense {getSpecLicense :: Either SPDX.License License}
   deriving (Show, Eq)
 
@@ -414,7 +418,7 @@ instance Pretty SpecLicense where
 -- TestedWith
 -------------------------------------------------------------------------------
 
--- | Version range or just version
+-- | Version range or just version.
 newtype TestedWith = TestedWith {getTestedWith :: (CompilerFlavor, VersionRange)}
 
 instance Newtype (CompilerFlavor, VersionRange) TestedWith
@@ -434,7 +438,7 @@ parsecTestedWith = do
 
 -- $alaSet
 -- 'alaSet' and 'alaSet'' are simply 'Set'' constructor, with additional phantom
--- arguments to constrain the resulting type
+-- arguments to constrain the resulting type.
 
 -- $alaSetFSepTokenDoctest
 -- >>> :t alaSet VCat
@@ -445,7 +449,7 @@ parsecTestedWith = do
 
 -- $alaList
 -- 'alaList' and 'alaList'' are simply 'List', with additional phantom arguments
--- to constrain the resulting type
+-- to constrain the resulting type.
 
 -- $alaListFSepTokenDoctest
 -- >>> :t alaList VCat

--- a/cabal-install/src/Distribution/Client/Utils/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/Utils/Parsec.hs
@@ -6,9 +6,9 @@
 module Distribution.Client.Utils.Parsec
   ( -- * NubList
     NubList'
-  -- $alaNubList
-  -- $alaNubListFSepTokenDoctest
-  -- $alaNubListFSepTokenDoctestBroken
+    -- $alaNubList
+    -- $alaNubListFSepTokenDoctest
+    -- $alaNubListFSepTokenDoctestBroken
   , alaNubList
   , alaNubList'
 

--- a/cabal-install/src/Distribution/Client/Utils/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/Utils/Parsec.hs
@@ -35,13 +35,14 @@ import Distribution.Simple.Flag
 import Distribution.Utils.NubList (NubList (..))
 import qualified Distribution.Utils.NubList as NubList
 
--- | Like 'List' for usage with a 'FieldGrammar', but for 'Flag'.
--- This enables to parse type aliases such as 'FilePath' that do not have 'Parsec' instances
+-- | Like 'List' for usage with a 'FieldGrammar', but for a 'Flag'.
+-- This enables parsing type aliases such as 'FilePath' that do not have 'Parsec' instances
 -- by using newtype variants such as 'FilePathNT'.
--- For example, if you need to parse a 'Flag FilePath', you can use 'alaFlag' FilePathNT'.
+-- For example, if you need to parse a 'Flag' 'FilePath', you can use 'alaFlag' 'FilePathNT'.
 newtype Flag' b a = Flag' {_getFlag :: Flag a}
 
--- | 'Flag'' constructor, with additional phantom argument to constrain the resulting type
+-- | 'Flag'' constructor, with additional phantom argument to constrain the
+-- resulting type.
 alaFlag :: (a -> b) -> Flag a -> Flag' b a
 alaFlag _ = Flag'
 
@@ -84,8 +85,8 @@ remoteRepoGrammar remoteRepoName = do
       }
 
 -- $alaNubList
--- 'alaNubList' and 'alaNubList'' are simply 'NubList'' constructor, with additional phantom
--- arguments to constrain the resulting type
+-- 'alaNubList' and 'alaNubList'' are simply 'NubList'' constructor, with
+-- additional phantom arguments to constrain the resulting type.
 
 -- $alaNubListFSepTokenDoctest
 -- >>> :t alaNubList VCat

--- a/cabal-install/src/Distribution/Client/Utils/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/Utils/Parsec.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/cabal-install/src/Distribution/Client/Utils/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/Utils/Parsec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -51,18 +52,18 @@ instance (Newtype a b, Pretty b) => Pretty (Flag' b a) where
 -- | Like 'List' for usage with a 'FieldGrammar', but for 'NubList'.
 newtype NubList' sep b a = NubList' {_getNubList :: NubList a}
 
+{- FOURMOLU_DISABLE -}
 -- | 'alaNubList' and 'alaNubList'' are simply 'NubList'' constructor, with additional phantom
 -- arguments to constrain the resulting type
 --
 -- >>> :t alaNubList VCat
 -- alaNubList VCat :: NubList a -> NubList' VCat (Identity a) a
 --
--- >>> :t alaNubList' FSep Token
--- alaNubList' FSep Token
---   :: NubList String -> NubList' FSep Token String
+-- $alaNubListFSepTokenDoctest
 --
 -- >>> unpack' (alaNubList' FSep Token) <$> eitherParsec "foo bar foo"
 -- Right ["foo","bar"]
+{- FOURMOLU_ENABLE -}
 alaNubList :: sep -> NubList a -> NubList' sep (Identity a) a
 alaNubList _ = NubList'
 
@@ -89,3 +90,16 @@ remoteRepoGrammar remoteRepoName = do
       { remoteRepoShouldTryHttps = False -- we don't parse remoteRepoShouldTryHttps
       , ..
       }
+
+-- TODO: Find out why GHCi stops using the String type alias.
+#if MIN_VERSION_base(4,22,0)
+-- $alaNubListFSepTokenDoctest
+-- >>> :t alaNubList' FSep Token
+-- alaNubList' FSep Token
+--   :: NubList [Char] -> NubList' FSep Token [Char]
+#else
+-- $alaNubListFSepTokenDoctest
+-- >>> :t alaNubList' FSep Token
+-- alaNubList' FSep Token
+--   :: NubList String -> NubList' FSep Token String
+#endif

--- a/cabal-install/src/Distribution/Client/Utils/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/Utils/Parsec.hs
@@ -4,18 +4,22 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Distribution.Client.Utils.Parsec
-  ( remoteRepoGrammar
+  ( -- * NubList
+    NubList'
+  -- $alaNubList
+  -- $alaNubListFSepTokenDoctest
+  -- $alaNubListFSepTokenDoctestBroken
+  , alaNubList
+  , alaNubList'
 
-    -- ** Flag
+    -- * Flag
   , alaFlag
   , Flag'
 
-    -- ** NubList
-  , alaNubList
-  , alaNubList'
-  , NubList'
+    -- * Remote Repo
+  , remoteRepoGrammar
 
-    -- ** Newtype wrappers
+    -- * Newtype wrappers
   , module Distribution.Client.Utils.Newtypes
   ) where
 
@@ -52,18 +56,6 @@ instance (Newtype a b, Pretty b) => Pretty (Flag' b a) where
 -- | Like 'List' for usage with a 'FieldGrammar', but for 'NubList'.
 newtype NubList' sep b a = NubList' {_getNubList :: NubList a}
 
-{- FOURMOLU_DISABLE -}
--- | 'alaNubList' and 'alaNubList'' are simply 'NubList'' constructor, with additional phantom
--- arguments to constrain the resulting type
---
--- >>> :t alaNubList VCat
--- alaNubList VCat :: NubList a -> NubList' VCat (Identity a) a
---
--- $alaNubListFSepTokenDoctest
---
--- >>> unpack' (alaNubList' FSep Token) <$> eitherParsec "foo bar foo"
--- Right ["foo","bar"]
-{- FOURMOLU_ENABLE -}
 alaNubList :: sep -> NubList a -> NubList' sep (Identity a) a
 alaNubList _ = NubList'
 
@@ -91,14 +83,25 @@ remoteRepoGrammar remoteRepoName = do
       , ..
       }
 
+-- $alaNubList
+-- 'alaNubList' and 'alaNubList'' are simply 'NubList'' constructor, with additional phantom
+-- arguments to constrain the resulting type
+
+-- $alaNubListFSepTokenDoctest
+-- >>> :t alaNubList VCat
+-- alaNubList VCat :: NubList a -> NubList' VCat (Identity a) a
+--
+-- >>> unpack' (alaNubList' FSep Token) <$> eitherParsec "foo bar foo"
+-- Right ["foo","bar"]
+
 -- TODO: Find out why GHCi stops using the String type alias.
 #if MIN_VERSION_base(4,22,0)
--- $alaNubListFSepTokenDoctest
+-- $alaNubListFSepTokenDoctestBroken
 -- >>> :t alaNubList' FSep Token
 -- alaNubList' FSep Token
 --   :: NubList [Char] -> NubList' FSep Token [Char]
 #else
--- $alaNubListFSepTokenDoctest
+-- $alaNubListFSepTokenDoctestBroken
 -- >>> :t alaNubList' FSep Token
 -- alaNubList' FSep Token
 --   :: NubList String -> NubList' FSep Token String


### PR DESCRIPTION
Workaround for #11796 that enables running doctests in `ghc-9.14.1` and leaves a TODO note about the problem.

Split from #11793.

- Get doctest expectations to play nicely with haddocks when expectations change for `ghc-9.14`, when `String` is replaced with `[Char]`. I don't yet know why this is happening and have left a TODO for that problem with the output of a type lookup with `:t`.
- Fixes some other minor haddock markup problems.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
