### PR TITLE
Add a doctest-% pattern target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,14 +158,32 @@ ghcid-lib: ## Run ghcid for the Cabal library.
 ghcid-cli: ## Run ghcid for the cabal-install executable.
 	ghcid -c 'cabal repl cabal-install'
 
-.PHONY: doctest
-doctest: ## Run doctests.
+# doctests
+
+# To find package directories that might have doctests:
+# $ grep --exclude generics-sop-lens.hs -E "\- >>>" **/*.hs | awk -F/ '{print $1}' | sort -u
+DOCTEST_PACKAGES := \
+  Cabal \
+  Cabal-described \
+  Cabal-syntax \
+  cabal-install \
+  cabal-install-solver \
+  cabal-testsuite
+
+DOCTEST_TARGETS := $(addprefix doctest-, $(DOCTEST_PACKAGES))
+
+doctest-%: ## Run doctests for a specific package.
+	@echo "Running doctests for $*:"
 	cabal --numeric-version
-	cd Cabal-syntax && $(DOCTEST)
-	cd Cabal-described && $(DOCTEST)
-	cd Cabal && $(DOCTEST)
-	cd cabal-install-solver && $(DOCTEST)
-	cd cabal-install && $(DOCTEST)
+	@$(DOCTEST) $*
+
+doctest-PACKAGENAME: ## Run doctests for a single package (replace PACKAGENAME).
+	@echo 'Please use one of the following targets:'
+	@printf "%s\n" $(DOCTEST_TARGETS)
+
+.PHONY: doctest
+doctest: ## Run doctests in all packages.
+doctest: $(DOCTEST_TARGETS)
 
 # If we pin and periodically bump the version of doctest, we get more
 # reproducible testing. Initially we pinned to doctest-0.25.0 to avoid failures

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ doctest-%: ## Run doctests for a specific package.
 	@echo "Running doctests for $*:" && cd $* && $(CABAL_DOCTEST) $*
 
 doctest-cabal-testsuite: ## Run doctests for a specific package.
-	@echo "Running doctests for cabal-testsuite:" && $(REPL_WITH_DOCTEST) cabal-testsuite
+	@echo "Running doctests for cabal-testsuite:" && $(CABAL_DOCTEST) cabal-testsuite
 
 doctest-PACKAGENAME: ## Run doctests for a single package (replace PACKAGENAME).
 	@echo 'Please use one of the following targets:'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@
 CABALBUILD := cabal build
 CABALRUN   := cabal run
 
-DOCTEST := cabal doctest
+CABAL_DOCTEST := cabal doctest
+REPL_WITH_DOCTEST := cabal repl --with-compiler=doctest --build-depends=QuickCheck --verbose=0 --repl-options='-w -Wdefault -Wno-inconsistent-flags'
 
 # default rules
 
@@ -173,9 +174,11 @@ DOCTEST_PACKAGES := \
 DOCTEST_TARGETS := $(addprefix doctest-, $(DOCTEST_PACKAGES))
 
 doctest-%: ## Run doctests for a specific package.
-	@echo "Running doctests for $*:"
 	cabal --numeric-version
-	@$(DOCTEST) $*
+	@echo "Running doctests for $*:" && cd $* && $(CABAL_DOCTEST) $*
+
+doctest-cabal-testsuite: ## Run doctests for a specific package.
+	@echo "Running doctests for cabal-testsuite:" && $(REPL_WITH_DOCTEST) cabal-testsuite
 
 doctest-PACKAGENAME: ## Run doctests for a single package (replace PACKAGENAME).
 	@echo 'Please use one of the following targets:'

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,8 @@ DOCTEST_PACKAGES := \
   Cabal-syntax \
   cabal-install \
   cabal-install-solver \
-  cabal-testsuite
+  # Can't include cabal-testsuite because of the --keep-temp-files problem
+  # cabal-testsuite
 
 DOCTEST_TARGETS := $(addprefix doctest-, $(DOCTEST_PACKAGES))
 
@@ -177,12 +178,18 @@ doctest-%: ## Run doctests for a specific package.
 	cabal --numeric-version
 	@echo "Running doctests for $*:" && cd $* && $(CABAL_DOCTEST) $*
 
-doctest-cabal-testsuite: ## Run doctests for a specific package.
-	@echo "Running doctests for cabal-testsuite:" && $(CABAL_DOCTEST) cabal-testsuite
-
 doctest-PACKAGENAME: ## Run doctests for a single package (replace PACKAGENAME).
 	@echo 'Please use one of the following targets:'
 	@printf "%s\n" $(DOCTEST_TARGETS)
+
+# TODO: Fix this problem
+# Configuring cabal-testsuite-3...
+# unrecognized 'repl' option `--keep-temp-files'
+# Error: [Cabal-7125]
+# repl failed for cabal-testsuite-3.
+# make: *** [Makefile:172: doctest-cabal-testsuite] Error 1
+doctest-cabal-testsuite: ## Run doctests for a specific package.
+	@echo "Running doctests for cabal-testsuite:" && $(CABAL_DOCTEST) cabal-testsuite
 
 .PHONY: doctest
 doctest: ## Run doctests in all packages.


### PR DESCRIPTION
Fixes #11798. Adds a `make help` item `doctest-PACKAGENAME` and targets for running doctests for a single package using a `doctest-%` pattern rule.

```
$ make help
...
doctest-PACKAGENAME            Run doctests for a single package (replace PACKAGENAME).
doctest-install                Install doctest tool needed for running doctests.
doctest                        Run doctests in all packages.
```

```
$ make doctest-PACKAGENAME
Please use one of the following targets:
doctest-Cabal
doctest-Cabal-described
doctest-Cabal-syntax
doctest-cabal-install
doctest-cabal-install-solver
doctest-cabal-testsuite
```

> [!NOTE]
> There were doctests in `cabal-testsuite`. These weren't being run before and cannot be run with `cd cabal-testsuite && cabal doctest` so these use `REPL_WITH_DOCTEST`. I renamed `DOCTEST` to `CABAL_DOCTEST`.



---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
