### PR TITLE
Follow hlint suggestion: use lambda-case

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -26,7 +26,6 @@
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
-- ignore: {name: "Use lambda-case"} # 58 hints
 - ignore: {name: "Use newtype instead of data"} # 31 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints

--- a/Cabal-syntax/src/Distribution/Fields/ConfVar.hs
+++ b/Cabal-syntax/src/Distribution/Fields/ConfVar.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Distribution.Fields.ConfVar (parseConditionConfVar, parseConditionConfVarFromClause) where
@@ -35,7 +36,7 @@ import qualified Text.Parsec.Pos as P
 
 parseConditionConfVarFromClause :: B8.ByteString -> Either P.ParseError (Condition ConfVar)
 parseConditionConfVarFromClause x =
-  readFields x >>= \r -> case r of
+  readFields x >>= \case
     (Section _ xs _ : _) -> P.runParser (parser <* P.eof) () "<condition>" xs
     _ -> Left $ P.newErrorMessage (P.Message "No fields in clause") (P.initialPos "<condition>")
 
@@ -124,11 +125,11 @@ parser = condOr
           ]
 
     -- Number token can have many dots in it: SecArgNum (Position 65 15) "7.6.1"
-    identBS = tokenPrim $ \t -> case t of
+    identBS = tokenPrim $ \case
       SecArgName _ s -> Just s
       _ -> Nothing
 
-    boolLiteral' = tokenPrim $ \t -> case t of
+    boolLiteral' = tokenPrim $ \case
       SecArgName _ s
         | s == "True" -> Just True
         | s == "true" -> Just True
@@ -137,11 +138,11 @@ parser = condOr
       _ -> Nothing
 
     string :: B8.ByteString -> Parser ()
-    string s = tokenPrim $ \t -> case t of
+    string s = tokenPrim $ \case
       SecArgName _ s' | s == s' -> Just ()
       _ -> Nothing
 
-    oper o = tokenPrim $ \t -> case t of
+    oper o = tokenPrim $ \case
       SecArgOther _ o' | o == o' -> Just ()
       _ -> Nothing
 

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -124,15 +125,15 @@ tokIndent :: Parser Int
 tokColon, tokCloseBrace :: Parser ()
 tokOpenBrace :: Parser Position
 tokFieldLine :: Parser (FieldLine Position)
-tokSym = getTokenWithPos $ \t -> case t of L pos (TokSym x) -> Just (mkName pos x); _ -> Nothing
-tokSym' = getTokenWithPos $ \t -> case t of L pos (TokSym x) -> Just (SecArgName pos x); _ -> Nothing
-tokStr = getTokenWithPos $ \t -> case t of L pos (TokStr x) -> Just (SecArgStr pos x); _ -> Nothing
-tokOther = getTokenWithPos $ \t -> case t of L pos (TokOther x) -> Just (SecArgOther pos x); _ -> Nothing
-tokIndent = getToken $ \t -> case t of Indent x -> Just x; _ -> Nothing
-tokColon = getToken $ \t -> case t of Colon -> Just (); _ -> Nothing
-tokOpenBrace = getTokenWithPos $ \t -> case t of L pos OpenBrace -> Just pos; _ -> Nothing
-tokCloseBrace = getToken $ \t -> case t of CloseBrace -> Just (); _ -> Nothing
-tokFieldLine = getTokenWithPos $ \t -> case t of L pos (TokFieldLine s) -> Just (FieldLine pos s); _ -> Nothing
+tokSym = getTokenWithPos $ \case L pos (TokSym x) -> Just (mkName pos x); _ -> Nothing
+tokSym' = getTokenWithPos $ \case L pos (TokSym x) -> Just (SecArgName pos x); _ -> Nothing
+tokStr = getTokenWithPos $ \case L pos (TokStr x) -> Just (SecArgStr pos x); _ -> Nothing
+tokOther = getTokenWithPos $ \case L pos (TokOther x) -> Just (SecArgOther pos x); _ -> Nothing
+tokIndent = getToken $ \case Indent x -> Just x; _ -> Nothing
+tokColon = getToken $ \case Colon -> Just (); _ -> Nothing
+tokOpenBrace = getTokenWithPos $ \case L pos OpenBrace -> Just pos; _ -> Nothing
+tokCloseBrace = getToken $ \case CloseBrace -> Just (); _ -> Nothing
+tokFieldLine = getTokenWithPos $ \case L pos (TokFieldLine s) -> Just (FieldLine pos s); _ -> Nothing
 
 colon, openBrace, closeBrace :: Parser ()
 sectionArg :: Parser (SectionArg Position)

--- a/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -560,7 +561,7 @@ versionRangeParser digitParser csv = expr
 --
 -- @since 2.2
 majorUpperBound :: Version -> Version
-majorUpperBound = alterVersion $ \numbers -> case numbers of
+majorUpperBound = alterVersion $ \case
   [] -> [0, 1] -- should not happen
   [m1] -> [m1, 1] -- e.g. version '1'
   (m1 : m2 : _) -> [m1, m2 + 1]

--- a/Cabal/src/Distribution/PackageDescription/Check/Target.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Target.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 -- |
 -- Module      :  Distribution.PackageDescription.Check.Target
 -- Copyright   :  Lennart Kolmodin 2008, Francesco Ariis 2023
@@ -953,7 +955,7 @@ checkGHCOptions title t opts = do
         )
         (PackageDistInexcusable . DynamicUnneeded)
       checkFlagsP
-        ( \opt -> case opt of
+        ( \case
             "-j" -> True
             ('-' : 'j' : d : _) -> isDigit d
             _ -> False

--- a/Cabal/src/Distribution/Simple/Build.hs
+++ b/Cabal/src/Distribution/Simple/Build.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -367,7 +368,7 @@ repl_setupHooks
         verbosity = mkVerbosity verbHandles $ fromFlag (replVerbosity flags)
 
     target <-
-      readTargetInfos verbosity pkg_descr lbi args >>= \r -> case r of
+      readTargetInfos verbosity pkg_descr lbi args >>= \case
         -- This seems DEEPLY questionable.
         [] -> case allTargetsInBuildOrder' pkg_descr lbi of
           (target : _) -> return target

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
@@ -955,7 +956,7 @@ installLib verbosity lbi targetDir dynlibTargetDir bytecodeTargetDir _builtDir p
   info verbosity ("Wanted install ways: " ++ show libWays)
 
   -- copy .hi files over:
-  forM_ (wantedLibWays isIndef) $ \w -> case w of
+  forM_ (wantedLibWays isIndef) $ \case
     StaticWay -> copyModuleFiles (Suffix "hi")
     DynWay -> copyModuleFiles (Suffix "dyn_hi")
     ProfWay -> copyModuleFiles (Suffix "p_hi")
@@ -970,7 +971,7 @@ installLib verbosity lbi targetDir dynlibTargetDir bytecodeTargetDir _builtDir p
     -- without stripping; see doc/internal/bytecode-libraries.md.
     whenBytecodeLib $ installOrdinaryNoStrip builtDir bytecodeTargetDir bytecodeLibName
 
-    forM_ libWays $ \w -> case w of
+    forM_ libWays $ \case
       StaticWay -> do
         sequence_
           [ installOrdinary

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -1256,7 +1257,7 @@ renderPureArgs version comp platform args =
     , bool [] ["--gen-index"] . fromFlagOrDefault False . argGenIndex $ args
     , maybe [] ((: []) . ("--base-url=" ++)) . flagToMaybe . argBaseUrl $ args
     , bool [verbosityFlag] [] . getAny . argVerbose $ args
-    , map (\o -> case o of Hoogle -> "--hoogle"; Html -> "--html")
+    , map (\case Hoogle -> "--hoogle"; Html -> "--html")
         . fromFlagOrDefault []
         . argOutput
         $ args

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -572,7 +573,7 @@ configureOptions showOrParseArgs =
           [ optArgDef'
               "n"
               (show NoOptimisation, Flag . flagToOptimisationLevel)
-              ( \f -> case f of
+              ( \case
                   Flag NoOptimisation -> []
                   Flag NormalOptimisation -> [Nothing]
                   Flag MaximumOptimisation -> [Just "2"]
@@ -594,7 +595,7 @@ configureOptions showOrParseArgs =
           [ optArg'
               "n"
               (Flag . flagToDebugInfoLevel)
-              ( \f -> case f of
+              ( \case
                   Flag NoDebugInfo -> []
                   Flag MinimalDebugInfo -> [Just "1"]
                   Flag NormalDebugInfo -> [Nothing]

--- a/Cabal/src/Distribution/Simple/Setup/Copy.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Copy.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -117,7 +118,7 @@ copyCommand =
           , "COMPONENTS [FLAGS]"
           ]
     , commandDefaultFlags = defaultCopyFlags
-    , commandOptions = \showOrParseArgs -> case showOrParseArgs of
+    , commandOptions = \case
         ShowArgs ->
           filter
             ( (`notElem` ["target-package-db"])
@@ -145,7 +146,7 @@ copyOptions showOrParseArgs =
         ( reqArg
             "DIR"
             (succeedReadE (Flag . CopyTo))
-            (\f -> case f of Flag (CopyTo p) -> [p]; _ -> [])
+            (\case Flag (CopyTo p) -> [p]; _ -> [])
         )
     , option
         ""
@@ -160,7 +161,7 @@ copyOptions showOrParseArgs =
         ( reqArg
             "DATABASE"
             (succeedReadE (Flag . CopyToDb))
-            (\f -> case f of Flag (CopyToDb p) -> [p]; _ -> [])
+            (\case Flag (CopyToDb p) -> [p]; _ -> [])
         )
     ]
 

--- a/Cabal/src/Distribution/Simple/Setup/Install.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Install.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -168,7 +169,7 @@ installOptions =
       ( reqArg
           "DATABASE"
           (succeedReadE (Flag . CopyToDb))
-          (\f -> case f of Flag (CopyToDb p) -> [p]; _ -> [])
+          (\case Flag (CopyToDb p) -> [p]; _ -> [])
       )
   ]
 

--- a/Cabal/src/Distribution/Utils/UnionFind.hs
+++ b/Cabal/src/Distribution/Utils/UnionFind.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 
 -- | A simple mutable union-find data structure.
@@ -50,14 +51,13 @@ fresh desc = do
 -- which points directly to the canonical representation.
 repr :: Point s a -> ST s (Point s a)
 repr point =
-  readPoint point >>= \r ->
-    case r of
-      Link point' -> do
-        point'' <- repr point'
-        when (point'' /= point') $ do
-          writePoint point =<< readPoint point'
-        return point''
-      Info _ _ -> return point
+  readPoint point >>= \case
+    Link point' -> do
+      point'' <- repr point'
+      when (point'' /= point') $ do
+        writePoint point =<< readPoint point'
+      return point''
+    Info _ _ -> return point
 
 -- | Return the canonical element of an equivalence
 -- class 'Point'.
@@ -65,14 +65,12 @@ find :: Point s a -> ST s a
 find point =
   -- Optimize length 0 and 1 case at expense of
   -- general case
-  readPoint point >>= \r ->
-    case r of
-      Info _ d_ref -> readSTRef d_ref
-      Link point' ->
-        readPoint point' >>= \r' ->
-          case r' of
-            Info _ d_ref -> readSTRef d_ref
-            Link _ -> repr point >>= find
+  readPoint point >>= \case
+    Info _ d_ref -> readSTRef d_ref
+    Link point' ->
+      readPoint point' >>= \case
+        Info _ d_ref -> readSTRef d_ref
+        Link _ -> repr point >>= find
 
 -- | Unify two equivalence classes, so that they share
 -- a canonical element. Keeps the descriptor of point2.

--- a/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
 
 -- | Fine-grained package dependencies
 --
@@ -184,9 +185,10 @@ nonSetupDeps = select (/= ComponentSetup)
 -- | Library dependencies proper only.  (Includes dependencies
 -- of internal libraries.)
 libraryDeps :: Monoid a => ComponentDeps a -> a
-libraryDeps = select (\c -> case c of ComponentSubLib _ -> True
-                                      ComponentLib -> True
-                                      _ -> False)
+libraryDeps = select (\case
+  ComponentSubLib _ -> True
+  ComponentLib -> True
+  _ -> False)
 
 -- | List components
 components :: ComponentDeps a -> Set Component

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 module Distribution.Client.CmdHaddockProject
@@ -215,113 +216,114 @@ haddockProjectAction flags _extraArgs globalFlags = do
       -- Copy haddocks to the destination folder
       --
 
-      packageInfos <- fmap (nub . concat) $ for pkgs $ \pkg ->
-        case pkg of
-          Left package | localStyle -> do
-            let packageName = unPackageName (pkgName $ sourcePackageId package)
-                destDir = outputDir </> packageName
-            fmap catMaybes $ for (haddockInterfaces package) $ \interfacePath -> do
-              let docDir = takeDirectory interfacePath
-              a <- doesFileExist interfacePath
-              case a of
-                True -> do
-                  copyDirectoryRecursive verbosity docDir destDir
-                  return $ Just $ Right (packageName, interfacePath, Hidden)
-                False -> return Nothing
-          Left _ -> return []
-          Right package ->
-            case elabLocalToProject package of
-              True -> do
-                let distDirParams = elabDistDirParams sharedConfig' package
-                    pkg_descr = elabPkgDescription package
-
-                    packageName = pkgName $ elabPkgSourceId package
-                    unitId = elabUnitId package
-                    packageDir = haddockDirName ForDevelopment pkg_descr
-                    destDir = outputDir </> packageDir
-                    interfacePath = destDir </> haddockPath pkg_descr
-
-                    buildDir = distBuildDirectory distLayout distDirParams
-                    docDir =
-                      buildDir
-                        </> "doc"
-                        </> "html"
-                        </> packageDir
-
-                a <- doesDirectoryExist docDir
-                if a
-                  then do
-                    copyDirectoryRecursive verbosity docDir destDir
-                    let infos :: [(String, FilePath, Visibility)]
-                        infos =
-                          (unPackageName packageName, interfacePath, Visible)
-                            : [ (sublibDirPath, sublibInterfacePath, Visible)
-                              | lib <- subLibraries pkg_descr
-                              , let sublibDirPath = haddockLibraryDirPath ForDevelopment pkg_descr lib
-                                    sublibInterfacePath =
-                                      outputDir
-                                        </> sublibDirPath
-                                        </> haddockLibraryPath pkg_descr lib
-                              ]
-                            ++ [ (testPath, testInterfacePath, Visible)
-                               | test <- testSuites pkg_descr
-                               , let testPath = haddockTestDirPath ForDevelopment pkg_descr test
-                                     testInterfacePath =
-                                      outputDir
-                                        </> testPath
-                                        </> haddockPath pkg_descr
-                               ]
-                            ++ [ (benchPath, benchInterfacePath, Visible)
-                               | bench <- benchmarks pkg_descr
-                               , let benchPath = haddockBenchmarkDirPath ForDevelopment pkg_descr bench
-                                     benchInterfacePath =
-                                      outputDir
-                                        </> benchPath
-                                        </> haddockPath pkg_descr
-                               ]
-                    infos' <-
-                      mapM
-                        ( \x@(_, path, _) -> do
-                            e <- doesFileExist path
-                            return $
-                              if e
-                                then Right x
-                                else Left path
-                        )
-                        infos
-                    return infos'
-                  else do
-                    warn
-                      verbosity
-                      ( "haddocks of "
-                          ++ unUnitId unitId
-                          ++ " not found in the store"
-                      )
-                    return []
-              False
-                | not localStyle ->
-                    return []
-              False -> do
-                let pkg_descr = elabPkgDescription package
-                    unitId = unUnitId (elabUnitId package)
-                    packageDir =
-                      storePackageDirectory
-                        (cabalStoreDirLayout cabalLayout)
-                        (pkgConfigCompiler sharedConfig')
-                        (elabUnitId package)
-                    -- TODO: use `InstallDirTemplates`
-                    docDir = packageDir </> "share" </> "doc" </> "html"
-                    destDir = outputDir </> haddockDirName ForDevelopment pkg_descr
-                    interfacePath = destDir </> haddockPath pkg_descr
-                a <- doesDirectoryExist docDir
+      packageInfos <- fmap (nub . concat) $
+        for pkgs $
+          \case
+            Left package | localStyle -> do
+              let packageName = unPackageName (pkgName $ sourcePackageId package)
+                  destDir = outputDir </> packageName
+              fmap catMaybes $ for (haddockInterfaces package) $ \interfacePath -> do
+                let docDir = takeDirectory interfacePath
+                a <- doesFileExist interfacePath
                 case a of
                   True -> do
                     copyDirectoryRecursive verbosity docDir destDir
-                    -- non local packages will be hidden in haddock's
-                    -- generated contents page
-                    return [Right (unitId, interfacePath, Hidden)]
-                  False -> do
-                    return [Left unitId]
+                    return $ Just $ Right (packageName, interfacePath, Hidden)
+                  False -> return Nothing
+            Left _ -> return []
+            Right package ->
+              case elabLocalToProject package of
+                True -> do
+                  let distDirParams = elabDistDirParams sharedConfig' package
+                      pkg_descr = elabPkgDescription package
+
+                      packageName = pkgName $ elabPkgSourceId package
+                      unitId = elabUnitId package
+                      packageDir = haddockDirName ForDevelopment pkg_descr
+                      destDir = outputDir </> packageDir
+                      interfacePath = destDir </> haddockPath pkg_descr
+
+                      buildDir = distBuildDirectory distLayout distDirParams
+                      docDir =
+                        buildDir
+                          </> "doc"
+                          </> "html"
+                          </> packageDir
+
+                  a <- doesDirectoryExist docDir
+                  if a
+                    then do
+                      copyDirectoryRecursive verbosity docDir destDir
+                      let infos :: [(String, FilePath, Visibility)]
+                          infos =
+                            (unPackageName packageName, interfacePath, Visible)
+                              : [ (sublibDirPath, sublibInterfacePath, Visible)
+                                | lib <- subLibraries pkg_descr
+                                , let sublibDirPath = haddockLibraryDirPath ForDevelopment pkg_descr lib
+                                      sublibInterfacePath =
+                                        outputDir
+                                          </> sublibDirPath
+                                          </> haddockLibraryPath pkg_descr lib
+                                ]
+                              ++ [ (testPath, testInterfacePath, Visible)
+                                 | test <- testSuites pkg_descr
+                                 , let testPath = haddockTestDirPath ForDevelopment pkg_descr test
+                                       testInterfacePath =
+                                        outputDir
+                                          </> testPath
+                                          </> haddockPath pkg_descr
+                                 ]
+                              ++ [ (benchPath, benchInterfacePath, Visible)
+                                 | bench <- benchmarks pkg_descr
+                                 , let benchPath = haddockBenchmarkDirPath ForDevelopment pkg_descr bench
+                                       benchInterfacePath =
+                                        outputDir
+                                          </> benchPath
+                                          </> haddockPath pkg_descr
+                                 ]
+                      infos' <-
+                        mapM
+                          ( \x@(_, path, _) -> do
+                              e <- doesFileExist path
+                              return $
+                                if e
+                                  then Right x
+                                  else Left path
+                          )
+                          infos
+                      return infos'
+                    else do
+                      warn
+                        verbosity
+                        ( "haddocks of "
+                            ++ unUnitId unitId
+                            ++ " not found in the store"
+                        )
+                      return []
+                False
+                  | not localStyle ->
+                      return []
+                False -> do
+                  let pkg_descr = elabPkgDescription package
+                      unitId = unUnitId (elabUnitId package)
+                      packageDir =
+                        storePackageDirectory
+                          (cabalStoreDirLayout cabalLayout)
+                          (pkgConfigCompiler sharedConfig')
+                          (elabUnitId package)
+                      -- TODO: use `InstallDirTemplates`
+                      docDir = packageDir </> "share" </> "doc" </> "html"
+                      destDir = outputDir </> haddockDirName ForDevelopment pkg_descr
+                      interfacePath = destDir </> haddockPath pkg_descr
+                  a <- doesDirectoryExist docDir
+                  case a of
+                    True -> do
+                      copyDirectoryRecursive verbosity docDir destDir
+                      -- non local packages will be hidden in haddock's
+                      -- generated contents page
+                      return [Right (unitId, interfacePath, Hidden)]
+                    False -> do
+                      return [Left unitId]
 
       --
       -- generate index, content, etc.

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -523,7 +524,7 @@ depsFromLocalPackages verbosity ctx targetSelectors = do
         selectComponentTargetForOutdated
         (localPackages ctx)
         targetSelectors
-  fmap concat <$> forM (localPackages ctx) $ \pkg -> case pkg of
+  fmap concat <$> forM (localPackages ctx) $ \case
     SpecificSourcePackage pkg' -> do
       -- Find the package in the resolved targets
       let pkgId = packageId pkg'

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 -----------------------------------------------------------------------------
@@ -1202,7 +1203,7 @@ configFieldDescriptions src =
           $ let name = "optimization"
              in FieldDescr
                   name
-                  ( \f -> case f of
+                  ( \case
                       Flag NoOptimisation -> Disp.text "False"
                       Flag NormalOptimisation -> Disp.text "True"
                       Flag MaximumOptimisation -> Disp.text "2"
@@ -1233,7 +1234,7 @@ configFieldDescriptions src =
           let name = "debug-info"
            in FieldDescr
                 name
-                ( \f -> case f of
+                ( \case
                     Flag NoDebugInfo -> Disp.text "False"
                     Flag MinimalDebugInfo -> Disp.text "1"
                     Flag NormalDebugInfo -> Disp.text "True"

--- a/cabal-install/src/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/FileMonitor.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -1181,10 +1182,9 @@ readCacheFileHashes
 readCacheFileHashes monitor =
   handleDoesNotExist Map.empty $
     handleErrorCall Map.empty $
-      withCacheFile monitor $ \res ->
-        case res of
-          Left _ -> return Map.empty
-          Right (msfs, _, _) -> return (mkFileHashCache msfs)
+      withCacheFile monitor $ \case
+        Left _ -> return Map.empty
+        Right (msfs, _, _) -> return (mkFileHashCache msfs)
   where
     mkFileHashCache :: MonitorStateFileSet -> FileHashCache
     mkFileHashCache (MonitorStateFileSet singlePaths globPaths) =

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -990,7 +990,7 @@ testAction (buildFlags, testFlags) extraArgs globalFlags = do
       mbWorkDir
       distPref
       "test suites"
-      (\c -> case c of LBI.CTest{} -> True; _ -> False)
+      (\case LBI.CTest{} -> True; _ -> False)
 
   let extraArgs'
         | null extraArgs = case names of
@@ -1114,7 +1114,7 @@ benchmarkAction
         mbWorkDir
         distPref
         "benchmarks"
-        (\c -> case c of LBI.CBench{} -> True; _ -> False)
+        (\case LBI.CBench{} -> True; _ -> False)
 
     let extraArgs'
           | null extraArgs = case names of

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1720,7 +1720,7 @@ legacyPackageConfigFieldDescrs =
         $ let name = "build-info"
            in FieldDescr
                 name
-                ( \f -> case f of
+                ( \case
                     Flag NoDumpBuildInfo -> Disp.text "False"
                     Flag DumpBuildInfo -> Disp.text "True"
                     _ -> Disp.empty
@@ -1748,7 +1748,7 @@ legacyPackageConfigFieldDescrs =
         $ let name = "optimization"
            in FieldDescr
                 name
-                ( \f -> case f of
+                ( \case
                     Flag NoOptimisation -> Disp.text "False"
                     Flag NormalOptimisation -> Disp.text "True"
                     Flag MaximumOptimisation -> Disp.text "2"
@@ -1773,7 +1773,7 @@ legacyPackageConfigFieldDescrs =
         let name = "debug-info"
          in FieldDescr
               name
-              ( \f -> case f of
+              ( \case
                   Flag NoDebugInfo -> Disp.text "False"
                   Flag MinimalDebugInfo -> Disp.text "1"
                   Flag NormalDebugInfo -> Disp.text "True"

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -470,7 +471,7 @@ runProjectBuildPhase
     where
       previousBuildOutcomes :: BuildStatusMap -> BuildOutcomes
       previousBuildOutcomes =
-        Map.mapMaybe $ \status -> case status of
+        Map.mapMaybe $ \case
           BuildStatusUpToDate buildSuccess -> Just (Right buildSuccess)
           -- TODO: [nice to have] record build failures persistently
           _ -> Nothing

--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -665,27 +666,24 @@ postBuildProjectStatus
 
       packagesBuildLocal :: Set UnitId
       packagesBuildLocal =
-        selectPlanPackageIdSet $ \pkg ->
-          case pkg of
-            InstallPlan.PreExisting _ -> False
-            InstallPlan.Installed _ -> False
-            InstallPlan.Configured srcpkg -> elabLocalToProject srcpkg
+        selectPlanPackageIdSet $ \case
+          InstallPlan.PreExisting _ -> False
+          InstallPlan.Installed _ -> False
+          InstallPlan.Configured srcpkg -> elabLocalToProject srcpkg
 
       packagesBuildInplace :: Set UnitId
       packagesBuildInplace =
-        selectPlanPackageIdSet $ \pkg ->
-          case pkg of
-            InstallPlan.PreExisting _ -> False
-            InstallPlan.Installed _ -> False
-            InstallPlan.Configured srcpkg -> isInplaceBuildStyle (elabBuildStyle srcpkg)
+        selectPlanPackageIdSet $ \case
+          InstallPlan.PreExisting _ -> False
+          InstallPlan.Installed _ -> False
+          InstallPlan.Configured srcpkg -> isInplaceBuildStyle (elabBuildStyle srcpkg)
 
       packagesAlreadyInStore :: Set UnitId
       packagesAlreadyInStore =
-        selectPlanPackageIdSet $ \pkg ->
-          case pkg of
-            InstallPlan.PreExisting _ -> True
-            InstallPlan.Installed _ -> True
-            InstallPlan.Configured _ -> False
+        selectPlanPackageIdSet $ \case
+          InstallPlan.PreExisting _ -> True
+          InstallPlan.Installed _ -> True
+          InstallPlan.Configured _ -> False
 
       selectPlanPackageIdSet
         :: ( InstallPlan.GenericPlanPackage InstalledPackageInfo ElaboratedConfiguredPackage

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2257,7 +2257,7 @@ elaborateInstallPlan
             elabStanzasAvailable = stanzas
 
             elabStanzasRequested :: OptionalStanzaMap (Maybe Bool)
-            elabStanzasRequested = optStanzaTabulate $ \o -> case o of
+            elabStanzasRequested = optStanzaTabulate $ \case
               -- NB: even if a package stanza is requested, if the package
               -- doesn't actually have any of that stanza we omit it from
               -- the request, to ensure that we don't decide that this

--- a/cabal-install/src/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/src/Distribution/Client/RebuildMonad.hs
@@ -220,12 +220,11 @@ delayInitSharedResource action = do
   where
     getOrInitResource :: MVar (Maybe a) -> IO a
     getOrInitResource var =
-      modifyMVar var $ \mx ->
-        case mx of
-          Just x -> return (Just x, x)
-          Nothing -> do
-            x <- action
-            return (Just x, x)
+      modifyMVar var $ \case
+        Just x -> return (Just x, x)
+        Nothing -> do
+          x <- action
+          return (Just x, x)
 
 -- | Much like 'delayInitSharedResource' but for a keyed set of resources.
 --

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -2637,7 +2637,7 @@ installOptions showOrParseArgs =
       ( reqArg
           "DATABASE"
           (succeedReadE (Flag . Cabal.CopyToDb))
-          (\f -> case f of Flag (Cabal.CopyToDb p) -> [p]; _ -> [])
+          (\case Flag (Cabal.CopyToDb p) -> [p]; _ -> [])
       )
   ]
     ++ optionSolverFlags

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module UnitTests.Distribution.Client.ArbitraryInstances
@@ -319,7 +320,7 @@ instance Arbitrary a => Arbitrary (OptionalStanzaMap a) where
   arbitrary = do
     x1 <- arbitrary
     x2 <- arbitrary
-    return $ optStanzaTabulate $ \x -> case x of
+    return $ optStanzaTabulate $ \case
       TestStanzas -> x1
       BenchStanzas -> x2
 

--- a/cabal-testsuite/PackageTests/ExtraProgPathGlobal/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ExtraProgPathGlobal/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -29,7 +30,7 @@ main = cabalTest $ do
       case mb_sh of
           Nothing -> skip "no sh"
           Just sh -> do
-            let escape = concatMap (\c -> case c of '\\' -> "\\\\\\\\"; x -> [x])
+            let escape = concatMap (\case '\\' -> "\\\\\\\\"; x -> [x])
             void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> escape sh <> "/g", escape (scripts </> "pkg-config.shim"), escape (scripts_winpath </> "pkg-config.shim") ]
             void $ shell "sed" [ "-i", "-e", "s/SCRIPTSDIR/" <> escape scripts <> "/g", escape (scripts </> "pkg-config.shim") ]
             void $ shell "sed" [ "-i", "-e", "s/SCRIPTSWINPATHDIR/" <> escape scripts_winpath <> "/g", escape (scripts_winpath </> "pkg-config.shim") ]

--- a/cabal-testsuite/PackageTests/ExtraProgPathLocal/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ExtraProgPathLocal/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -20,7 +21,7 @@ main = cabalTest $ do
       case mb_sh of
           Nothing -> skip "no sh"
           Just sh -> do
-            let escape = concatMap (\c -> case c of '\\' -> "\\\\\\\\"; x -> [x])
+            let escape = concatMap (\case '\\' -> "\\\\\\\\"; x -> [x])
             void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> escape sh <> "/g", escape (scripts1 </> "alex.shim"), escape (scripts2 </> "alex.shim") ]
             void $ shell "sed" [ "-i", "-e", "s/SCRIPTSDIR/" <> escape scripts1 <> "/g", escape (scripts1 </> "alex.shim") ]
             void $ shell "sed" [ "-i", "-e", "s/SCRIPTS2DIR/" <> escape scripts2 <> "/g", escape (scripts2 </> "alex.shim") ]

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectory/setup.test.hs
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectory/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -7,7 +8,7 @@ main = setupAndCabalTest $ do
         case sh of
             Nothing -> skip "no sh"
             Just sh' -> do
-                let sh'' = concatMap (\c -> case c of
+                let sh'' = concatMap (\case
                             '\\' -> "\\\\\\\\"
                             x -> [x]) sh'
                 void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> sh'' <> "/g", "ghc.shim", "ghc-pkg.shim"]

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryGhcVersion/setup.test.hs
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryGhcVersion/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -7,7 +8,7 @@ main = setupAndCabalTest $ do
         case sh of
             Nothing -> skip "no sh"
             Just sh' -> do
-                let sh'' = concatMap (\c -> case c of
+                let sh'' = concatMap (\case
                             '\\' -> "\\\\\\\\"
                             x -> [x]) sh'
                 void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> sh'' <> "/g", "ghc-7.10.shim", "ghc-pkg-ghc-7.10.shim"]

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryVersion/setup.test.hs
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryVersion/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -7,7 +8,7 @@ main = setupAndCabalTest $ do
         case sh of
             Nothing -> skip "no sh"
             Just sh' -> do
-                let sh'' = concatMap (\c -> case c of
+                let sh'' = concatMap (\case
                             '\\' -> "\\\\\\\\"
                             x -> [x]) sh'
                 void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> sh'' <> "/g", "ghc-7.10.shim", "ghc-pkg-7.10.shim"]

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/Symlink/setup.test.hs
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/Symlink/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -7,7 +8,7 @@ main = setupAndCabalTest $ do
         case sh of
             Nothing -> skip "no sh"
             Just sh' -> do
-                let sh'' = concatMap (\c -> case c of
+                let sh'' = concatMap (\case
                             '\\' -> "\\\\\\\\"
                             x -> [x]) sh'
                 void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> sh'' <> "/g", "bin/ghc.shim", "bin/ghc-pkg.shim"]

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SymlinkGhcVersion/setup.test.hs
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SymlinkGhcVersion/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -7,7 +8,7 @@ main = setupAndCabalTest $ do
         case sh of
             Nothing -> skip "no sh"
             Just sh' -> do
-                let sh'' = concatMap (\c -> case c of
+                let sh'' = concatMap (\case
                             '\\' -> "\\\\\\\\"
                             x -> [x]) sh'
                 void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> sh'' <> "/g", "bin/ghc-7.10.shim", "bin/ghc-pkg-7.10.shim"]

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SymlinkVersion/setup.test.hs
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SymlinkVersion/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
 import System.Directory
 
@@ -7,7 +8,7 @@ main = setupAndCabalTest $ do
         case sh of
             Nothing -> skip "no sh"
             Just sh' -> do
-                let sh'' = concatMap (\c -> case c of
+                let sh'' = concatMap (\case
                             '\\' -> "\\\\\\\\"
                             x -> [x]) sh'
                 void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> sh'' <> "/g", "bin/ghc-7.10.shim", "bin/ghc-pkg-ghc-7.10.shim"]

--- a/cabal-testsuite/PackageTests/PkgConfigParse/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PkgConfigParse/setup.test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 import System.Directory
 import Test.Cabal.Prelude
 
@@ -8,7 +9,7 @@ main = cabalTest $ do
         case sh of
             Nothing -> skip "no sh"
             Just sh' -> do
-                let sh'' = concatMap (\c -> case c of
+                let sh'' = concatMap (\case
                             '\\' -> "\\\\\\\\"
                             x -> [x]) sh'
                 void $ shell "sed" [ "-i", "-e", "s/FINDSH/" <> sh'' <> "/g", "pkg-config.shim"]

--- a/cabal-testsuite/src/Test/Cabal/Server.hs
+++ b/cabal-testsuite/src/Test/Cabal/Server.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -267,8 +268,7 @@ initServer :: Server -> IO Server
 initServer s0 = do
     -- NB: withProcessHandle reads an MVar and is interruptible
 
-    pid <- withProcessHandle (serverProcessHandle s0) $ \ph ->
-              case ph of
+    pid <- withProcessHandle (serverProcessHandle s0) $ \case
 #if mingw32_HOST_OS
                   OpenHandle x   -> fmap show (Win32.getProcessId x)
 #else


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use lambda-case" suggestion so that these will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved. I've left the styling change to module `CmdHaddockProject` separate for an easier review.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
