### PR TITLE
Ignore hlint suggestion: use fold in Test.Laws

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -24,7 +24,6 @@
 - ignore: {name: "Use bimap"} # 7 hints
 - ignore: {name: "Use camelCase"} # 97 hints
 - ignore: {name: "Use const"} # 36 hints
-- ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use lambda-case"} # 58 hints
 - ignore: {name: "Use newtype instead of data"} # 31 hints
@@ -37,6 +36,7 @@
 - ignore: {name: "Monoid law, right identity", within: [Test.Laws, UnitTests.Distribution.Utils.NubList]}
 - ignore: {name: "Replace case with maybe", within: [Distribution.Client.InLibrary]}
 - ignore: {name: "Use fmap", within: [Distribution.Client.HttpUtils, Distribution.Simple.SrcDist]}
+- ignore: {name: "Use fold", within: [Test.Laws]}
 
 - group:
     name: cabal-suggestions


### PR DESCRIPTION
See #9110. Minor. Ignores HLint's "use fold" suggestion only within module `Test.Laws` so that this will be suggested by our CI linting.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
