### PR TITLE
Remove redundant constraints

### DIFF
--- a/Cabal-syntax/src/Distribution/Compat/Semigroup.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Semigroup.hs
@@ -47,7 +47,7 @@ gmempty = to gmempty'
 class GSemigroup f => GMonoid f where
   gmempty' :: f p
 
-instance (Semigroup a, Monoid a) => GMonoid (K1 i a) where
+instance Monoid a => GMonoid (K1 i a) where
   gmempty' = K1 mempty
 
 instance GMonoid f => GMonoid (M1 i c f) where

--- a/Cabal-syntax/src/Distribution/Compiler.hs
+++ b/Cabal-syntax/src/Distribution/Compiler.hs
@@ -162,7 +162,7 @@ instance Semigroup a => Semigroup (PerCompilerFlavor a) where
       (a <> a')
       (b <> b')
 
-instance (Semigroup a, Monoid a) => Monoid (PerCompilerFlavor a) where
+instance Monoid a => Monoid (PerCompilerFlavor a) where
   mempty = PerCompilerFlavor mempty mempty
   mappend = (<>)
 

--- a/Cabal-syntax/src/Distribution/FieldGrammar/Class.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Class.hs
@@ -209,7 +209,7 @@ optionalField fn l = optionalFieldAla fn Identity l
 
 -- | Optional field with default value.
 optionalFieldDef
-  :: (FieldGrammar c g, Functor (g s), c (Identity a), Eq a)
+  :: (FieldGrammar c g, c (Identity a), Eq a)
   => FieldName
   -- ^ field name
   -> ALens' s a

--- a/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
@@ -177,10 +177,8 @@ libraryFieldGrammar
      , c (List CommaVCat (Identity ModuleReexport) ModuleReexport)
      , c (List FSep (MQuoted Extension) Extension)
      , c (List FSep (MQuoted Language) Language)
-     , c (List FSep Token String)
      , c (List NoCommaFSep Token' String)
      , c (List VCat (MQuoted ModuleName) ModuleName)
-     , c (List VCat (RelativePathNT Pkg File) (RelativePath Pkg File))
      , c (List FSep (SymbolicPathNT Pkg (Dir Framework)) (SymbolicPath Pkg (Dir Framework)))
      , c (List FSep (SymbolicPathNT Pkg (Dir Lib)) (SymbolicPath Pkg (Dir Lib)))
      , c (List FSep (SymbolicPathNT Pkg (Dir Source)) (SymbolicPath Pkg (Dir Source)))
@@ -233,7 +231,6 @@ foreignLibFieldGrammar
      , c (List FSep (Identity ForeignLibOption) ForeignLibOption)
      , c (List FSep (MQuoted Extension) Extension)
      , c (List FSep (MQuoted Language) Language)
-     , c (List FSep Token String)
      , c (List FSep (SymbolicPathNT Pkg (Dir Framework)) (SymbolicPath Pkg (Dir Framework)))
      , c (List FSep (SymbolicPathNT Pkg (Dir Lib)) (SymbolicPath Pkg (Dir Lib)))
      , c (List FSep (SymbolicPathNT Pkg (Dir Source)) (SymbolicPath Pkg (Dir Source)))
@@ -277,7 +274,6 @@ executableFieldGrammar
      , c (List CommaVCat (Identity Mixin) Mixin)
      , c (List FSep (MQuoted Extension) Extension)
      , c (List FSep (MQuoted Language) Language)
-     , c (List FSep Token String)
      , c (List FSep (SymbolicPathNT Pkg (Dir Framework)) (SymbolicPath Pkg (Dir Framework)))
      , c (List FSep (SymbolicPathNT Pkg (Dir Lib)) (SymbolicPath Pkg (Dir Lib)))
      , c (List FSep (SymbolicPathNT Pkg (Dir Source)) (SymbolicPath Pkg (Dir Source)))
@@ -355,7 +351,6 @@ testSuiteFieldGrammar
      , c (List CommaVCat (Identity Mixin) Mixin)
      , c (List FSep (MQuoted Extension) Extension)
      , c (List FSep (MQuoted Language) Language)
-     , c (List FSep Token String)
      , c (List NoCommaFSep Token' String)
      , c (List VCat (MQuoted ModuleName) ModuleName)
      , c (List FSep (SymbolicPathNT Pkg (Dir Framework)) (SymbolicPath Pkg (Dir Framework)))
@@ -504,7 +499,6 @@ benchmarkFieldGrammar
      , c (List CommaVCat (Identity Mixin) Mixin)
      , c (List FSep (MQuoted Extension) Extension)
      , c (List FSep (MQuoted Language) Language)
-     , c (List FSep Token String)
      , c (List NoCommaFSep Token' String)
      , c (List VCat (MQuoted ModuleName) ModuleName)
      , c (List FSep (SymbolicPathNT Pkg (Dir Framework)) (SymbolicPath Pkg (Dir Framework)))
@@ -611,7 +605,6 @@ buildInfoFieldGrammar
      , c (List CommaVCat (Identity Mixin) Mixin)
      , c (List FSep (MQuoted Extension) Extension)
      , c (List FSep (MQuoted Language) Language)
-     , c (List FSep Token String)
      , c (List NoCommaFSep Token' String)
      , c (List VCat (MQuoted ModuleName) ModuleName)
      , c (List FSep (SymbolicPathNT Pkg (Dir Framework)) (SymbolicPath Pkg (Dir Framework)))
@@ -812,7 +805,7 @@ flagFieldGrammar name =
 -------------------------------------------------------------------------------
 
 sourceRepoFieldGrammar
-  :: (FieldGrammar c g, Applicative (g SourceRepo), c (Identity RepoType), c Token, c FilePathNT)
+  :: (FieldGrammar c g, Applicative (g SourceRepo), c (Identity RepoType))
   => RepoKind
   -> g SourceRepo SourceRepo
 sourceRepoFieldGrammar kind =

--- a/Cabal-syntax/src/Distribution/Types/CondTree.hs
+++ b/Cabal-syntax/src/Distribution/Types/CondTree.hs
@@ -66,7 +66,7 @@ instance (NFData v, NFData a) => NFData (CondTree v a) where rnf = genericRnf
 instance Semigroup a => Semigroup (CondTree v a) where
   (CondNode a bs) <> (CondNode a' bs') = CondNode (a <> a') (bs <> bs')
 
-instance (Semigroup a, Monoid a) => Monoid (CondTree v a) where
+instance Monoid a => Monoid (CondTree v a) where
   mappend = (<>)
   mempty = CondNode mempty mempty
 

--- a/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
@@ -503,7 +503,7 @@ versionRangeParser digitParser csv = expr
               , prettyShow (foldr1 unionVersionRanges (fmap op vs))
               ]
 
-    verSet :: CabalParsing m => m (NonEmpty Version)
+    verSet :: m (NonEmpty Version)
     verSet = do
       _ <- P.char '{'
       P.spaces
@@ -512,22 +512,22 @@ versionRangeParser digitParser csv = expr
       pure vs
 
     -- a plain version without tags or wildcards
-    verPlain :: CabalParsing m => m Version
+    verPlain :: m Version
     verPlain = mkVersion . toList <$> P.sepByNonEmpty digitParser (P.char '.')
 
     -- either wildcard or normal version
-    verOrWild :: CabalParsing m => m (Bool, Version)
+    verOrWild :: m (Bool, Version)
     verOrWild = do
       x <- digitParser
       verLoop (DList.singleton x)
 
     -- trailing: wildcard (.y.*) or normal version (optional tags) (.y.z-tag)
-    verLoop :: CabalParsing m => DList.DList Int -> m (Bool, Version)
+    verLoop :: DList.DList Int -> m (Bool, Version)
     verLoop acc =
       verLoop' acc
         <|> (tags *> pure (False, mkVersion (DList.toList acc)))
 
-    verLoop' :: CabalParsing m => DList.DList Int -> m (Bool, Version)
+    verLoop' :: DList.DList Int -> m (Bool, Version)
     verLoop' acc = do
       _ <- P.char '.'
       let digit = digitParser >>= verLoop . DList.snoc acc
@@ -542,7 +542,7 @@ versionRangeParser digitParser csv = expr
         P.spaces
         return a
 
-    tags :: CabalParsing m => m ()
+    tags :: m ()
     tags = do
       ts <- many $ P.char '-' *> some (P.satisfy isAlphaNum)
       case ts of

--- a/Cabal-syntax/src/Distribution/Utils/Structured.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Structured.hs
@@ -227,7 +227,7 @@ structureBuilder s0 = State.evalState (go s0) Map.empty
 -- @since 3.2.0.0
 class Typeable a => Structured a where
   structure :: Proxy a -> Structure
-  default structure :: (Generic a, GStructured (Rep a)) => Proxy a -> Structure
+  default structure :: GStructured (Rep a) => Proxy a -> Structure
   structure = genericStructure
 
   -- This member is hidden. It's there to precalc
@@ -332,7 +332,7 @@ containerStructure _ =
 -------------------------------------------------------------------------------
 
 -- | Derive 'structure' generically.
-genericStructure :: forall a. (Typeable a, Generic a, GStructured (Rep a)) => Proxy a -> Structure
+genericStructure :: forall a. (Typeable a, GStructured (Rep a)) => Proxy a -> Structure
 genericStructure _ = gstructured (typeRep (Proxy :: Proxy a)) (Proxy :: Proxy (Rep a)) 0
 
 -- | Used to implement 'genericStructure'.

--- a/Cabal-tests/tests/HackageTests.hs
+++ b/Cabal-tests/tests/HackageTests.hs
@@ -469,7 +469,7 @@ fieldLinesToString fieldLines =
 -- | We assume that monoid is commutative.
 --
 -- First we chunk input (as single cabal file is little work)
-foldIO :: forall a m. (Monoid m, NFData m) => (a -> IO m) -> [a] -> IO m
+foldIO :: forall a m. (Monoid m) => (a -> IO m) -> [a] -> IO m
 foldIO f = go mempty where
     go !acc [] = acc
     go !acc (x:xs) = go (mappend acc (f x)) xs

--- a/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
+++ b/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
@@ -40,7 +40,7 @@ import qualified Distribution.Compat.NonEmptySet as NES
 -- instances
 -------------------------------------------------------------------------------
 
-instance (Eq a, Show a) => ToExpr (Condition a) where toExpr = defaultExprViaShow
+instance (Show a) => ToExpr (Condition a) where toExpr = defaultExprViaShow
 instance (Show a, ToExpr c, Show c, Eq a, Eq c) => ToExpr (CondTree a c)
 instance (Show a, ToExpr c, Show c, Eq a, Eq c) => ToExpr (CondBranch a c)
 instance (ToExpr a) => ToExpr (NubList a)

--- a/Cabal/src/Distribution/PackageDescription/Check/Monad.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Monad.hs
@@ -136,8 +136,7 @@ data CheckCtx m = CheckCtx
 -- | Creates a pristing 'CheckCtx'. With pristine we mean everything that
 -- can be deduced by GPD but *not* user flags information.
 pristineCheckCtx
-  :: Monad m
-  => CheckInterface m
+  :: CheckInterface m
   -> GenericPackageDescription
   -> CheckCtx m
 pristineCheckCtx ci gpd =
@@ -151,7 +150,7 @@ pristineCheckCtx ci gpd =
 
 -- | Adds useful bits to 'CheckCtx' (as now, whether we are operating under
 -- a user off-by-default flag).
-initCheckCtx :: Monad m => TargetAnnotation a -> CheckCtx m -> CheckCtx m
+initCheckCtx :: TargetAnnotation a -> CheckCtx m -> CheckCtx m
 initCheckCtx t c = c{ccFlag = taPackageFlag t}
 
 -- | 'TargetAnnotation' collects contextual information on the target we are
@@ -323,7 +322,7 @@ checkIntDep acc mck = do
   po <- asksCM (acc . ccInterface)
   maybe (return ()) (lc . mck) po
   where
-    lc :: Monad m => m (Maybe PackageCheck) -> CheckM m ()
+    lc :: m (Maybe PackageCheck) -> CheckM m ()
     lc wmck = do
       b <- liftCM wmck
       maybe (return ()) (check True) b

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -2307,7 +2307,7 @@ getInstalledPackagesMonitorFiles verbosity comp mbWorkDir packageDBs progdb plat
 -- | Looks up the 'InstalledPackageInfo' of the given 'UnitId's from the
 -- 'PackageDBStack' in the 'LocalBuildInfo'.
 getInstalledPackagesById
-  :: (Exception (VerboseException exception), Show exception, Typeable exception)
+  :: Exception (VerboseException exception)
   => Verbosity
   -> LocalBuildInfo
   -> (UnitId -> exception)

--- a/Cabal/src/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/src/Distribution/Simple/InstallDirs.hs
@@ -114,7 +114,7 @@ instance Binary dir => Binary (InstallDirs dir)
 instance NFData dir => NFData (InstallDirs dir)
 instance Structured dir => Structured (InstallDirs dir)
 
-instance (Semigroup dir, Monoid dir) => Monoid (InstallDirs dir) where
+instance Monoid dir => Monoid (InstallDirs dir) where
   mempty = gmempty
   mappend = (<>)
 

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -464,7 +464,7 @@ data VerboseException a = VerboseException CallStack POSIXTime VerbosityFlags a
   deriving (Show)
 
 -- Function which will replace the existing die' call sites
-dieWithException :: (HasCallStack, Show a1, Typeable a1, Exception (VerboseException a1)) => Verbosity -> a1 -> IO a
+dieWithException :: (HasCallStack, Exception (VerboseException a1)) => Verbosity -> a1 -> IO a
 dieWithException verbosity exception = do
   ts <- getPOSIXTime
   throwIO $ VerboseException callStack ts (verbosityFlags verbosity) exception

--- a/Cabal/src/Distribution/Utils/NubList.hs
+++ b/Cabal/src/Distribution/Utils/NubList.hs
@@ -75,7 +75,7 @@ instance (Ord a, Binary a) => Binary (NubList a) where
 
 instance Structured a => Structured (NubList a)
 
-instance (Ord a, NFData a) => NFData (NubList a) where
+instance NFData a => NFData (NubList a) where
   rnf (NubList xs) = rnf xs
 
 -- | NubListR : A right-biased version of 'NubList'. That is @toNubListR

--- a/cabal-install/src/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/src/Distribution/Client/CmdLegacy.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Distribution.Client.CmdLegacy (legacyCmd, legacyWrapperCmd, newCmd) where
 

--- a/cabal-install/src/Distribution/Client/Errors/Parser.hs
+++ b/cabal-install/src/Distribution/Client/Errors/Parser.hs
@@ -106,7 +106,7 @@ renderParseErrorCabalFile errors warnings =
 -- | Render parse error highlighting the part of the input file.
 renderParseError
   :: forall src
-   . (Ord src, Eq src)
+   . Ord src
   => (src -> ([PError], [PWarning]) -> String)
   -> NonEmpty (PErrorWithSource src)
   -> [PWarningWithSource src]

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- | This module exposes functions to build and register unpacked packages.
 --

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -266,7 +266,7 @@ import Distribution.Solver.Types.ProjectConfigPath
 -- 'PackageName'. This returns the configuration that applies to all local
 -- packages plus any package-specific configuration for this package.
 lookupLocalPackageConfig
-  :: (Semigroup a, Monoid a)
+  :: Monoid a
   => (PackageConfig -> a)
   -> ProjectConfig
   -> PackageName

--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -313,7 +313,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
                 then dist_dir </> "build" </> prettyShow s </> prettyShow s <.> exeExtension plat
                 else InstallDirs.bindir (elabInstallDirs elab) </> prettyShow s <.> exeExtension plat
 
-        flib_file' :: (Pretty a, Show a) => a -> [J.Pair]
+        flib_file' :: Pretty a => a -> [J.Pair]
         flib_file' s =
           ["bin-file" J..= J.String bin]
           where

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {- FOURMOLU_DISABLE -}
 
 -----------------------------------------------------------------------------

--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -258,7 +258,7 @@ readTargetSelectors
 readTargetSelectors = readTargetSelectorsWith defaultDirActions
 
 readTargetSelectorsWith
-  :: (Applicative m, Monad m)
+  :: Monad m
   => DirActions m
   -> [PackageSpecifier (SourcePackage (PackageLocation a))]
   -> Maybe ComponentKindFilter
@@ -455,7 +455,7 @@ noFileStatus :: FileStatus
 noFileStatus = FileStatusNotExists False
 
 getTargetStringFileStatus
-  :: (Applicative m, Monad m)
+  :: Monad m
   => DirActions m
   -> TargetString
   -> m TargetStringFileStatus
@@ -1832,7 +1832,7 @@ emptyKnownTargets = KnownTargets [] [] [] [] [] []
 
 getKnownTargets
   :: forall m a
-   . (Applicative m, Monad m)
+   . Monad m
   => DirActions m
   -> [PackageSpecifier (SourcePackage (PackageLocation a))]
   -> m KnownTargets
@@ -1868,7 +1868,7 @@ getKnownTargets dirActions@DirActions{..} pkgs = do
       [c | KnownPackage{pinfoComponents} <- ps, c <- pinfoComponents]
 
 collectKnownPackageInfo
-  :: (Applicative m, Monad m)
+  :: Monad m
   => DirActions m
   -> PackageSpecifier (SourcePackage (PackageLocation a))
   -> m KnownPackage
@@ -2285,7 +2285,7 @@ matchComponentModuleFile cs str = do
 -- | Compare two filepaths for equality using DirActions' canonicalizePath
 -- to normalize AND canonicalize filepaths before comparison.
 compareFilePath
-  :: (Applicative m, Monad m)
+  :: Monad m
   => DirActions m
   -> FilePath
   -> FilePath

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1758,7 +1758,7 @@ testTargetProblemsHaddock config reportSubCase = do
 
 assertProjectDistinctTargets
   :: forall err
-   . (Eq err, Show err)
+   . Show err
   => ElaboratedInstallPlan
   -> (forall k. TargetSelector -> [AvailableTarget k] -> Either (TargetProblem err) [k])
   -> (forall k. SubComponentTarget -> AvailableTarget k -> Either (TargetProblem err) k)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -1105,8 +1105,7 @@ testSimplePrompt label f target =
   testPrompt label f (assertFailure . show) (\(a, _) -> target @=? a)
 
 testPromptBreak
-  :: Eq a
-  => Show a
+  :: Show a
   => String
   -> (InitFlags -> PurePrompt a)
   -> [String]
@@ -1118,9 +1117,7 @@ testPromptBreak label f =
       return ()
 
 testPrompt
-  :: Eq a
-  => Show a
-  => String
+  :: String
   -> (InitFlags -> PurePrompt a)
   -> (BreakException -> Assertion)
   -> ((a, NonEmpty String) -> Assertion)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
@@ -1372,9 +1372,7 @@ testBool label f target input =
   testSimple label f target [input]
 
 testGo
-  :: Eq a
-  => Show a
-  => String
+  :: String
   -> (InitFlags -> PurePrompt a)
   -> (BreakException -> Assertion)
   -> ((a, NEL.NonEmpty String) -> Assertion)

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- | Generally useful definitions that we expect most test scripts
 -- to use.

--- a/project-cabal/ghc-options.config
+++ b/project-cabal/ghc-options.config
@@ -1,6 +1,7 @@
 program-options
   ghc-options:
     -fno-ignore-asserts
+    -Wredundant-constraints
 
 -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives false
 -- positives with GHC 8.10.


### PR DESCRIPTION
There are quite some constraints that are not needed, so we remove them.
I added the flag to each of the packages that got this warning, except test packages.

TODO (for me) :
- [x] document why it's ok to remove field grammar constraints

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
