### PR TITLE
Revert "Merge pull request #10534

### DIFF
--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -290,65 +290,63 @@ preprocessFile
   -- ^ fail on missing file
   -> IO ()
 preprocessFile mbWorkDir searchLoc buildLoc forSDist baseFile verbosity builtinSuffixes handlers failOnMissing = do
-  bsrcFiles <- findFileCwdWithExtension mbWorkDir builtinSuffixes (searchLoc ++ [buildAsSrcLoc]) baseFile
-  case bsrcFiles of
-    -- found a non-processable file in one of the source dirs
-    Just _ -> do
-      pure ()
-    Nothing -> do
-      -- look for files in the various source dirs with this module name
-      -- and a file extension of a known preprocessor
-      psrcFiles <- findFileCwdWithExtension' mbWorkDir (map fst handlers) searchLoc baseFile
-      case psrcFiles of
-        -- no preprocessor file exists, look for an ordinary source file
-        -- just to make sure one actually exists at all for this module.
+  -- look for files in the various source dirs with this module name
+  -- and a file extension of a known preprocessor
+  psrcFiles <- findFileCwdWithExtension' mbWorkDir (map fst handlers) searchLoc baseFile
+  case psrcFiles of
+    -- no preprocessor file exists, look for an ordinary source file
+    -- just to make sure one actually exists at all for this module.
 
-        -- Note [Dodgy build dirs for preprocessors]
-        -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        -- By looking in the target/output build dir too, we allow
-        -- source files to appear magically in the target build dir without
-        -- any corresponding "real" source file. This lets custom Setup.hs
-        -- files generate source modules directly into the build dir without
-        -- the rest of the build system being aware of it (somewhat dodgy)
-        Nothing ->
-          when failOnMissing $ do
-            dieWithException verbosity $
-              CantFindSourceForPreProcessFile $
-                "can't find source for "
-                  ++ getSymbolicPath baseFile
-                  ++ " in "
-                  ++ intercalate ", " (map getSymbolicPath searchLoc)
-        Just (psrcLoc, psrcRelFile) -> do
-          let (srcStem, ext) = splitExtension $ getSymbolicPath psrcRelFile
-              psrcFile = psrcLoc </> psrcRelFile
-              pp =
-                fromMaybe
-                  (error "Distribution.Simple.PreProcess: Just expected")
-                  (lookup (Suffix $ safeTail ext) handlers)
-          -- Preprocessing files for 'sdist' is different from preprocessing
-          -- for 'build'.  When preprocessing for sdist we preprocess to
-          -- avoid that the user has to have the preprocessors available.
-          -- ATM, we don't have a way to specify which files are to be
-          -- preprocessed and which not, so for sdist we only process
-          -- platform independent files and put them into the 'buildLoc'
-          -- (which we assume is set to the temp. directory that will become
-          -- the tarball).
-          -- TODO: eliminate sdist variant, just supply different handlers
-          when (not forSDist || forSDist && platformIndependent pp) $ do
-            -- look for existing pre-processed source file in the dest dir to
-            -- see if we really have to re-run the preprocessor.
-            ppsrcFiles <- findFileCwdWithExtension mbWorkDir builtinSuffixes [buildAsSrcLoc] baseFile
-            recomp <- case ppsrcFiles of
-              Nothing -> return True
-              Just ppsrcFile ->
-                i psrcFile `moreRecentFile` i ppsrcFile
-            when recomp $ do
-              let destDir = i buildLoc </> takeDirectory srcStem
-              createDirectoryIfMissingVerbose verbosity True destDir
-              runPreProcessorWithHsBootHack
-                pp
-                (psrcLoc, getSymbolicPath psrcRelFile)
-                (buildLoc, srcStem <.> "hs")
+    -- Note [Dodgy build dirs for preprocessors]
+    -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    -- By looking in the target/output build dir too, we allow
+    -- source files to appear magically in the target build dir without
+    -- any corresponding "real" source file. This lets custom Setup.hs
+    -- files generate source modules directly into the build dir without
+    -- the rest of the build system being aware of it (somewhat dodgy)
+    Nothing -> do
+      bsrcFiles <- findFileCwdWithExtension mbWorkDir builtinSuffixes (buildAsSrcLoc : searchLoc) baseFile
+      case (bsrcFiles, failOnMissing) of
+        (Nothing, True) ->
+          dieWithException verbosity $
+            CantFindSourceForPreProcessFile $
+              "can't find source for "
+                ++ getSymbolicPath baseFile
+                ++ " in "
+                ++ intercalate ", " (map getSymbolicPath searchLoc)
+        _ -> return ()
+    -- found a pre-processable file in one of the source dirs
+    Just (psrcLoc, psrcRelFile) -> do
+      let (srcStem, ext) = splitExtension $ getSymbolicPath psrcRelFile
+          psrcFile = psrcLoc </> psrcRelFile
+          pp =
+            fromMaybe
+              (error "Distribution.Simple.PreProcess: Just expected")
+              (lookup (Suffix $ safeTail ext) handlers)
+      -- Preprocessing files for 'sdist' is different from preprocessing
+      -- for 'build'.  When preprocessing for sdist we preprocess to
+      -- avoid that the user has to have the preprocessors available.
+      -- ATM, we don't have a way to specify which files are to be
+      -- preprocessed and which not, so for sdist we only process
+      -- platform independent files and put them into the 'buildLoc'
+      -- (which we assume is set to the temp. directory that will become
+      -- the tarball).
+      -- TODO: eliminate sdist variant, just supply different handlers
+      when (not forSDist || forSDist && platformIndependent pp) $ do
+        -- look for existing pre-processed source file in the dest dir to
+        -- see if we really have to re-run the preprocessor.
+        ppsrcFiles <- findFileCwdWithExtension mbWorkDir builtinSuffixes [buildAsSrcLoc] baseFile
+        recomp <- case ppsrcFiles of
+          Nothing -> return True
+          Just ppsrcFile ->
+            i psrcFile `moreRecentFile` i ppsrcFile
+        when recomp $ do
+          let destDir = i buildLoc </> takeDirectory srcStem
+          createDirectoryIfMissingVerbose verbosity True destDir
+          runPreProcessorWithHsBootHack
+            pp
+            (psrcLoc, getSymbolicPath psrcRelFile)
+            (buildLoc, srcStem <.> "hs")
   where
     i = interpretSymbolicPath mbWorkDir -- See Note [Symbolic paths] in Distribution.Utils.Path
     buildAsSrcLoc :: SymbolicPath Pkg (Dir Source)

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
@@ -11,5 +11,6 @@ Failed to build MainIsExe-0.1-inplace-Exe. The exception was:
 Error: [Cabal-7554]
 can't find source for MyDummy in ., cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/Exe/autogen, cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/global-autogen
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/PreProcess.hs:315:13 in Cabal-3.17.0.0-inplace:Distribution.Simple.PreProcess
+  dieWithException, called at src/Distribution/Simple/PreProcess.hs:311:11 in Cabal-3.17.0.0-inplace:Distribution.Simple.PreProcess
+
 


### PR DESCRIPTION
This reverts commit 8974189e44915a3b8547794f082b6acd4a4ced8a, reversing changes made to 41f5e57e1e1c34991dcfd89d08b4ca17220a4e89 as suggested in https://github.com/haskell/cabal/issues/11810#issuecomment-4426070931

I assume this patch doesn't change a behaviour of any released cabal, so Template B is appropriate.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
