### PR TITLE
Make ShortText a type synonym of Text

### DIFF
--- a/Cabal-syntax/src/Distribution/Utils/ShortText.hs
+++ b/Cabal-syntax/src/Distribution/Utils/ShortText.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric #-}
-
--- | Compact representation of short 'Strings'
+-- | This is a legacy compatibility layer,
+-- new developments can use "Data.Text" directly.
 --
 -- This module is designed to be import qualified
 --
@@ -25,81 +22,36 @@ module Distribution.Utils.ShortText
 import Distribution.Compat.Prelude hiding (length, null)
 import Prelude ()
 
-import Distribution.Utils.Structured (Structured (..), nominalStructure)
-
 import qualified Data.ByteString as BS
-import qualified Data.List as List
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
 
-import qualified Data.ByteString.Short as BS.Short
-
 -- | Construct 'ShortText' from 'String'
 toShortText :: String -> ShortText
+toShortText = T.pack
 
 -- | Convert 'ShortText' to 'String'
 fromShortText :: ShortText -> String
+fromShortText = T.unpack
 
 -- | Convert from UTF-8 encoded strict 'ByteString'.
 --
 -- @since 3.2.0.0
 unsafeFromUTF8BS :: BS.ByteString -> ShortText
+unsafeFromUTF8BS = T.decodeUtf8With T.lenientDecode
 
 -- | Text whether 'ShortText' is empty.
 --
 -- @since 3.2.0.0
 null :: ShortText -> Bool
+null = T.null
 
--- | Compact representation of short 'Strings'
---
--- The data is stored internally as UTF8 in an
--- 'BS.Short.ShortByteString'.
---
--- Note: This type is for internal uses (such as e.g. 'PackageName')
--- and shall not be exposed in Cabal's API
---
--- @since 2.0.0.2
-newtype ShortText = ST {unST :: BS.Short.ShortByteString}
-  deriving (Eq, Ord, Generic, Data)
+-- | @since 2.0.0.2
+type ShortText = T.Text
 
-instance Binary ShortText where
-  put = put . unST
-  get = fmap ST get
-
-toShortText = ST . BS.Short.toShort . T.encodeUtf8 . T.pack
-
-fromShortText = T.unpack . T.decodeUtf8With T.lenientDecode . BS.Short.fromShort . unST
-
-unsafeFromUTF8BS = ST . BS.Short.toShort
-
-null = BS.Short.null . unST
-
-instance Structured ShortText where structure = nominalStructure
-
-instance NFData ShortText where
-  rnf = rnf . unST
-
-instance Show ShortText where
-  show = show . fromShortText
-
-instance Read ShortText where
-  readsPrec p = map (first toShortText) . readsPrec p
-
-instance Semigroup ShortText where
-  ST a <> ST b = ST (mappend a b)
-
-instance Monoid ShortText where
-  mempty = ST mempty
-  mappend = (<>)
-
-instance IsString ShortText where
-  fromString = toShortText
-
--- | /O(n)/. Length in characters. /Slow/ as converts to string.
+-- | /O(n)/. Length in characters.
 --
 -- @since 3.2.0.0
 length :: ShortText -> Int
-length = List.length . fromShortText
-
--- Note: avoid using it, we use it @cabal check@ implementation, where it's ok.
+length = T.length

--- a/Cabal-tests/tests/NoThunks.hs
+++ b/Cabal-tests/tests/NoThunks.hs
@@ -26,7 +26,6 @@ import Distribution.Parsec.Source
 import Distribution.SPDX                      (License, LicenseExceptionId, LicenseExpression, LicenseId, LicenseRef, SimpleLicenseExpression)
 import Distribution.System                    (Arch, OS)
 import Distribution.Utils.Path                (SymbolicPathX)
-import Distribution.Utils.ShortText           (ShortText)
 import Distribution.Version                   (Version, VersionRange)
 import Language.Haskell.Extension             (Extension, KnownExtension, Language)
 import NoThunks.Class                         (NoThunks (..), OnlyCheckWhnf (..), noThunksInValues)
@@ -117,8 +116,6 @@ instance NoThunks TestType
 instance NoThunks UnqualComponentName
 instance NoThunks Version
 instance NoThunks VersionRange
-
-instance NoThunks ShortText where
 
 instance NoThunks a => NoThunks (PerCompilerFlavor a)
 

--- a/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
@@ -27,7 +27,7 @@ InstalledPackageInfo {
   synopsis =
   "Concrete functor and monad transformers",
   description =
-  concat
+  T.concat
     [
       "A portable library of functor and monad transformers, inspired by\n",
       "the paper \\\"Functional Programming with Overloading and Higher-Order\n",

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.expr
@@ -27,7 +27,7 @@ InstalledPackageInfo {
   synopsis =
   "Concrete functor and monad transformers",
   description =
-  concat
+  T.concat
     [
       "A portable library of functor and monad transformers, inspired by\n",
       "the paper \\\"Functional Programming with Overloading and Higher-Order\n",

--- a/Cabal-tests/tests/ParserTests/regressions/generics-sop.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/generics-sop.expr
@@ -61,7 +61,7 @@ GenericPackageDescription {
     synopsis =
     "Generic Programming using True Sums of Products",
     description =
-    concat
+    T.concat
       [
         "A library to support the definition of generic functions.\n",
         "Datatypes are viewed in a uniform, structured way:\n",

--- a/Cabal-tests/tests/ParserTests/regressions/indentation.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/indentation.expr
@@ -18,7 +18,7 @@ GenericPackageDescription {
     bugReports = "",
     sourceRepos = [],
     synopsis = "",
-    description = concat
+    description = T.concat
       [
         "* foo\n",
         "\n",

--- a/Cabal-tests/tests/ParserTests/regressions/indentation2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/indentation2.expr
@@ -18,7 +18,7 @@ GenericPackageDescription {
     bugReports = "",
     sourceRepos = [],
     synopsis = "",
-    description = concat
+    description = T.concat
       [
         "foo\n",
         "  indent2\n",

--- a/Cabal-tests/tests/ParserTests/regressions/indentation3.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/indentation3.expr
@@ -18,7 +18,7 @@ GenericPackageDescription {
     bugReports = "",
     sourceRepos = [],
     synopsis = "",
-    description = concat
+    description = T.concat
       [
         "indent0\n",
         "\n",

--- a/Cabal-tests/tests/ParserTests/regressions/issue-774.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-774.expr
@@ -18,7 +18,7 @@ GenericPackageDescription {
     sourceRepos = [],
     synopsis =
     "Package description parser interprets curly braces in the description field",
-    description = concat
+    description = T.concat
       [
         "Here is some C code:\n",
         "\n",

--- a/Cabal-tests/tests/ParserTests/regressions/jaeger-flamegraph.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/jaeger-flamegraph.expr
@@ -45,7 +45,7 @@ GenericPackageDescription {
     synopsis =
     "Generate flamegraphs from Jaeger .json dumps.",
     description =
-    concat
+    T.concat
       [
         "This is a small tool to convert JSON dumps obtained from a Jaeger\n",
         "server (<https://www.jaegertracing.io/>) into a format consumable\n",

--- a/Cabal-tests/tests/ParserTests/regressions/libpq1.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/libpq1.expr
@@ -10,7 +10,7 @@ GenericPackageDescription {
     licenseRaw = Right BSD3,
     licenseFiles = [
       SymbolicPath "LICENSE"],
-    copyright = concat
+    copyright = T.concat
       [
         "(c) 2010 Grant Monroe\n",
         "(c) 2011 Leon P Smith"],
@@ -67,7 +67,7 @@ GenericPackageDescription {
     sourceRepos = [],
     synopsis =
     "low-level binding to libpq",
-    description = concat
+    description = T.concat
       [
         "This is a binding to libpq: the C application\n",
         "programmer's interface to PostgreSQL. libpq is a\n",

--- a/Cabal-tests/tests/ParserTests/regressions/libpq2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/libpq2.expr
@@ -14,7 +14,7 @@ GenericPackageDescription {
           Nothing)),
     licenseFiles = [
       SymbolicPath "LICENSE"],
-    copyright = concat
+    copyright = T.concat
       [
         "(c) 2010 Grant Monroe\n",
         "(c) 2011 Leon P Smith"],
@@ -71,7 +71,7 @@ GenericPackageDescription {
     sourceRepos = [],
     synopsis =
     "low-level binding to libpq",
-    description = concat
+    description = T.concat
       [
         "This is a binding to libpq: the C application\n",
         "programmer's interface to PostgreSQL. libpq is a\n",

--- a/Cabal-tests/tests/ParserTests/regressions/shake.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/shake.expr
@@ -56,7 +56,7 @@ GenericPackageDescription {
     synopsis =
     "Build system library, like Make, but more accurate dependencies.",
     description =
-    concat
+    T.concat
       [
         "Shake is a Haskell library for writing build systems - designed as a\n",
         "replacement for @make@. See \"Development.Shake\" for an introduction,\n",

--- a/Cabal-tests/tests/ParserTests/regressions/th-lift-instances.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/th-lift-instances.expr
@@ -37,7 +37,7 @@ GenericPackageDescription {
     synopsis =
     "Lift instances for template-haskell for common data types.",
     description =
-    concat
+    T.concat
       [
         "Most data types in haskell platform do not have Lift instances. This package provides orphan instances\n",
         "for containers, text, bytestring and vector."],

--- a/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.expr
@@ -32,7 +32,7 @@ GenericPackageDescription {
     synopsis =
     "The Wadler/Leijen Pretty Printer",
     description =
-    concat
+    T.concat
       [
         "This is a pretty printing library based on Wadler's paper \"A Prettier\n",
         "Printer\".  See the haddocks for full info.  This version allows the\n",

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,8 +29,8 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
-    0x9f021aa01a9db87b4270029dc14c5966
+    0xaa065de51286b8f80733ffff51a44a20
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x78979713e08179ab070d6ab10cd5ef6c
+    0xff2e1755aa2473b9d10c1236ef3ec80e

--- a/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
+++ b/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
@@ -30,7 +30,6 @@ import Distribution.Types.PackageVersionConstraint
 import Distribution.Types.UnitId                   (DefUnitId, UnitId)
 import Distribution.Utils.NubList                  (NubList)
 import Distribution.Utils.Path                     (SymbolicPathX)
-import Distribution.Utils.ShortText                (ShortText, fromShortText)
 import Distribution.Verbosity
 import Distribution.Verbosity.Internal
 
@@ -154,5 +153,3 @@ instance ToExpr UnqualComponentName
 instance ToExpr VerbosityFlags
 instance ToExpr VerbosityFlag
 instance ToExpr VerbosityLevel
-
-instance ToExpr ShortText where toExpr = toExpr . fromShortText

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -3,7 +3,7 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
-index-state: hackage.haskell.org 2025-06-27T20:43:14Z
+index-state: hackage.haskell.org 2026-05-22T20:43:14Z
 
 -- never include this or its TH dependency in a release!
 package cabal-install

--- a/changelog.d/pr-11846.md
+++ b/changelog.d/pr-11846.md
@@ -1,0 +1,10 @@
+---
+synopsis: Make ShortText a type synonym of Text
+packages: [Cabal-syntax]
+prs: 11846
+---
+The data type `Distribution.Utils.ShortText` is now just a type synonym for `Data.Text.Text`.
+The constructor was not exported, so the change should not be noticeable by users
+unless they used to define instances for `ShortText`, in which case
+they might need to enable `{-# LANGUAGE TypeSynonymInstances #-}` or perhaps
+drop their instances entirely, if they duplicate instances for `Text`.


### PR DESCRIPTION
The data type `Distribution.Utils.ShortText` was introduced in 2016 (993d20a2e9b8fb29aefaa2c266f31177a00a5ee6) to provide a compact representation of UTF-8 strings. Since then the ecosystem moved forward and converged to using `Data.Text.Text` for this purpose. The commit defines `type ShortText = Text` and retains `Distribution.Utils` as a boring compatibility layer.

An alert reader can object that while `Data.Text.Text` is also UTF-8 encoded, its memory overhead is a few bytes more than `Distribution.Utils.ShortText` (because `Text` provides constant-time slicing, while `ShortText` takes linear time). My experience as a maintainer of `bytestring` and `text` is that this memory overhead is unlikely to matter for Cabal use case, and reducing mental overhead takes the priority.

**Template Α: This PR modifies [behaviour or interface](CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)