### PR TITLE
Follow hlint suggestion: use void

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,34 +1,33 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
-- ignore: {name: "Avoid lambda"} # 49 hints
-- ignore: {name: "Eta reduce"} # 139 hints
+- ignore: {name: "Avoid lambda"} # 54 hints
+- ignore: {name: "Eta reduce"} # 136 hints
 - ignore: {name: "Hoist not"} # 16 hints
 - ignore: {name: "Move filter"} # 4 hints
-- ignore: {name: "Redundant $!"} # 1 hint
-- ignore: {name: "Redundant bracket"} # 273 hints
+- ignore: {name: "Redundant $!"} # 3 hints
+- ignore: {name: "Redundant bracket"} # 253 hints
 - ignore: {name: "Redundant guard"} # 1 hint
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 16 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
-- ignore: {name: "Redundant return"} # 9 hints
+- ignore: {name: "Redundant return"} # 7 hints
 - ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
-- ignore: {name: "Use :"} # 29 hints
+- ignore: {name: "Use :"} # 30 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 82 hints
+- ignore: {name: "Use <$>"} # 83 hints
 - ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
 - ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
-- ignore: {name: "Use camelCase"} # 97 hints
+- ignore: {name: "Use camelCase"} # 96 hints
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use fst"} # 2 hints
-- ignore: {name: "Use newtype instead of data"} # 31 hints
+- ignore: {name: "Use newtype instead of data"} # 32 hints
 - ignore: {name: "Use null"} # 2 hints
-- ignore: {name: "Use record patterns"} # 16 hints
-- ignore: {name: "Use void"} # 23 hints
+- ignore: {name: "Use record patterns"} # 15 hints
 
 - ignore: {name: "Functor law", within: [Test.Laws]}
 - ignore: {name: "Monoid law, left identity", within: [Test.Laws, UnitTests.Distribution.Utils.NubList]}

--- a/Cabal-syntax/src/Distribution/Compat/Parsing.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Parsing.hs
@@ -82,7 +82,7 @@ option x p = p <|> pure x
 -- It only fails if @p@ fails after consuming input. It discards the result
 -- of @p@. (Plays the role of parsec's optional, which conflicts with Applicative's optional)
 skipOptional :: Alternative m => m a -> m ()
-skipOptional p = (() <$ p) <|> pure ()
+skipOptional p = void p <|> pure ()
 {-# INLINE skipOptional #-}
 
 -- | @between open close p@ parses @open@, followed by @p@ and @close@.
@@ -224,7 +224,7 @@ class Alternative m => Parsing m where
   -- | A version of many that discards its input. Specialized because it
   -- can often be implemented more cheaply.
   skipMany :: m a -> m ()
-  skipMany p = () <$ many p
+  skipMany p = void $ many p
   {-# INLINE skipMany #-}
 
   -- | @skipSome p@ applies the parser @p@ /one/ or more times, skipping

--- a/Cabal/src/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ReadyComponent.hs
@@ -403,11 +403,9 @@ toReadyComponents pid_map subst0 comps =
       -- Top-level instantiation per subst0
       | not (Map.null subst0)
       , [lc] <- filter lc_public (Map.elems cmap) =
-          do
-            _ <- instantiateUnitId (lc_cid lc) subst0
-            return ()
+          void $ instantiateUnitId (lc_cid lc) subst0
       | otherwise =
           forM_ (Map.elems cmap) $ \lc ->
             if null (lc_insts lc)
-              then instantiateUnitId (lc_cid lc) Map.empty >> return ()
-              else indefiniteUnitId (lc_cid lc) >> return ()
+              then void $ instantiateUnitId (lc_cid lc) Map.empty
+              else void $ indefiniteUnitId (lc_cid lc)

--- a/Cabal/src/Distribution/Simple/Glob/Internal.hs
+++ b/Cabal/src/Distribution/Simple/Glob/Internal.hs
@@ -79,7 +79,7 @@ instance Parsec Glob where
     where
       dirSep :: CabalParsing m => m ()
       dirSep =
-        () <$ P.char '/'
+        void (P.char '/')
           <|> P.try
             ( do
                 _ <- P.char '\\'

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/PackageFileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/PackageFileMonitor.hs
@@ -151,9 +151,7 @@ checkPackageFileMonitorChanged
         pkgconfig
     case configChanged of
       MonitorChanged monitorReason ->
-        return (Left (BuildStatusConfigure monitorReason'))
-        where
-          monitorReason' = fmap (const ()) monitorReason
+        return (Left (BuildStatusConfigure $ void monitorReason))
       MonitorUnchanged () _
         -- The configChanged here includes the identity of the dependencies,
         -- so depsBuildStatus is just needed for the changes in the content
@@ -182,16 +180,14 @@ checkPackageFileMonitorChanged
               (MonitorChanged monitorReason, _) ->
                 return (Left (BuildStatusBuild mreg buildReason))
                 where
-                  buildReason = BuildReasonFilesChanged monitorReason'
-                  monitorReason' = fmap (const ()) monitorReason
+                  buildReason = BuildReasonFilesChanged $ void monitorReason
               (MonitorUnchanged _ _, MonitorChanged monitorReason) ->
                 -- this should only happen if the file is corrupt or been
                 -- manually deleted. We don't want to bother with another
                 -- phase just for this, so we'll reregister by doing a build.
                 return (Left (BuildStatusBuild Nothing buildReason))
                 where
-                  buildReason = BuildReasonFilesChanged monitorReason'
-                  monitorReason' = fmap (const ()) monitorReason
+                  buildReason = BuildReasonFilesChanged $ void monitorReason
               (MonitorUnchanged _ _, MonitorUnchanged _ _)
                 | pkgHasEphemeralBuildTargets pkg ->
                     return (Left (BuildStatusBuild mreg buildReason))

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1329,8 +1329,8 @@ parsePackageLocationTokenQ =
       where
         outerTerm = alternateEither1 outerToken (braces innerTerm)
         innerTerm = alternateEither innerToken (braces innerTerm)
-        outerToken = Parse.munch1 outerChar >> return ()
-        innerToken = Parse.munch1 innerChar >> return ()
+        outerToken = void $ Parse.munch1 outerChar
+        innerToken = void $ Parse.munch1 innerChar
         outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
         innerChar c = not (isSpace c || c == '{' || c == '}')
         braces = Parse.between (Parse.char '{') (Parse.char '}')

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -1018,7 +1018,7 @@ selectBuildableTargetsWith' p =
   (fmap . map) forgetTargetDetail . unzip . zipBuildableTargetsWith p
 
 forgetTargetDetail :: AvailableTarget k -> AvailableTarget ()
-forgetTargetDetail = fmap (const ())
+forgetTargetDetail = void
 
 forgetTargetsDetail :: [AvailableTarget k] -> [AvailableTarget ()]
 forgetTargetsDetail = map forgetTargetDetail

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -3048,15 +3048,11 @@ instantiateInstallPlan storeDirLayout defaultInstallDirs elaboratedShared plan =
 
     ready_map = execState work Map.empty
 
-    work = for_ pkgs $ \pkg ->
-      case pkg of
-        InstallPlan.Configured elab
-          | not (Map.null (elabLinkedInstantiatedWith elab)) ->
-              indefiniteUnitId (elabComponentId elab)
-                >> return ()
-        _ ->
-          instantiateUnitId (getComponentId pkg) Map.empty
-            >> return ()
+    work = for_ pkgs $ \case
+      InstallPlan.Configured elab
+        | not (Map.null (elabLinkedInstantiatedWith elab)) ->
+            void $ indefiniteUnitId (elabComponentId elab)
+      pkg -> void $ instantiateUnitId (getComponentId pkg) Map.empty
 
 ---------------------------
 -- Build targets

--- a/cabal-testsuite/PackageTests/ExternalCommand/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommand/cabal.test.hs
@@ -3,6 +3,7 @@ import qualified System.Process as Process
 import Control.Concurrent (threadDelay)
 import System.Directory (removeFile)
 import Control.Exception (catch, throwIO)
+import Control.Monad (void)
 import System.IO.Error (isDoesNotExistError)
 import qualified Data.Time.Clock as Time
 import qualified Data.Time.Format as Time
@@ -16,18 +17,18 @@ main = do
     exe_path <- withPlan $ planExePath "setup-test" "cabal-aaaa"
     addToPath (takeDirectory exe_path) $ do
       -- Test that the thing works at all
-      res <- cabal_raw_action ["aaaa"] (\h -> () <$ Process.waitForProcess h)
+      res <- cabal_raw_action ["aaaa"] (\h -> void (Process.waitForProcess h))
 
       -- Test that the extra arguments are passed on
-      res <- cabal_raw_action ["aaaa", "--foobaz"] (\h -> () <$ Process.waitForProcess h)
+      res <- cabal_raw_action ["aaaa", "--foobaz"] (\h -> void (Process.waitForProcess h))
       assertOutputContains "--foobaz" res
 
       -- Test what happens with "global" flags
-      res <- cabal_raw_action ["aaaa", "--version"] (\h -> () <$ Process.waitForProcess h)
+      res <- cabal_raw_action ["aaaa", "--version"] (\h -> void (Process.waitForProcess h))
       assertOutputContains "--version" res
 
       -- Test what happens with "global" flags
-      res <- cabal_raw_action ["aaaa", "--config-file", "abc"] (\h -> () <$ Process.waitForProcess h)
+      res <- cabal_raw_action ["aaaa", "--config-file", "abc"] (\h -> void (Process.waitForProcess h))
       assertOutputContains "--config-file" res
 
 

--- a/cabal-testsuite/PackageTests/ExternalCommandEnv/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommandEnv/cabal.test.hs
@@ -3,6 +3,7 @@ import qualified System.Process as Process
 import Control.Concurrent (threadDelay)
 import System.Directory (removeFile)
 import Control.Exception (catch, throwIO)
+import Control.Monad (void)
 import System.IO.Error (isDoesNotExistError)
 import qualified Data.Time.Clock as Time
 import qualified Data.Time.Format as Time
@@ -16,7 +17,7 @@ main =
     env <- getTestEnv
     let new_env = (("OTHER_VAR", Just "is set") : (testEnvironment env))
     withEnv new_env $ addToPath (takeDirectory exe_path) $ do
-      res <- cabal_raw_action ["aaaa"] (\h -> () <$ Process.waitForProcess h)
+      res <- cabal_raw_action ["aaaa"] (\h -> void (Process.waitForProcess h))
       assertOutputContains "cabal-install" res
       assertOutputContains "is set" res
 

--- a/cabal-testsuite/PackageTests/ExternalCommandExitCode/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommandExitCode/cabal.test.hs
@@ -3,6 +3,7 @@ import qualified System.Process as Process
 import Control.Concurrent (threadDelay)
 import System.Directory (removeFile)
 import Control.Exception (catch, throwIO)
+import Control.Monad (void)
 import System.IO.Error (isDoesNotExistError)
 import qualified Data.Time.Clock as Time
 import qualified Data.Time.Format as Time
@@ -17,7 +18,7 @@ main = do
     exe_path <- withPlan $ planExePath "setup-test" "cabal-aaaa"
     addToPath (takeDirectory exe_path) $ do
       -- Test that the thing works at all
-      res <- fails $ cabal_raw_action ["aaaa"] (\h -> () <$ Process.waitForProcess h)
+      res <- fails $ cabal_raw_action ["aaaa"] (\h -> void (Process.waitForProcess h))
       -- Check the exit code is the one returned by subcommand
       unless (resultExitCode res == ExitFailure 99) (assertFailure $ "Incorrect exit code: " ++ show (resultExitCode res))
 

--- a/cabal-testsuite/PackageTests/ExternalCommandHelp/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ExternalCommandHelp/cabal.test.hs
@@ -3,6 +3,7 @@ import qualified System.Process as Process
 import Control.Concurrent (threadDelay)
 import System.Directory (removeFile)
 import Control.Exception (catch, throwIO)
+import Control.Monad (void)
 import System.IO.Error (isDoesNotExistError)
 import qualified Data.Time.Clock as Time
 import qualified Data.Time.Format as Time
@@ -14,7 +15,7 @@ main = do
     res <- cabalWithStdin "v2-build" ["all"] ""
     exe_path <- withPlan $ planExePath "setup-test" "cabal-aaaa"
     addToPath (takeDirectory exe_path) $ do
-      res <- cabal_raw_action ["help", "aaaa"] (\h -> () <$ Process.waitForProcess h)
+      res <- cabal_raw_action ["help", "aaaa"] (\h -> void (Process.waitForProcess h))
       assertOutputContains "I am helping with the aaaa command" res
 
 


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use void" suggestion so that these will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved. The first commit resets the `# count` comments in `.hlint.yaml`.

---

* [x] Patches conform to the [coding conventions](CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
