### PR TITLE
Fix createTempDirectory name generation

### DIFF
--- a/Cabal/src/Distribution/Compat/Internal/TempFile.hs
+++ b/Cabal/src/Distribution/Compat/Internal/TempFile.hs
@@ -10,10 +10,11 @@ module Distribution.Compat.Internal.TempFile
 
 import Distribution.Compat.Exception
 
+import GHC.IORef (IORef, atomicModifyIORef'_, newIORef)
 import System.FilePath ((</>))
-
 import System.IO (Handle, openBinaryTempFile, openBinaryTempFileWithDefaultPermissions, openTempFile)
 import System.IO.Error (isAlreadyExistsError)
+import System.IO.Unsafe (unsafePerformIO)
 import System.Posix.Internals (c_getpid)
 
 #if defined(mingw32_HOST_OS) || defined(ghcjs_HOST_OS)
@@ -28,17 +29,21 @@ openNewBinaryFile = openBinaryTempFileWithDefaultPermissions
 createTempDirectory :: FilePath -> String -> IO FilePath
 createTempDirectory dir template = do
   pid <- c_getpid
-  findTempName pid
-  where
-    findTempName x = do
-      let relpath = template ++ "-" ++ show x
-          dirpath = dir </> relpath
-      r <- tryIO $ mkPrivateDir dirpath
-      case r of
-        Right _ -> return relpath
-        Left e
-          | isAlreadyExistsError e -> findTempName (x + 1)
-          | otherwise -> ioError e
+  let findTempName = do
+        (counter, _) <- atomicModifyIORef'_ tempDirectoryCounter (+ 1)
+        let relpath = template ++ "-" ++ show pid ++ show counter
+            dirpath = dir </> relpath
+        r <- tryIO $ mkPrivateDir dirpath
+        case r of
+          Right _ -> pure relpath
+          Left e
+            | isAlreadyExistsError e -> findTempName
+            | otherwise -> ioError e
+  findTempName
+
+tempDirectoryCounter :: IORef Word
+tempDirectoryCounter = unsafePerformIO $ newIORef 0
+{-# NOINLINE tempDirectoryCounter #-}
 
 mkPrivateDir :: String -> IO ()
 #if defined(mingw32_HOST_OS) || defined(ghcjs_HOST_OS)

--- a/changelog.d/pr-11872.md
+++ b/changelog.d/pr-11872.md
@@ -1,0 +1,7 @@
+---
+synopsis: Improve name assigning for temporary folders
+packages: [Cabal,cabal-install]
+prs: 11872
+---
+
+Now `createTempDirectory` from `Distribution.Compat.Internal.TempFile` uses a global counter as a part of temporary folder name template, so that probing is less likely to fail. The change should be invisible for users.


### PR DESCRIPTION
The existing `createTempDirectory` uses a suboptimal schema to generate temporary directory names. Namely, it starts with `foo-$processId`. If there is no such folder that's it, otherwise it tries to create `foo-($processId+1)`, then `foo-($processId+2)`, etc.

While on the surface this is OK, in practice it puts strain on the file system. If we need to create N temporary folders, the name assignment will cycle starting from `foo-$processid` every time, totaling N^2 IO calls. There are also seem to be issues on Windows when one thread is removing its temporary folder, while another it trying to create the very same one.

It would be so much better if our temporary names were more diverse by construction. Yes, there might be an odd chance of a clash because someone else just accidentally created the very same folder, but we should not routinely make our own life harder.

Normally this is achieved by generating random numbers, but Cabal cannot depend on non-boot libraries such as `random`. So this patch uses a global counter. The approach is similar to one used by [`file-io`](https://hackage-content.haskell.org/package/file-io-0.2.0/docs/src/System.File.Platform.html#tempCounter) for temporary files or by [`temporary-ospath`](https://hackage-content.haskell.org/package/temporary-ospath-1.3/docs/src/System.IO.Temp.OsPath.html#tempDirectoryCounter).

(Both `file-io` and `temporary-ospath` actually have even more refined schema for name generation, getting entropy from CPU time, but I think in the interest of simplicity Cabal can get away just with a global counter)

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)