### PR TITLE
Follow hlint suggestion to replace with const maps

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,20 +1,18 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
 - ignore: {name: "Avoid lambda"} # 54 hints
-- ignore: {name: "Eta reduce"} # 136 hints
+- ignore: {name: "Eta reduce"} # 137 hints
 - ignore: {name: "Hoist not"} # 16 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Redundant $!"} # 3 hints
-- ignore: {name: "Redundant bracket"} # 253 hints
+- ignore: {name: "Redundant bracket"} # 255 hints
 - ignore: {name: "Redundant guard"} # 1 hint
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 16 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant return"} # 7 hints
-- ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 30 hints
-- ignore: {name: "Use <$"} # 2 hints
 - ignore: {name: "Use <$>"} # 83 hints
 - ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
@@ -22,7 +20,7 @@
 - ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
-- ignore: {name: "Use camelCase"} # 96 hints
+- ignore: {name: "Use camelCase"} # 92 hints
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use newtype instead of data"} # 32 hints

--- a/Cabal-syntax/src/Distribution/Parsec.hs
+++ b/Cabal-syntax/src/Distribution/Parsec.hs
@@ -60,6 +60,7 @@ module Distribution.Parsec
 
 import Data.ByteString (ByteString)
 import Data.Char (digitToInt, intToDigit)
+import Data.Functor (($>))
 import Data.List (transpose)
 import Distribution.CabalSpecVersion
 import Distribution.Compat.Prelude
@@ -254,8 +255,8 @@ instance Parsec Bool where
       postprocess str
         | str == "True" = pure True
         | str == "False" = pure False
-        | lstr == "true" = parsecWarning PWTBoolCase caseWarning *> pure True
-        | lstr == "false" = parsecWarning PWTBoolCase caseWarning *> pure False
+        | lstr == "true" = parsecWarning PWTBoolCase caseWarning $> True
+        | lstr == "false" = parsecWarning PWTBoolCase caseWarning $> False
         | otherwise = fail $ "Not a boolean: " ++ str
         where
           lstr = map toLower str

--- a/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
@@ -37,6 +37,7 @@ module Distribution.Types.VersionRange.Internal
   , wildcardUpperBound
   ) where
 
+import Data.Functor (($>))
 import Distribution.Compat.Prelude
 import Distribution.Types.Version
 import Prelude ()
@@ -526,7 +527,7 @@ versionRangeParser digitParser csv = expr
     verLoop :: DList.DList Int -> m (Bool, Version)
     verLoop acc =
       verLoop' acc
-        <|> (tags *> pure (False, mkVersion (DList.toList acc)))
+        <|> (tags $> (False, mkVersion (DList.toList acc)))
 
     verLoop' :: DList.DList Int -> m (Bool, Version)
     verLoop' acc = do

--- a/Cabal/src/Distribution/Simple/GHC/EnvironmentParser.hs
+++ b/Cabal/src/Distribution/Simple/GHC/EnvironmentParser.hs
@@ -3,6 +3,7 @@
 
 module Distribution.Simple.GHC.EnvironmentParser (parseGhcEnvironmentFile, readGhcEnvironmentFile, ParseErrorExc (..)) where
 
+import Data.Functor (($>))
 import Distribution.Compat.Prelude
 import Prelude ()
 
@@ -25,7 +26,7 @@ parseEnvironmentFileLine =
   GhcEnvFileComment <$> comment
     <|> GhcEnvFilePackageId <$> unitId
     <|> GhcEnvFilePackageDb <$> packageDb
-    <|> pure GhcEnvFileClearPackageDbStack <* clearDb
+    <|> GhcEnvFileClearPackageDbStack <$ clearDb
   where
     comment = P.string "--" *> P.many (P.noneOf "\r\n")
     unitId =
@@ -34,8 +35,8 @@ parseEnvironmentFileLine =
           *> P.spaces
           *> (mkUnitId <$> P.many1 (P.satisfy $ \c -> isAlphaNum c || c `elem` "-_.+"))
     packageDb =
-      (P.string "global-package-db" *> pure GlobalPackageDB)
-        <|> (P.string "user-package-db" *> pure UserPackageDB)
+      (P.string "global-package-db" $> GlobalPackageDB)
+        <|> (P.string "user-package-db" $> UserPackageDB)
         <|> (P.string "package-db" *> P.spaces *> (SpecificPackageDB <$> P.many1 (P.noneOf "\r\n") <* P.lookAhead P.endOfLine))
     clearDb = P.string "clear-package-db"
 

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -423,7 +423,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
     -- provide location of the documentation of dependencies.
     localStyle =
       let hackage = fromFlagOrDefault False (haddockProjectHackage flags)
-          location = fromFlagOrDefault False (const True <$> haddockProjectHtmlLocation flags)
+          location = fromFlagOrDefault False (True <$ haddockProjectHtmlLocation flags)
        in not hackage && not location
 
     reportTargetProblems :: Show x => [x] -> IO a


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use <$"  and "use $>" suggestions so that these will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
