### PR TITLE
Follow hlint suggestion: use <&>

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,11 +1,11 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
 - ignore: {name: "Avoid lambda"} # 54 hints
-- ignore: {name: "Eta reduce"} # 136 hints
+- ignore: {name: "Eta reduce"} # 137 hints
 - ignore: {name: "Hoist not"} # 16 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Redundant $!"} # 3 hints
-- ignore: {name: "Redundant bracket"} # 253 hints
+- ignore: {name: "Redundant bracket"} # 255 hints
 - ignore: {name: "Redundant guard"} # 1 hint
 - ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 16 hints
@@ -16,13 +16,12 @@
 - ignore: {name: "Use :"} # 30 hints
 - ignore: {name: "Use <$"} # 2 hints
 - ignore: {name: "Use <$>"} # 83 hints
-- ignore: {name: "Use <&>"} # 16 hints
 - ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
 - ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
-- ignore: {name: "Use camelCase"} # 96 hints
+- ignore: {name: "Use camelCase"} # 92 hints
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use fst"} # 2 hints
 - ignore: {name: "Use newtype instead of data"} # 32 hints

--- a/Cabal-syntax/src/Distribution/Compat/Binary.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Binary.hs
@@ -6,6 +6,7 @@ module Distribution.Compat.Binary
 
 import Control.Exception (ErrorCall (..), catch, evaluate)
 import Data.ByteString.Lazy (ByteString)
+import Data.Functor ((<&>))
 
 import Data.Binary
 
@@ -15,6 +16,6 @@ decodeFileOrFail' f = either (Left . snd) Right `fmap` decodeFileOrFail f
 
 decodeOrFailIO :: Binary a => ByteString -> IO (Either String a)
 decodeOrFailIO bs =
-  catch (evaluate (decode bs) >>= return . Right) handler
+  catch (evaluate (decode bs) <&> Right) handler
   where
     handler (ErrorCall str) = return $ Left str

--- a/Cabal-syntax/src/Distribution/Fields/ConfVar.hs
+++ b/Cabal-syntax/src/Distribution/Fields/ConfVar.hs
@@ -3,6 +3,7 @@
 
 module Distribution.Fields.ConfVar (parseConditionConfVar, parseConditionConfVarFromClause) where
 
+import Data.Functor ((<&>))
 import Distribution.Compat.CharParsing (char, integral)
 import Distribution.Compat.Prelude
 import Distribution.Fields.Field (Field (..), SectionArg (..), sectionArgAnn)
@@ -73,8 +74,8 @@ sepByNonEmpty p sep = (:|) <$> p <*> many (sep *> p)
 parser :: Parser (Condition ConfVar)
 parser = condOr
   where
-    condOr = sepByNonEmpty condAnd (oper "||") >>= return . foldl1 COr
-    condAnd = sepByNonEmpty cond (oper "&&") >>= return . foldl1 CAnd
+    condOr = sepByNonEmpty condAnd (oper "||") <&> foldl1 COr
+    condAnd = sepByNonEmpty cond (oper "&&") <&> foldl1 CAnd
     cond =
       P.choice
         [boolLiteral, parens condOr, notCond, osCond, archCond, flagCond, implCond]

--- a/Cabal-syntax/src/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/Configuration.hs
@@ -34,6 +34,7 @@ module Distribution.PackageDescription.Configuration
   , simplifyWithSysParams
   ) where
 
+import Data.Functor ((<&>))
 import Distribution.Compat.Prelude
 import Prelude ()
 
@@ -113,8 +114,8 @@ simplifyWithSysParams os arch cinfo cond = (cond', flags)
 parseCondition :: CabalParsing m => m (Condition ConfVar)
 parseCondition = condOr
   where
-    condOr = sepByNonEmpty condAnd (oper "||") >>= return . foldl1 COr
-    condAnd = sepByNonEmpty cond (oper "&&") >>= return . foldl1 CAnd
+    condOr = sepByNonEmpty condAnd (oper "||") <&> foldl1 COr
+    condAnd = sepByNonEmpty cond (oper "&&") <&> foldl1 CAnd
     -- TODO: try?
     cond =
       sp
@@ -127,11 +128,11 @@ parseCondition = condOr
               <|> implCond
            )
     inparens = between (P.char '(' >> sp) (sp >> P.char ')' >> sp)
-    notCond = P.char '!' >> sp >> cond >>= return . CNot
-    osCond = string "os" >> sp >> inparens osIdent >>= return . Var
-    archCond = string "arch" >> sp >> inparens archIdent >>= return . Var
-    flagCond = string "flag" >> sp >> inparens flagIdent >>= return . Var
-    implCond = string "impl" >> sp >> inparens implIdent >>= return . Var
+    notCond = (P.char '!' >> sp >> cond) <&> CNot
+    osCond = (string "os" >> sp >> inparens osIdent) <&> Var
+    archCond = (string "arch" >> sp >> inparens archIdent) <&> Var
+    flagCond = (string "flag" >> sp >> inparens flagIdent) <&> Var
+    implCond = (string "impl" >> sp >> inparens implIdent) <&> Var
     boolLiteral = fmap Lit parsec
     archIdent = fmap Arch parsec
     osIdent = fmap OS parsec

--- a/Cabal-syntax/src/Distribution/Utils/Structured.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Structured.hs
@@ -72,6 +72,7 @@ module Distribution.Utils.Structured
   , typeName
   ) where
 
+import Data.Functor ((<&>))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Proxy (Proxy (..))
@@ -271,7 +272,7 @@ structuredDecode lbs = snd (Binary.decode lbs :: (Tag a, a))
 
 structuredDecodeOrFailIO :: (Binary.Binary a, Structured a) => LBS.ByteString -> IO (Either String a)
 structuredDecodeOrFailIO bs =
-  catch (evaluate (structuredDecode bs) >>= return . Right) handler
+  catch (evaluate (structuredDecode bs) <&> Right) handler
   where
     handler (ErrorCall str) = return $ Left str
 

--- a/Cabal/src/Distribution/Simple/Program/Db.hs
+++ b/Cabal/src/Distribution/Simple/Program/Db.hs
@@ -70,6 +70,7 @@ module Distribution.Simple.Program.Db
   , updatePathProgDb
   ) where
 
+import Data.Functor ((<&>))
 import Distribution.Compat.Prelude
 import Prelude ()
 
@@ -407,7 +408,7 @@ configureUnconfiguredProgram verbosity prog progdb = do
   maybeLocation <- case userSpecifiedPath prog progdb of
     Nothing ->
       programFindLocation prog verbosity (progSearchPath progdb)
-        >>= return . fmap (swap . fmap FoundOnSystem . swap)
+        <&> fmap (swap . fmap FoundOnSystem . swap)
     Just path -> do
       absolute <- doesExecutableExist path
       if absolute

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -31,6 +31,7 @@ import Distribution.Client.Compat.Prelude hiding (many, readFile, (<|>))
 
 import Distribution.Simple.Setup (fromFlagOrDefault)
 
+import Data.Functor ((<&>))
 import qualified Data.List as L
 import qualified Data.Set as Set
 import Distribution.CabalSpecVersion
@@ -140,10 +141,9 @@ guessSourceDirectories :: Interactive m => InitFlags -> m [FilePath]
 guessSourceDirectories flags = do
   pkgDir <- fromFlagOrDefault getCurrentDirectory $ return <$> packageDir flags
 
-  doesDirectoryExist (pkgDir </> "src")
-    >>= return . \case
-      False -> [defaultSourceDir]
-      True -> ["src"]
+  doesDirectoryExist (pkgDir </> "src") <&> \case
+    False -> [defaultSourceDir]
+    True -> ["src"]
 
 -- | Guess author and email using git configuration options.
 guessAuthorName :: Interactive m => m (Maybe String)

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
@@ -50,6 +50,7 @@ import Distribution.Verbosity
 
 import Control.Monad.State.Strict (StateT, execStateT, lift)
 import qualified Data.ByteString as BS
+import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Distribution.Client.Errors.Parser (ProjectFileSource (..))
@@ -386,7 +387,7 @@ type FieldSuffix = String
 -- | Extract the program name of a <progname> field, allow it to have a suffix such as '-options' and check whether the 'ProgramDB' contains it.
 readProgramName :: FieldSuffix -> ProgramDb -> FieldName -> Maybe String
 readProgramName suffix programDb fieldName =
-  parseProgramName suffix fieldName >>= ((flip lookupKnownProgram) programDb) >>= pure . programName
+  (parseProgramName suffix fieldName >>= ((flip lookupKnownProgram) programDb)) <&> programName
 
 parseProgramName :: FieldSuffix -> FieldName -> Maybe String
 parseProgramName suffix fieldName = case runParsecParser parser "<parseProgramName>" fieldNameStream of

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -228,6 +229,7 @@ import Control.Monad (mapM_, sequence)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State as State (State, execState, runState, state)
 import Data.Foldable (fold)
+import Data.Functor ((<&>))
 import Data.List (deleteBy, groupBy)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
@@ -559,13 +561,13 @@ configureCompiler
         )
         $ do
           liftIO $ info verbosity "Compiler settings changed, reconfiguring..."
-          progdb <-
-            liftIO $
-              -- Add paths in the global config
-              prependProgramSearchPath verbosity (fromNubList projectConfigProgPathExtra) [] defaultProgramDb
-                -- Add paths in the local config
-                >>= prependProgramSearchPath verbosity (fromNubList packageConfigProgramPathExtra) []
-                >>= pure . userSpecifyPaths (Map.toList (getMapLast packageConfigProgramPaths))
+          progdb <- liftIO $ do
+            -- Add paths in the global config then paths in the local config
+            let addPaths pathList = prependProgramSearchPath verbosity (fromNubList pathList) []
+            let globalPaths :: IO ProgramDb = addPaths projectConfigProgPathExtra defaultProgramDb
+            let localPaths :: ProgramDb -> IO ProgramDb = addPaths packageConfigProgramPathExtra
+            let userPaths :: ProgramDb -> ProgramDb = userSpecifyPaths (Map.toList $ getMapLast packageConfigProgramPaths)
+            (globalPaths >>= localPaths) <&> userPaths
           result@(_, _, progdb') <-
             liftIO $
               Cabal.configCompiler

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -180,6 +180,7 @@ import Data.Type.Equality  ( type (==) )
 import Data.Type.Bool      ( If )
 import System.Directory (doesFileExist)
 import System.FilePath ((<.>), (</>))
+import Data.Functor ((<&>))
 import System.IO (Handle, hPutStr)
 import System.Process (StdStream (..))
 import qualified System.Process as Process
@@ -463,7 +464,7 @@ getSetup verbosity options mpkg allowInLibrary = do
     mbWorkDir = useWorkingDir options
     getPkg =
       (tryFindPackageDesc verbosity mbWorkDir >>= readGenericPackageDescription verbosity mbWorkDir . relativeSymbolicPath)
-        >>= return . packageDescription
+        <&> packageDescription
 
 -- | Decide if we're going to be able to do a direct internal call to the
 -- entry point in the Cabal library or if we're going to have to compile


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use <&>" suggestion so that these will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
