### PR TITLE
Stop using lukko

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -34,11 +34,6 @@ Flag native-dns
   default:      True
   manual:       True
 
-Flag lukko
-  description:  Use @lukko@ for file-locking
-  default:      False
-  manual:       False
-
 flag git-rev
   description: include Git revision hash in version
   default: False
@@ -289,10 +284,6 @@ library
     else
       build-depends:
         , unix >= 2.5 && < 2.8 || >= 2.8.6.0 && < 2.9
-
-    if flag(lukko)
-      build-depends:
-        , lukko >= 0.1 && <0.2
 
     -- pull in process version with fixed waitForProcess error
     if impl(ghc >=8.2)

--- a/cabal-install/src/Distribution/Client/Store.hs
+++ b/cabal-install/src/Distribution/Client/Store.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -37,15 +36,10 @@ import Distribution.Simple.Utils
 
 import Control.Exception
 import qualified Data.Set as Set
+import GHC.IO.Handle.Lock (LockMode (ExclusiveLock), hLock, hTryLock, hUnlock)
 import System.Directory
 import System.FilePath
-
-#ifdef MIN_VERSION_lukko
-import Lukko
-#else
-import System.IO (openFile, IOMode(ReadWriteMode), hClose)
-import GHC.IO.Handle.Lock (LockMode (ExclusiveLock), hLock, hTryLock, hUnlock)
-#endif
+import System.IO (IOMode (ReadWriteMode), hClose, openFile)
 
 -- $concurrency
 --
@@ -250,36 +244,17 @@ withIncomingUnitIdLock
     bracket takeLock releaseLock (\_hnd -> action)
     where
       compid = compilerId compiler
-#ifdef MIN_VERSION_lukko
-      takeLock
-          | fileLockingSupported = do
-              fd <- fdOpen (storeIncomingLock compiler unitid)
-              gotLock <- fdTryLock fd ExclusiveLock
-              unless gotLock  $ do
-                  info verbosity $ "Waiting for file lock on store entry "
-                                ++ prettyShow compid </> prettyShow unitid
-                  fdLock fd ExclusiveLock
-              return fd
-
-          -- if there's no locking, do nothing. Be careful on AIX.
-          | otherwise = return undefined -- :(
-
-      releaseLock fd
-          | fileLockingSupported = do
-              fdUnlock fd
-              fdClose fd
-          | otherwise = return ()
-#else
       takeLock = do
         h <- openFile (storeIncomingLock compiler unitid) ReadWriteMode
         -- First try non-blocking, but if we would have to wait then
         -- log an explanation and do it again in blocking mode.
         gotlock <- hTryLock h ExclusiveLock
         unless gotlock $ do
-          info verbosity $ "Waiting for file lock on store entry "
-                        ++ prettyShow compid </> prettyShow unitid
+          info verbosity $
+            "Waiting for file lock on store entry "
+              ++ prettyShow compid
+              </> prettyShow unitid
           hLock h ExclusiveLock
         return h
 
       releaseLock h = hUnlock h >> hClose h
-#endif

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -7,7 +7,7 @@ index-state: hackage.haskell.org 2026-05-25T10:36:08Z
 
 -- never include this or its TH dependency in a release!
 package cabal-install
-  flags: -git-rev -lukko
+  flags: -git-rev
 
 package Cabal
   flags: -git-rev

--- a/changelog.d/pr-11915.md
+++ b/changelog.d/pr-11915.md
@@ -1,0 +1,7 @@
+---
+synopsis: Stop using lukko
+packages: [cabal-install]
+prs: 11915
+---
+
+In the previous release we switch `lukko` flag off by default. This release removes the flag and thus any usage of `lukko` in `cabal-install`, now `base:GHC.IO.Handle.Lock` is used unconditionally.


### PR DESCRIPTION
A year ago we stopped using `lukko` package by default and guarded it by a Cabal flag. No one complained and I never heard of anyone forcing the Cabal flag to use `lukko` instead of `base`. I think it's time we clean it up entirely.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)