### PR TITLE
Follow hlint suggestions to use monadic compose

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -13,9 +13,7 @@
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 30 hints
 - ignore: {name: "Use <$>"} # 83 hints
-- ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
-- ignore: {name: "Use >=>"} # 3 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
 - ignore: {name: "Use camelCase"} # 92 hints

--- a/Cabal-syntax/src/Distribution/Utils/Generic.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Generic.hs
@@ -87,6 +87,7 @@ import Prelude ()
 
 import Control.Concurrent (threadDelay)
 import qualified Control.Exception as Exception
+import Control.Monad ((>=>))
 import Data.Bits (shiftL, (.&.), (.|.))
 import qualified Data.ByteString as SBS
 import qualified Data.ByteString.Lazy as LBS
@@ -161,11 +162,7 @@ wrapLine width = wrap 0 []
 -- The file is read lazily; if it is not fully consumed by the action then an
 -- exception is thrown.
 withFileContents :: FilePath -> (String -> IO a) -> IO a
-withFileContents name action =
-  withFile
-    name
-    ReadMode
-    (\hnd -> hGetContents hnd >>= action)
+withFileContents name action = withFile name ReadMode (hGetContents >=> action)
 
 -- | Writes a file atomically.
 --
@@ -317,7 +314,7 @@ withUTF8FileContents name action =
   withBinaryFile
     name
     ReadMode
-    (\hnd -> LBS.hGetContents hnd >>= action . ignoreBOM . fromUTF8LBS)
+    (LBS.hGetContents >=> action . ignoreBOM . fromUTF8LBS)
 
 -- | Writes a Unicode String as a UTF8 encoded text file.
 --

--- a/cabal-dev-scripts/src/GenSPDX.hs
+++ b/cabal-dev-scripts/src/GenSPDX.hs
@@ -2,6 +2,7 @@
 module Main (main) where
 
 import Control.Lens     (imap)
+import Control.Monad    ((<=<))
 import Data.Aeson       (FromJSON (..), eitherDecode, withObject, (.!=), (.:), (.:?))
 import Data.List        (sortOn)
 import Data.Text        (Text)
@@ -55,7 +56,7 @@ main = generate =<< O.execParser opts where
 
 generate :: Opts -> IO ()
 generate (Opts tmplFile fns out) = do
-    lss <- for fns $ \fn -> either fail pure . eitherDecode =<< LBS.readFile fn
+    lss <- for fns (either fail pure . eitherDecode <=< LBS.readFile)
     template <- Z.parseAndCompileTemplateIO tmplFile
     output <- generate' lss template
     writeFile out (header <> "\n" <> output)

--- a/cabal-dev-scripts/src/GenSPDXExc.hs
+++ b/cabal-dev-scripts/src/GenSPDXExc.hs
@@ -2,6 +2,7 @@
 module Main (main) where
 
 import Control.Lens     (imap)
+import Control.Monad    ((<=<))
 import Data.Aeson       (FromJSON (..), eitherDecode, withObject, (.:))
 import Data.List        (sortOn)
 import Data.Text        (Text)
@@ -55,7 +56,7 @@ main = generate =<< O.execParser opts where
 
 generate :: Opts -> IO ()
 generate (Opts tmplFile fns out) = do
-    lss <- for fns $ \fn -> either fail pure . eitherDecode =<< LBS.readFile fn
+    lss <- for fns (either fail pure . eitherDecode <=< LBS.readFile)
     template <- Z.parseAndCompileTemplateIO tmplFile
     output <- generate' lss template
     writeFile out (header <> "\n" <> output)

--- a/cabal-install/src/Distribution/Client/HashValue.hs
+++ b/cabal-install/src/Distribution/Client/HashValue.hs
@@ -9,6 +9,7 @@ module Distribution.Client.HashValue
   , hashFromTUF
   ) where
 
+import Control.Monad ((<=<))
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
@@ -56,8 +57,7 @@ showHashValue (HashValue digest) = BS.unpack (Base16.encode digest)
 -- | Hash the content of a file. Uses SHA256.
 readFileHashValue :: FilePath -> IO HashValue
 readFileHashValue tarball =
-  withBinaryFile tarball ReadMode $ \hnd ->
-    evaluate . hashValue =<< LBS.hGetContents hnd
+  withBinaryFile tarball ReadMode (evaluate . hashValue <=< LBS.hGetContents)
 
 -- | Convert a hash from TUF metadata into a 'PackageSourceHash'.
 --

--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -777,8 +777,10 @@ readPackagesUpToDateCacheFile :: DistDirLayout -> IO PackagesUpToDate
 readPackagesUpToDateCacheFile DistDirLayout{distProjectCacheFile} =
   handleDoesNotExist Set.empty $
     handleDecodeFailure $
-      withBinaryFile (distProjectCacheFile "up-to-date") ReadMode $ \hnd ->
-        Binary.decodeOrFailIO =<< BS.hGetContents hnd
+      withBinaryFile
+        (distProjectCacheFile "up-to-date")
+        ReadMode
+        (Binary.decodeOrFailIO <=< BS.hGetContents)
   where
     handleDecodeFailure = fmap (fromRight Set.empty)
 

--- a/cabal-install/src/Distribution/Client/SourceFiles.hs
+++ b/cabal-install/src/Distribution/Client/SourceFiles.hs
@@ -12,6 +12,7 @@
 -- we cannot "see" easily.
 module Distribution.Client.SourceFiles (needElaboratedConfiguredPackage) where
 
+import Control.Monad ((>=>))
 import Control.Monad.IO.Class
 
 import Distribution.Client.ProjectPlanning.Types
@@ -190,9 +191,11 @@ needBuildInfo pkg_descr bi modules = do
       , map getSymbolicPath $ asmSources bi
       , map getSymbolicPath expandedExtraSrcFiles
       ]
-  for_ (fmap getSymbolicPath $ installIncludes bi) $ \f ->
-    findFileMonitored ("." : fmap getSymbolicPath (includeDirs bi)) f
-      >>= maybe (return ()) need
+  for_
+    (fmap getSymbolicPath $ installIncludes bi)
+    ( findFileMonitored ("." : fmap getSymbolicPath (includeDirs bi))
+        >=> maybe (return ()) need
+    )
   where
     findNeededModules :: [Suffix] -> Rebuild ()
     findNeededModules exts =


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use >=>"  and "use <=<" suggestions so that these will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
