### PR TITLE
Fix typo temeplate

### DIFF
--- a/cabal-dev-scripts/src/GenCabalInstallCabal.hs
+++ b/cabal-dev-scripts/src/GenCabalInstallCabal.hs
@@ -19,7 +19,7 @@ withIO k = do
                 putStrLn $ "Exception: " ++ displayException e
                 exitFailure
         _         -> do
-            putStrLn "Usage cabal run ... source.temeplate.ext target.ext"
+            putStrLn "Usage cabal run ... source.template.ext target.ext"
             exitFailure
   where
     parseBool "True"  = Just True

--- a/cabal-dev-scripts/src/GenCabalMacros.hs
+++ b/cabal-dev-scripts/src/GenCabalMacros.hs
@@ -65,7 +65,7 @@ withIO k = do
             putStrLn $ "Exception: " ++ displayException e
             exitFailure
         _         -> do
-            putStrLn "Usage cabal run ... source.temeplate.ext target.ext"
+            putStrLn "Usage cabal run ... source.template.ext target.ext"
             exitFailure
 
 main :: IO ()

--- a/cabal-dev-scripts/src/GenPathsModule.hs
+++ b/cabal-dev-scripts/src/GenPathsModule.hs
@@ -58,7 +58,7 @@ withIO k = do
             putStrLn $ "Exception: " ++ displayException e
             exitFailure
         _         -> do
-            putStrLn "Usage cabal run ... source.temeplate.ext target.ext"
+            putStrLn "Usage cabal run ... source.template.ext target.ext"
             exitFailure
 
 main :: IO ()


### PR DESCRIPTION
Fixes a typo.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
