### PR TITLE
Bump process

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -58,6 +58,10 @@ library
     build-depends:
       , unix  >= 2.8.6.0 && < 2.9
 
+  if os(darwin)
+    build-depends:
+      , process >= 1.6.29.0
+
   if flag(git-rev)
     build-depends:
       , githash ^>= 0.1.7.0

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -299,6 +299,10 @@ library
       build-depends:
         , process >= 1.6.15.0
 
+    if os(darwin)
+      build-depends:
+        , process >= 1.6.29.0
+
     if flag(git-rev)
       build-depends: githash ^>= 0.1.7.0
       cpp-options: -DGIT_REV

--- a/changelog.d/pr-11928
+++ b/changelog.d/pr-11928
@@ -1,0 +1,13 @@
+synopsis: bump `process`
+packages: Cabal cabal-install
+prs: #11928
+issues: #11923
+significance:
+
+description: {
+
+`Cabal` and `cabal-install` now depend on a newer version of `process`
+(`1.6.29.0`).  This avoids segfaults on macOS, where certain symbols
+are available, but *only* for targets that support them.
+
+}


### PR DESCRIPTION
Closes #11923

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * ~~[ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.~~ no
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* ~~[ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~ N/A, a bit difficult to test this one.

**QA Notes**

- have macos version 15
- have a command line sdk that can compile for macos 26
- this setup should segfault before this patch and not after