### PR TITLE
Running cabal doctest with ghc-9.12

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -15,7 +15,7 @@ on:
       - created
 
 env:
-  GHC_FOR_QUICK_JOBS: 9.10.3
+  GHC_FOR_QUICK_JOBS: 9.12.2
 
 jobs:
   meta:

--- a/Makefile
+++ b/Makefile
@@ -151,15 +151,21 @@ ghcid-cli: ## Run ghcid for the cabal-install executable.
 
 .PHONY: doctest
 doctest: ## Run doctests.
+	cabal --numeric-version
 	cd Cabal-syntax && $(DOCTEST)
 	cd Cabal-described && $(DOCTEST)
 	cd Cabal && $(DOCTEST)
 	cd cabal-install-solver && $(DOCTEST)
 	cd cabal-install && $(DOCTEST)
 
+# If we pin and periodically bump the version of doctest, we get more
+# reproducible testing. Initially we pinned to doctest-0.25.0 to avoid failures
+# with doctest-0.24.3 but `cabal install doctest` depends on index state that
+# itself gets bumped when `cabal update --ignore-project` is run.
+# SEE: https://github.com/haskell/cabal/issues/11493#issuecomment-4615438425
 .PHONY: doctest-install
 doctest-install: ## Install doctest tool needed for running doctests.
-	cabal install doctest --overwrite-policy=always --ignore-project --flag cabal-doctest
+	cabal install doctest-0.25.0 --overwrite-policy=always --ignore-project --flag cabal-doctest
 
 # tests
 


### PR DESCRIPTION
Fixes #11493. I found something that works by accident, pinning to `doctest-0.25.0`. This fix supercedes the one from #11793 and sticks with using `cabal doctest` for the doctests. I also log the version of cabal we use when running doctests and bumped to `ghc-9.12.4`, the ghc used for running quick-jobs.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
