### PR TITLE
Re #6038 #9370 Deps with no main lib are accepted by Cabal (the tool)

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -800,11 +800,6 @@ Library
     components in other packages (public). A package can have no more than one
     unnamed library.
 
-    .. Note::
-
-       The 'cabal' executable provided by the 'cabal-install' package will not
-       accept dependencies on sublibraries of packages with no unnamed library.
-
     This guide refers to an unnamed library as the main library and a named
     library as a sublibrary (such components may be considered as subidiary, or
     ancillary, to the main library). It refers to a private sublibrary as an


### PR DESCRIPTION
**Template B: This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). Not applicable

See:
* #6038 
* #9370

Cabal (the tool) v3.14.2.0 and v3.16.1.0 appear to accept dependencies on packages with public sublibraries and no main library. Consequently, the note in the Cabal User Guide stating otherwise can be deleted. For example, the following example appears to be buildable on a Windows 11 system:

~~~text
-- cabal.project
packages:
    myPackageA
    myPackageB
~~~

~~~text
-- myPackageA/myPackageA.cabal
cabal-version: 3.4
name:           myPackageA
version:        0.0.0

library
  exposed-modules:
      Lib
  hs-source-dirs:
      src
  build-depends:
      base
    , myPackageB:myPackageB-sub
  default-language: Haskell2010
~~~

~~~text
-- myPackageB/myPackageB.cabal
cabal-version: 3.4
name:           myPackageB
version:        0.0.0

library myPackageB-sub
  visibility: public
  exposed-modules:
      Sublib
  hs-source-dirs:
      sub
  build-depends:
      base
~~~
