### PR TITLE
Preflight 3.18

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: ["9.2.8", "9.4.8", "9.6.7", "9.8.4", "9.10.3", "9.12.2"]
+        ghc: ["9.4.8", "9.6.7", "9.8.4", "9.10.3", "9.12.2"]
         include:
           - os: macos-latest
-            ghc: "9.2.8"
+            ghc: "9.12.2"
     name: Bootstrap ${{ matrix.os }} ghc-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -562,6 +562,10 @@ data KnownExtension
   | -- | Allow identifiers to be used at different levels than where they’re
     -- defined, using path-based persistence.
     ImplicitStagePersistence
+  | -- | Enable qualified string literals.
+    QualifiedStrings
+  | -- | Enable modifier syntax.
+    Modifiers
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Data)
 
 instance Binary KnownExtension

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,8 +29,8 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
-    0xd0df09480e91e08ae600d3ba4d9c3740
+    0xfd3ceefd3ccba5b23fa3688aefb363a9
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x8190203d49e950335b62db3978880e45
+    0x1bc2c98e507f9818275835dcf4dd2f12

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.6
+cabal-version: 3.8
 name:          Cabal
 version:       3.17.0.0
 copyright:     2003-2025, Cabal Development Team (see AUTHORS file)

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -172,7 +172,11 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
     argumentFilters :: [String] -> [String]
     argumentFilters =
       flagArgumentFilter
-        ["-ghci-script", "-H", "-interactive-print"]
+        [ "-ghci-script"
+        , "-H"
+        , "-interactive-print"
+        , "-fghci-browser-assets-dir"
+        ]
 
     -- \| Remove RTS arguments from a list.
     filterRtsArgs :: [String] -> [String]

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -151,6 +151,9 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
         makeFilter :: String -> String -> Maybe (First ([String] -> [String]))
         makeFilter flag arg = First . filterRest <$> stripPrefix flag arg
           where
+            -- Drop the next argument, whether it comes after a `=` or
+            -- is stand-alone.
+            filterRest :: String -> [String] -> [String]
             filterRest leftOver = case dropEq leftOver of
               [] -> drop 1
               _ -> id
@@ -164,6 +167,8 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
           Just f -> go (f args)
           Nothing -> arg : go args
 
+    -- Options that take parameters and do not modify the generated artifacts
+    -- are filtered out.
     argumentFilters :: [String] -> [String]
     argumentFilters =
       flagArgumentFilter
@@ -173,6 +178,9 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
     filterRtsArgs :: [String] -> [String]
     filterRtsArgs = snd . splitRTSArgs
 
+    -- Simple options (i.e. that do not take parameters, or just
+    -- take int parameters) which do *not* change generated artifacts
+    -- are filtered out.
     simpleFilters :: String -> Bool
     simpleFilters =
       not
@@ -183,7 +191,8 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
           , Any . isPrefixOf "-dsuppress-"
           , Any . isPrefixOf "-dno-suppress-"
           , flagIn $ invertibleFlagSet "-" ["ignore-dot-ghci"]
-          , flagIn . invertibleFlagSet "-f" . mconcat $
+          , -- -f-something -f-no-something options.
+            flagIn . invertibleFlagSet "-f" . mconcat $
               [
                 [ "reverse-errors"
                 , "warn-unused-binds"

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -388,7 +388,7 @@ test-suite unit-tests
       , tasty-expected-failure
       , tasty-hunit >= 0.10
       , tree-diff
-      , QuickCheck >= 2.14.3 && <2.18
+      , QuickCheck >= 2.14.3 && <2.19
 
 -- Tests for the project file parser
 test-suite parser-tests
@@ -494,5 +494,5 @@ test-suite long-tests
     , tasty-expected-failure
     , tasty-hunit >= 0.10
     , tasty-quickcheck <0.12
-    , QuickCheck >= 2.14 && <2.18
+    , QuickCheck >= 2.14 && <2.19
     , pretty-show >= 1.6.15

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:      3.6
+Cabal-Version:      3.8
 
 Name:               cabal-install
 Version:            3.17.0.0

--- a/changelog.d/pr-11936
+++ b/changelog.d/pr-11936
@@ -1,0 +1,8 @@
+---
+synopsis: Recognise `Modifiers` and `QualifiedStrings` extensions
+packages: [Cabal, cabal-install]
+prs: 11936
+---
+
+`Cabal` and `cabal-install` now recognise extensions from GHC 10.0
+(`Modifiers` and `QualifiedStrings`).

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -216,6 +216,7 @@ syn keyword cabalExtension contained
   \ LinearTypes
   \ ListTuplePuns
   \ MagicHash
+  \ Modifiers
   \ MonadComprehensions
   \ MonadFailDesugaring
   \ MonoLocalBinds
@@ -251,6 +252,7 @@ syn keyword cabalExtension contained
   \ PolymorphicComponents
   \ PostfixOperators
   \ QualifiedDo
+  \ QualifiedStrings
   \ QuantifiedConstraints
   \ QuasiQuotes
   \ Rank2Types
@@ -362,6 +364,7 @@ syn keyword cabalExtension contained
   \ NoLiberalTypeSynonyms
   \ NoLinearTypes
   \ NoMagicHash
+  \ NoModifiers
   \ NoMonadComprehensions
   \ NoMonadFailDesugaring
   \ NoMonoLocalBinds
@@ -397,6 +400,7 @@ syn keyword cabalExtension contained
   \ NoPolymorphicComponents
   \ NoPostfixOperators
   \ NoQualifiedDo
+  \ NoQualifiedStrings
   \ NoQuantifiedConstraints
   \ NoQuasiQuotes
   \ NoRank2Types

--- a/hooks-exe/hooks-exe.cabal
+++ b/hooks-exe/hooks-exe.cabal
@@ -13,7 +13,7 @@ description:
 category:      Distribution
 build-type:    Simple
 
-extra-source-files:
+extra-doc-files:
   readme.md changelog.md
 
 common warnings

--- a/hooks-exe/hooks-exe.cabal
+++ b/hooks-exe/hooks-exe.cabal
@@ -45,7 +45,8 @@ library
       >= 1.4.0.0  && < 1.6 ,
     process
       >= 1.6.20.0 && < 1.7 ,
-    Cabal-syntax, Cabal
+    Cabal >= 3.17.0 && < 3.18,
+    Cabal-syntax >= 3.17.0 && < 3.18,
 
   exposed-modules:
     Distribution.Client.SetupHooks.CallHooksExe


### PR DESCRIPTION
Ready for review, meanwhile we wait for #11934 :
- [x] bump `cabal-version`
- [x] add two extension from #11934
- [x] add new flags
- [x] run `cabal check` and `cabal outdated` (bumped `QuickCheck`, tested with `cabal build --allow-newer=QuickCheck -cQuickCheck==2.18.0.0 cabal-install`
- [ ] backport to `3.18` and `3.16` 

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  ~~* [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.~~ no
* [x] The documentation has been updated, if necessary.
* ~~[ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.~~ N/A we do not have have the relevant GHC to QA this with.
* ~~[ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~ N/A