### PR TITLE
Make 'cabal clean' more robust: retry after getting 'Unsatisfied constraints (directory is non empty)' error

### DIFF
--- a/Cabal-tests/lib/Test/Utils/TempTestDir.hs
+++ b/Cabal-tests/lib/Test/Utils/TempTestDir.hs
@@ -60,7 +60,7 @@ removeDirectoryRecursiveHack :: Verbosity -> FilePath -> IO ()
 removeDirectoryRecursiveHack verbosity dir | isWindows = go 1
   where
     isWindows = System.Info.os == "mingw32"
-    limit = 3
+    limit = 5
 
     go :: Int -> IO ()
     go n = do

--- a/cabal-install/src/Distribution/Client/CmdClean.hs
+++ b/cabal-install/src/Distribution/Client/CmdClean.hs
@@ -81,6 +81,7 @@ import Control.Monad
   , mapM
   )
 import qualified Data.Set as Set
+import qualified GHC.IO.Exception as GHC
 import System.Directory
   ( canonicalizePath
   , doesDirectoryExist
@@ -92,7 +93,8 @@ import System.FilePath
   ( (</>)
   )
 import System.IO.Error
-  ( isPermissionError
+  ( ioeGetErrorType
+  , isPermissionError
   )
 import qualified System.Process as Process
 
@@ -193,7 +195,14 @@ cleanAction (ProjectFlags{..}, CleanFlags{..}) extraArgs _ = do
                 "attrib -s -h -r " <> distRoot <> "\\*.* /s /d"
         catch
           (removePathForcibly distRoot)
-          (\e -> if isPermissionError e then threadDelay 1000 >> removePathForcibly distRoot else throw e)
+          ( \e ->
+              -- Permission error is usually when some files are (temporarily) locked.
+              -- Unsatisfied constraints (directory is non empty) error happens
+              -- when some files inside the directory were not removed (perhaps because they are locked).
+              if isPermissionError e || ioeGetErrorType e == GHC.UnsatisfiedConstraints
+                then threadDelay 1000 >> removePathForcibly distRoot
+                else throw e
+          )
 
     removeEnvFiles $ distProjectRootDirectory distLayout
 

--- a/changelog.d/pr-11604.md
+++ b/changelog.d/pr-11604.md
@@ -1,7 +1,7 @@
 ---
 synopsis: Replace removeDirectoryRecursive with removePathForcibly
 packages: [Cabal, cabal-install]
-prs: 11604
+prs: 11604 11938
 ---
 
 We replace `System.Directory.removeDirectoryRecursive` calls with a more robust `System.Directory.removePathForcibly`. Additionally, some functions (most notably the one responsible for `cabal clean`) now run `removeDirectoryRecursive` twice on all platforms if the first time was not successful (previously only on Windows) and include a small delay in between.


### PR DESCRIPTION
I've been testing Cabal HEAD manually and uncovered another case when retrying `cabal clean` is helpful. This is a follow up to #11604.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
