### PR TITLE
Follow hlint suggestion: use =<<

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -13,7 +13,6 @@
 - ignore: {name: "Use ++"} # 4 hints
 - ignore: {name: "Use :"} # 30 hints
 - ignore: {name: "Use <$>"} # 83 hints
-- ignore: {name: "Use =<<"} # 7 hints
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use bimap"} # 7 hints
 - ignore: {name: "Use camelCase"} # 92 hints

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -750,7 +750,7 @@ checkSourceRepos rs = do
         checkP
           (any isAbsoluteOnAnyPlatform repoSubdir_)
           (PackageDistInexcusable SubdirRelPath)
-        case join . fmap isGoodRelativeDirectoryPath $ repoSubdir_ of
+        case isGoodRelativeDirectoryPath =<< repoSubdir_ of
           Just err ->
             tellP
               (PackageDistInexcusable $ SubdirGoodRelPath err)

--- a/Cabal/src/Distribution/Simple/Program/Db.hs
+++ b/Cabal/src/Distribution/Simple/Program/Db.hs
@@ -71,6 +71,7 @@ module Distribution.Simple.Program.Db
   , updatePathProgDb
   ) where
 
+import Control.Monad ((<=<))
 import Data.Functor ((<&>))
 import Distribution.Compat.Prelude
 import Prelude ()
@@ -345,7 +346,7 @@ userSpecifyArgss argss progdb =
 -- | Get the path that has been previously specified for a program, if any.
 userSpecifiedPath :: Program -> ProgramDb -> Maybe FilePath
 userSpecifiedPath prog =
-  join . fmap (\(_, p, _) -> p) . Map.lookup (programName prog) . unconfiguredProgs
+  (\(_, p, _) -> p) <=< (Map.lookup (programName prog) . unconfiguredProgs)
 
 -- | Get any extra args that have been previously specified for a program.
 userSpecifiedArgs :: Program -> ProgramDb -> [ProgArg]
@@ -617,6 +618,5 @@ requireProgramVersion
   -> ProgramDb
   -> IO (ConfiguredProgram, Version, ProgramDb)
 requireProgramVersion verbosity prog range programDb =
-  join $
-    either (dieWithException verbosity) return
-      `fmap` lookupProgramVersion verbosity prog range programDb
+  either (dieWithException verbosity) return
+    =<< lookupProgramVersion verbosity prog range programDb

--- a/Cabal/src/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/src/Distribution/Simple/Test/LibV09.hs
@@ -322,7 +322,7 @@ stubRunTests tests = do
       return $ GroupLogs (groupName g) logs
     stubRunTests' (ExtraOptions _ t) = stubRunTests' t
     maybeDefaultOption opt =
-      maybe Nothing (\d -> Just (optionName opt, d)) $ optionDefault opt
+      (\d -> Just (optionName opt, d)) =<< optionDefault opt
     defaultOptions testInst = mapMaybe maybeDefaultOption $ options testInst
 
 -- | From a test stub, write the 'TestSuiteLog' to temporary file for the calling

--- a/cabal-install/src/Distribution/Client/CmdTest.hs
+++ b/cabal-install/src/Distribution/Client/CmdTest.hs
@@ -212,8 +212,7 @@ selectComponentTarget
   -> Either TestTargetProblem k
 selectComponentTarget subtarget@WholeComponent t
   | CTestName _ <- availableTargetComponentName t =
-      either Left return $
-        selectComponentTargetBasic subtarget t
+      selectComponentTargetBasic subtarget t
   | otherwise =
       Left
         ( notTestProblem

--- a/cabal-install/src/Distribution/Client/List.hs
+++ b/cabal-install/src/Distribution/Client/List.hs
@@ -31,10 +31,7 @@ import Distribution.Package
   , packageName
   , packageVersion
   )
-import Distribution.PackageDescription
-  ( PackageFlag (..)
-  , unFlagName
-  )
+import Distribution.PackageDescription (PackageFlag (..), repoKind, repoLocation, sourceRepos, unFlagName)
 import qualified Distribution.PackageDescription as Source
 import Distribution.PackageDescription.Configuration
   ( flattenPackageDescription
@@ -607,14 +604,7 @@ mergePackageInfo versionPref installedPkgs sourcePkgs selectedPkg showVer =
             installed
       , bugReports = maybe mempty Source.bugReports source
       , sourceRepo =
-          fromMaybe mempty
-            . join
-            . fmap
-              ( uncons Nothing Source.repoLocation
-                  . sortBy (comparing Source.repoKind)
-                  . Source.sourceRepos
-              )
-            $ source
+          fromMaybe mempty $ (uncons Nothing repoLocation . sortBy (comparing repoKind) . sourceRepos) =<< source
       , -- TODO: installed package info is missing synopsis
         synopsis = maybe mempty Source.synopsis source
       , description =
@@ -650,11 +640,7 @@ mergePackageInfo versionPref installedPkgs sourcePkgs selectedPkg showVer =
             source
             (map InstalledDependency . Installed.depends)
             installed
-      , haddockHtml =
-          fromMaybe ""
-            . join
-            . fmap (listToMaybe . Installed.haddockHTMLs)
-            $ installed
+      , haddockHtml = fromMaybe "" $ (listToMaybe . Installed.haddockHTMLs) =<< installed
       , haveTarball = False
       }
   where


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use =<<" suggestion so that this will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved. I've left these commits so that any changes subsequent to the HLint suggestion can be reviewed as they progressed.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
