### PR TITLE
Avoid writing setup-config twice

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -459,13 +459,28 @@ findDistPrefOrDefault
 findDistPrefOrDefault = findDistPref defaultDistPref
 
 -- | Perform the \"@.\/setup configure@\" action.
---  Returns the @.setup-config@ file.
+--
+-- Returns the @LocalBuildInfo@, also writing it to the @setup-config@ file.
 configure
   :: (GenericPackageDescription, HookedBuildInfo)
   -> ConfigFlags
   -> IO LocalBuildInfo
-configure p = configure_setupHooks noConfigureHooks p defaultVerbosityHandles
+configure p cfg = do
+  lbi <- configure_setupHooks noConfigureHooks p defaultVerbosityHandles cfg
+  -- Write the 'LocalBuildInfo' to the @setup-config@ file.
+  --
+  -- NB: the shared 'configure_setupHooks'/'configureFinal' functions deliberately
+  -- don't include this logic, as it is the responsibility of each top-level
+  -- configure entry point.
+  let distPref = fromFlag $ configDistPref cfg
+      mbWorkDir = flagToMaybe $ configWorkingDir cfg
+  writePersistBuildConfig mbWorkDir distPref lbi
+  return lbi
 
+-- | Run the @Cabal@ library configure phase.
+--
+-- NB: this function does /not/ persist the resulting 'LocalBuildInfo' to the
+-- @setup-config@ file; that is the responsibility of callers.
 configure_setupHooks
   :: ConfigureHooks
   -> (GenericPackageDescription, HookedBuildInfo)
@@ -546,8 +561,6 @@ configureFinal
     } =
     do
       let verbosity = mkVerbosity verbHandles (fromFlag (configVerbosity cfg))
-          distPref = fromFlag $ configDistPref cfg
-          mbWorkDir = flagToMaybe $ configWorkingDir cfg
 
       -- Apply compiler capability checks to the incoming build options
       -- (idempotent).
@@ -608,10 +621,7 @@ configureFinal
           pkgInfo
           pkgDescr
           enabledComps
-      lbi <- configureComponents verbHandles lbc2 pbd3 installedPkgSet promisedDeps externalPkgDeps
-      writePersistBuildConfig mbWorkDir distPref lbi
-
-      return lbi
+      configureComponents verbHandles lbc2 pbd3 installedPkgSet promisedDeps externalPkgDeps
 
 runPreConfPackageHook
   :: ConfigFlags

--- a/changelog.d/T11619.md
+++ b/changelog.d/T11619.md
@@ -1,0 +1,9 @@
+---
+synopsis: Only write setup-config once
+packages: [Cabal]
+prs: 11949
+issues: 11619
+---
+
+We now ensure that the `setup-config` file, written by `writePersistBuildConfig`,
+is only ever written once in every code path.


### PR DESCRIPTION
This patch moves around the calls to `writePersistBuildConfig` to ensure that it is only called once on every code path.

No test, as it's rather difficult to test this without instrumenting the Cabal library itself (would have to use e.g. `strace`, which isn't portable).

Fixes #11619

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] No tests have been added; I couldn't think of how to test this without using `strace`.
