### PR TITLE
Reconfigure Cabal mismatch: fallback to external

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -666,17 +666,27 @@ buildInplaceUnpackedPackage
         case buildStatus of
           BuildStatusConfigure _ -> action
           _ -> do
-            lbi_wo_programs <- Cabal.getPersistBuildConfig (Just srcdir) builddir
-            -- Restore info about unconfigured programs, since it is not serialized
-            -- TODO: copied from Distribution.Simple.getBuildConfig.
-            let lbi =
-                  lbi_wo_programs
-                    { Cabal.withPrograms =
-                        restoreProgramDb
-                          builtinPrograms
-                          (Cabal.withPrograms lbi_wo_programs)
-                    }
-            return $ InLibraryLBI lbi
+            -- We are skipping reconfiguration, so we recover the
+            -- 'LocalBuildInfo' persisted by the previous 'configure'.
+            mbOldLBI <- Cabal.tryGetPersistBuildConfig (Just srcdir) builddir
+            case mbOldLBI of
+              -- #11942: if the previous LocalBuildInfo was written by an
+              -- external Setup.hs with an incompatible Cabal library version,
+              -- then we must continue to use the external setup method.
+              Left Cabal.ConfigStateFileBadVersion{} -> return NotInLibraryNoLBI
+              -- Other errors reflect genuine problems: re-throw them.
+              Left err -> throwIO err
+              Right lbi_wo_programs -> do
+                -- Restore info about unconfigured programs, since it is not serialized
+                -- TODO: copied from Distribution.Simple.getBuildConfig.
+                let lbi =
+                      lbi_wo_programs
+                        { Cabal.withPrograms =
+                            restoreProgramDb
+                              builtinPrograms
+                              (Cabal.withPrograms lbi_wo_programs)
+                        }
+                return $ InLibraryLBI lbi
 
       whenRebuild, whenReRegister :: IO () -> IO ()
       whenRebuild action

--- a/cabal-testsuite/PackageTests/T11942/Setup.hs
+++ b/cabal-testsuite/PackageTests/T11942/Setup.hs
@@ -1,0 +1,3 @@
+module Main where
+  import Distribution.Simple
+  main = defaultMain

--- a/cabal-testsuite/PackageTests/T11942/T11942.cabal
+++ b/cabal-testsuite/PackageTests/T11942/T11942.cabal
@@ -1,0 +1,10 @@
+cabal-version: 2.2
+name: T11942
+version: 1
+build-type: Custom
+
+custom-setup
+  setup-depends: base, Cabal
+
+library
+  build-depends: base

--- a/cabal-testsuite/PackageTests/T11942/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/T11942/cabal.test.hs
@@ -1,0 +1,17 @@
+import Test.Cabal.Prelude
+
+-- Setup.hs recompilation test for ticket #11942.
+-- Before fixing, this test erroneously failed with an error of the form:
+--
+--  Saved package config file is outdated:
+--    • the Cabal version changed from Cabal-3.16.0.0 to Cabal-3.17.0.0
+
+main = cabalTest $ recordMode DoNotRecord $ do
+  env <- getTestEnv
+
+  -- Do a first build...
+  cabal "v2-build" [ ]
+
+  -- ... then modify Setup.hs and rebuild
+  liftIO $ appendFile (testCurrentDir env </> "Setup.hs") "  -- some comment"
+  cabal "v2-build" [ ]

--- a/changelog.d/T11942.md
+++ b/changelog.d/T11942.md
@@ -1,0 +1,12 @@
+---
+synopsis: Don't use in-library path with mismatched Cabal library version when reconfiguring
+packages: [cabal-install]
+prs: 11950
+issues: 11942
+---
+
+`cabal-install` now correctly falls back to the external Setup method when
+reconfiguring a package which was previously configured with a different Cabal
+library version than `cabal-install` was built against (e.g. a package with
+`build-type: Custom` build whose `Setup` was built against an older `Cabal`
+library version).


### PR DESCRIPTION
When we skip reconfiguring because a package was previously configured, but the Cabal library version stored in the setup-config file doesn't match the Cabal library version that cabal-install was linked against, we now fall back to using the external Setup method instead of proceeding with the in-library method (which would fail due to Cabal library version mismatch).

Fixes #11942

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.

