### PR TITLE
Backport "Preflight 3.18 (#11936)"

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ghc: ["9.2.8", "9.4.8", "9.6.7", "9.8.4", "9.10.2", "9.12.2"]
+        ghc: ["9.4.8", "9.6.7", "9.8.4", "9.10.2", "9.12.2"]
         include:
           - os: macos-latest
-            ghc: "9.2.8"
+            ghc: "9.12.2"
     name: Bootstrap ${{ matrix.os }} ghc-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -556,6 +556,16 @@ data KnownExtension
   | -- | Allow use of or-pattern syntax, condensing multiple patterns
     -- into a single one.
     OrPatterns
+  | -- | Along with 'ImplicitStagePersistence', this gives fine-grained control
+    -- over which modules are needed at each stage of execution.
+    ExplicitLevelImports
+  | -- | Allow identifiers to be used at different levels than where they’re
+    -- defined, using path-based persistence.
+    ImplicitStagePersistence
+  | -- | Enable qualified string literals.
+    QualifiedStrings
+  | -- | Enable modifier syntax.
+    Modifiers
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Data)
 
 instance Binary KnownExtension

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,8 +29,8 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
-    0xc039c6741dead5203ad2b33bd3bf4dc8
+    0xda91a6027a4530c44729a634a7541e69
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0xea86b170fa32ac289cbd1fb6174b5cbf
+    0xe65b09ae90bca3cf826253e393c6926d

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -149,6 +149,9 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
         makeFilter :: String -> String -> Option' (First' ([String] -> [String]))
         makeFilter flag arg = Option' $ First' . filterRest <$> stripPrefix flag arg
           where
+            -- Drop the next argument, whether it comes after a `=` or
+            -- is stand-alone.
+            filterRest :: String -> [String] -> [String]
             filterRest leftOver = case dropEq leftOver of
               [] -> drop 1
               _ -> id
@@ -162,15 +165,24 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
           Just f -> go (f args)
           Nothing -> arg : go args
 
+    -- Options that take parameters and do not modify the generated artifacts
+    -- are filtered out.
     argumentFilters :: [String] -> [String]
     argumentFilters =
       flagArgumentFilter
-        ["-ghci-script", "-H", "-interactive-print"]
+        [ "-ghci-script"
+        , "-H"
+        , "-interactive-print"
+        , "-fghci-browser-assets-dir"
+        ]
 
     -- \| Remove RTS arguments from a list.
     filterRtsArgs :: [String] -> [String]
     filterRtsArgs = snd . splitRTSArgs
 
+    -- Simple options (i.e. that do not take parameters, or just
+    -- take int parameters) which do *not* change generated artifacts
+    -- are filtered out.
     simpleFilters :: String -> Bool
     simpleFilters =
       not
@@ -181,7 +193,8 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
           , Any . isPrefixOf "-dsuppress-"
           , Any . isPrefixOf "-dno-suppress-"
           , flagIn $ invertibleFlagSet "-" ["ignore-dot-ghci"]
-          , flagIn . invertibleFlagSet "-f" . mconcat $
+          , -- -f-something -f-no-something options.
+            flagIn . invertibleFlagSet "-f" . mconcat $
               [
                 [ "reverse-errors"
                 , "warn-unused-binds"

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -376,7 +376,7 @@ test-suite unit-tests
       , tasty-expected-failure
       , tasty-hunit >= 0.10
       , tree-diff
-      , QuickCheck >= 2.14.3 && <2.18
+      , QuickCheck >= 2.14.3 && <2.19
 
 -- Tests to run with a limited stack and heap size
 -- The test suite name must be keep short cause a longer one
@@ -424,7 +424,7 @@ test-suite integration-tests2
     , directory
     , filepath
     , process
-    , tasty >= 1.5 && <1.6
+    , tasty >= 1.5.4 && <1.6
     , tasty-hunit >= 0.10
     , tasty-expected-failure
     , silently
@@ -465,5 +465,5 @@ test-suite long-tests
     , tasty-expected-failure
     , tasty-hunit >= 0.10
     , tasty-quickcheck <0.12
-    , QuickCheck >= 2.14 && <2.18
+    , QuickCheck >= 2.14 && <2.19
     , pretty-show >= 1.6.15

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -119,7 +119,7 @@ main = do
   defaultMainWithIngredients
     (defaultIngredients ++ [includingOptions projectConfigOptionDescriptions])
     ( localOption (NumThreads 1) $ withProjectConfig $ \config ->
-        sequentialTestGroup
+        dependentTestGroup
           "Integration tests (internal)"
           AllFinish
           (tests config)
@@ -149,12 +149,16 @@ tests config =
   -- TODO: tests for:
   -- \* normal success
   -- \* dry-run tests with changes
-  [ sequentialTestGroup "Discovery and planning" AllFinish $
+  [ dependentTestGroup
+      "Discovery and planning"
+      AllFinish
       [ testCase "no package" (testExceptionInFindingPackage config)
       , testCase "no package2" (testExceptionInFindingPackage2 config)
       , testCase "proj conf1" (testExceptionInProjectConfig config)
       ]
-  , sequentialTestGroup "Target selectors" AllFinish $
+  , dependentTestGroup
+      "Target selectors"
+      AllFinish
       [ testCaseSteps "valid" testTargetSelectors
       , testCase "bad syntax" testTargetSelectorBadSyntax
       , testCaseSteps "ambiguous syntax" testTargetSelectorAmbiguous
@@ -171,7 +175,9 @@ tests config =
       , testCaseSteps "problems (bench)" (testTargetProblemsBench config)
       , testCaseSteps "problems (haddock)" (testTargetProblemsHaddock config)
       ]
-  , sequentialTestGroup "Exceptions during building (local inplace)" AllFinish $
+  , dependentTestGroup
+      "Exceptions during building (local inplace)"
+      AllFinish
       [ testCase "configure" (testExceptionInConfigureStep config)
       , testCase "build" (testExceptionInBuildStep config)
       --    , testCase "register"   testExceptionInRegisterStep
@@ -180,28 +186,29 @@ tests config =
     -- TODO: need to check we can build sub-libs, foreign libs and exes
     -- components for non-local packages / packages in the store.
 
-    sequentialTestGroup "Successful builds" AllFinish $
+    dependentTestGroup "Successful builds" AllFinish $
       [ testCaseSteps "Setup script styles" (testSetupScriptStyles config)
       , testCase "keep-going" (testBuildKeepGoing config)
       ]
-        ++ if isMingw32
-          then -- disabled because https://github.com/haskell/cabal/issues/6272
-            []
-          else
-            [ testCase "local tarball" (testBuildLocalTarball config)
-            ]
-  , sequentialTestGroup "Regression tests" AllFinish $
+        ++
+        -- disabled because https://github.com/haskell/cabal/issues/6272
+        [testCase "local tarball" (testBuildLocalTarball config) | isMingw32]
+  , dependentTestGroup
+      "Regression tests"
+      AllFinish
       [ testCase "issue #3324" (testRegressionIssue3324 config)
       , testCase "program options scope all" (testProgramOptionsAll config)
       , testCase "program options scope local" (testProgramOptionsLocal config)
       , testCase "program options scope specific" (testProgramOptionsSpecific config)
       ]
-  , sequentialTestGroup "Flag tests" AllFinish $
+  , dependentTestGroup
+      "Flag tests"
+      AllFinish
       [ testCase "Test Nix Flag" testNixFlags
       , testCase "Test Config options for commented options" testConfigOptionComments
       , testCase "Test Ignore Project Flag" testIgnoreProjectFlag
       ]
-  , sequentialTestGroup
+  , dependentTestGroup
       "haddock-project"
       AllFinish
       [ testCase "dependencies" (testHaddockProjectDependencies config)

--- a/changelog.d/pr-11936
+++ b/changelog.d/pr-11936
@@ -1,0 +1,8 @@
+---
+synopsis: Recognise `Modifiers` and `QualifiedStrings` extensions
+packages: [Cabal, cabal-install]
+prs: 11936
+---
+
+`Cabal` and `cabal-install` now recognise extensions from GHC 10.0
+(`Modifiers` and `QualifiedStrings`).

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -215,6 +215,7 @@ syn keyword cabalExtension contained
   \ ListTuplePuns
   \ RequiredTypeArguments
   \ MagicHash
+  \ Modifiers
   \ MonadComprehensions
   \ MonadFailDesugaring
   \ MonoLocalBinds
@@ -250,6 +251,7 @@ syn keyword cabalExtension contained
   \ PolymorphicComponents
   \ PostfixOperators
   \ QualifiedDo
+  \ QualifiedStrings
   \ QuantifiedConstraints
   \ QuasiQuotes
   \ Rank2Types
@@ -359,6 +361,7 @@ syn keyword cabalExtension contained
   \ NoLinearTypes
   \ NoRequiredTypeArguments
   \ NoMagicHash
+  \ NoModifiers
   \ NoMonadComprehensions
   \ NoMonadFailDesugaring
   \ NoMonoLocalBinds
@@ -394,6 +397,7 @@ syn keyword cabalExtension contained
   \ NoPolymorphicComponents
   \ NoPostfixOperators
   \ NoQualifiedDo
+  \ NoQualifiedStrings
   \ NoQuantifiedConstraints
   \ NoQuasiQuotes
   \ NoRank2Types


### PR DESCRIPTION
I did un-bump `cabal-version` on top of #11936, as this is a branch which will only see minor releases.

The other commits are to make test-suite green.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  ~~* [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.~~ no
* [x] The documentation has been updated, if necessary.
~~* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.~~
~~* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~