### PR TITLE
Add missing changelog for #11636

### DIFF
--- a/changelog.d/pr-11636
+++ b/changelog.d/pr-11636
@@ -1,0 +1,8 @@
+---
+synopsis: Recognise `ExplicitLevelImports` and `ImplicitStagePersistence` extensions
+packages: [Cabal, cabal-install]
+prs: 11936
+---
+
+`Cabal` and `cabal-install` now recognise extensions from GHC 9.14
+(`ImplicitStagePersistence` and `ImplicitStagePersistence`).


### PR DESCRIPTION
This adds missing changelog for #11636.
It is important to get it merged before the cut (3.18). If @ulysses4ever agrees I would skip the delay period.
This _needs_ a backport!

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* ~~[ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ no
