### PR TITLE
Remove compatibility layer for deepseq<1.4

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -33,7 +33,7 @@ library
     , binary     >= 0.8.1    && < 0.9
     , bytestring >= 0.10.4.0 && < 0.13
     , containers >= 0.5.2    && < 0.9
-    , deepseq    >= 1.3.0.1  && < 1.7
+    , deepseq    >= 1.4      && < 1.7
     , directory  >= 1.2      && < 1.4
     , filepath   >= 1.3.0.1  && < 1.6
     , mtl        >= 2.1      && < 2.4

--- a/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
+++ b/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
@@ -42,7 +42,7 @@ data CabalSpecVersion
 
 instance Binary CabalSpecVersion
 instance Structured CabalSpecVersion
-instance NFData CabalSpecVersion where rnf = genericRnf
+instance NFData CabalSpecVersion
 
 -- | Show cabal spec version, but not the way in the .cabal files
 --

--- a/Cabal-syntax/src/Distribution/Compat/Prelude.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Prelude.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeOperators #-}
 
 -- | This module does two things:
 --
@@ -25,7 +24,6 @@ module Distribution.Compat.Prelude
   , Data
   , Generic
   , NFData (..)
-  , genericRnf
   , Binary (..)
   , Structured
   , Alternative (..)
@@ -235,7 +233,7 @@ import Data.Void (Void, absurd, vacuous)
 import Data.Word (Word, Word16, Word32, Word64, Word8)
 import Distribution.Compat.Binary (Binary (..))
 import Distribution.Compat.Semigroup (gmappend, gmempty)
-import GHC.Generics (Generic (..), K1 (unK1), M1 (unM1), U1 (U1), V1, (:*:) ((:*:)), (:+:) (L1, R1))
+import GHC.Generics (Generic)
 import System.Exit (ExitCode (..), exitFailure, exitSuccess, exitWith)
 import Text.Read (readMaybe)
 
@@ -250,47 +248,6 @@ import qualified Debug.Trace
 -- | New name for 'Text.PrettyPrint.<>'
 (<<>>) :: Disp.Doc -> Disp.Doc -> Disp.Doc
 (<<>>) = (Disp.<>)
-
--- | "GHC.Generics"-based 'rnf' implementation
---
--- This is needed in order to support @deepseq < 1.4@ which didn't
--- have a 'Generic'-based default 'rnf' implementation yet.
---
--- In order to define instances, use e.g.
---
--- > instance NFData MyType where rnf = genericRnf
---
--- The implementation has been taken from @deepseq-1.4.2@'s default
--- 'rnf' implementation.
-genericRnf :: (Generic a, GNFData (Rep a)) => a -> ()
-genericRnf = grnf . from
-
--- | Hidden internal type-class
-class GNFData f where
-  grnf :: f a -> ()
-
-instance GNFData V1 where
-  grnf = error "Control.DeepSeq.rnf: uninhabited type"
-
-instance GNFData U1 where
-  grnf U1 = ()
-
-instance NFData a => GNFData (K1 i a) where
-  grnf = rnf . unK1
-  {-# INLINEABLE grnf #-}
-
-instance GNFData a => GNFData (M1 i c a) where
-  grnf = grnf . unM1
-  {-# INLINEABLE grnf #-}
-
-instance (GNFData a, GNFData b) => GNFData (a :*: b) where
-  grnf (x :*: y) = grnf x `seq` grnf y
-  {-# INLINEABLE grnf #-}
-
-instance (GNFData a, GNFData b) => GNFData (a :+: b) where
-  grnf (L1 x) = grnf x
-  grnf (R1 x) = grnf x
-  {-# INLINEABLE grnf #-}
 
 -- TODO: if we want foldr1/foldl1 to work on more than NonEmpty, we
 -- can define a local typeclass 'Foldable1', e.g.

--- a/Cabal-syntax/src/Distribution/Compiler.hs
+++ b/Cabal-syntax/src/Distribution/Compiler.hs
@@ -83,7 +83,7 @@ data CompilerFlavor
 
 instance Binary CompilerFlavor
 instance Structured CompilerFlavor
-instance NFData CompilerFlavor where rnf = genericRnf
+instance NFData CompilerFlavor
 
 knownCompilerFlavors :: [CompilerFlavor]
 knownCompilerFlavors =
@@ -177,7 +177,7 @@ data CompilerId = CompilerId CompilerFlavor Version
 
 instance Binary CompilerId
 instance Structured CompilerId
-instance NFData CompilerId where rnf = genericRnf
+instance NFData CompilerId
 
 instance Pretty CompilerId where
   pretty (CompilerId f v)

--- a/Cabal-syntax/src/Distribution/License.hs
+++ b/Cabal-syntax/src/Distribution/License.hs
@@ -115,7 +115,7 @@ data License
 
 instance Binary License
 instance Structured License
-instance NFData License where rnf = genericRnf
+instance NFData License
 
 -- | The list of all currently recognised licenses.
 knownLicenses :: [License]

--- a/Cabal-syntax/src/Distribution/Parsec/Error.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Error.hs
@@ -23,7 +23,7 @@ data PErrorWithSource src = PErrorWithSource {perrorSource :: !(PSource src), pe
   deriving (Show, Generic, Functor)
 
 instance Binary PError
-instance NFData PError where rnf = genericRnf
+instance NFData PError
 
 showPError :: FilePath -> PError -> String
 showPError fpath (PError pos msg) =

--- a/Cabal-syntax/src/Distribution/Parsec/Position.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Position.hs
@@ -21,7 +21,7 @@ data Position
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary Position
-instance NFData Position where rnf = genericRnf
+instance NFData Position
 
 -- | Shift position by n columns to the right.
 incPos :: Int -> Position -> Position

--- a/Cabal-syntax/src/Distribution/Parsec/Source.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Source.hs
@@ -42,4 +42,4 @@ instance Eq src => Eq (PSource src) where
   _ == _ = False
 
 instance Binary src => Binary (PSource src)
-instance NFData src => NFData (PSource src) where rnf = genericRnf
+instance NFData src => NFData (PSource src)

--- a/Cabal-syntax/src/Distribution/Parsec/Warning.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Warning.hs
@@ -70,7 +70,7 @@ data PWarnType
   deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 instance Binary PWarnType
-instance NFData PWarnType where rnf = genericRnf
+instance NFData PWarnType
 
 -- | Parser warning.
 data PWarning = PWarning {pwarningType :: !PWarnType, pwarningPosition :: !Position, pwarningMessage :: !String}
@@ -80,7 +80,7 @@ data PWarningWithSource src = PWarningWithSource {pwarningSource :: !(PSource sr
   deriving (Eq, Ord, Show, Generic, Functor)
 
 instance Binary PWarning
-instance NFData PWarning where rnf = genericRnf
+instance NFData PWarning
 
 showPWarning :: FilePath -> PWarning -> String
 showPWarning fpath (PWarning _ pos msg) =

--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -111,7 +111,7 @@ data OS
 
 instance Binary OS
 instance Structured OS
-instance NFData OS where rnf = genericRnf
+instance NFData OS
 
 knownOSs :: [OS]
 knownOSs =
@@ -214,7 +214,7 @@ data Arch
 
 instance Binary Arch
 instance Structured Arch
-instance NFData Arch where rnf = genericRnf
+instance NFData Arch
 
 knownArches :: [Arch]
 knownArches =
@@ -285,7 +285,7 @@ data Platform = Platform Arch OS
 
 instance Binary Platform
 instance Structured Platform
-instance NFData Platform where rnf = genericRnf
+instance NFData Platform
 
 instance Pretty Platform where
   pretty (Platform arch os) = pretty arch <<>> Disp.char '-' <<>> pretty os

--- a/Cabal-syntax/src/Distribution/Types/AbiDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/AbiDependency.hs
@@ -41,4 +41,4 @@ instance Parsec AbiDependency where
 
 instance Binary AbiDependency
 instance Structured AbiDependency
-instance NFData AbiDependency where rnf = genericRnf
+instance NFData AbiDependency

--- a/Cabal-syntax/src/Distribution/Types/AbiHash.hs
+++ b/Cabal-syntax/src/Distribution/Types/AbiHash.hs
@@ -52,7 +52,7 @@ instance IsString AbiHash where
 
 instance Binary AbiHash
 instance Structured AbiHash
-instance NFData AbiHash where rnf = genericRnf
+instance NFData AbiHash
 
 instance Pretty AbiHash where
   pretty = text . unAbiHash

--- a/Cabal-syntax/src/Distribution/Types/Benchmark.hs
+++ b/Cabal-syntax/src/Distribution/Types/Benchmark.hs
@@ -31,7 +31,7 @@ data Benchmark = Benchmark
 
 instance Binary Benchmark
 instance Structured Benchmark
-instance NFData Benchmark where rnf = genericRnf
+instance NFData Benchmark
 
 instance L.HasBuildInfo Benchmark where
   buildInfo f (Benchmark x1 x2 x3) = fmap (\y1 -> Benchmark x1 x2 y1) (f x3)

--- a/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
@@ -31,7 +31,7 @@ data BenchmarkInterface
 
 instance Binary BenchmarkInterface
 instance Structured BenchmarkInterface
-instance NFData BenchmarkInterface where rnf = genericRnf
+instance NFData BenchmarkInterface
 
 instance Monoid BenchmarkInterface where
   mempty = BenchmarkUnsupported (BenchmarkTypeUnknown mempty nullVersion)

--- a/Cabal-syntax/src/Distribution/Types/BenchmarkType.hs
+++ b/Cabal-syntax/src/Distribution/Types/BenchmarkType.hs
@@ -26,7 +26,7 @@ data BenchmarkType
 
 instance Binary BenchmarkType
 instance Structured BenchmarkType
-instance NFData BenchmarkType where rnf = genericRnf
+instance NFData BenchmarkType
 
 knownBenchmarkTypes :: [BenchmarkType]
 knownBenchmarkTypes = [benchmarkTypeExe]

--- a/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
@@ -151,7 +151,7 @@ data BuildInfo = BuildInfo
 
 instance Binary BuildInfo
 instance Structured BuildInfo
-instance NFData BuildInfo where rnf = genericRnf
+instance NFData BuildInfo
 
 instance Monoid BuildInfo where
   mempty =

--- a/Cabal-syntax/src/Distribution/Types/BuildType.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildType.hs
@@ -35,7 +35,7 @@ data BuildType
 
 instance Binary BuildType
 instance Structured BuildType
-instance NFData BuildType where rnf = genericRnf
+instance NFData BuildType
 
 knownBuildTypes :: [BuildType]
 knownBuildTypes = [Simple, Configure, Make, Custom, Hooks]

--- a/Cabal-syntax/src/Distribution/Types/CondTree.hs
+++ b/Cabal-syntax/src/Distribution/Types/CondTree.hs
@@ -61,7 +61,7 @@ data CondTree v a = CondNode
 
 instance (Binary v, Binary a) => Binary (CondTree v a)
 instance (Structured v, Structured a) => Structured (CondTree v a)
-instance (NFData v, NFData a) => NFData (CondTree v a) where rnf = genericRnf
+instance (NFData v, NFData a) => NFData (CondTree v a)
 
 instance Semigroup a => Semigroup (CondTree v a) where
   (CondNode a bs) <> (CondNode a' bs') = CondNode (a <> a') (bs <> bs')
@@ -82,7 +82,7 @@ data CondBranch v a = CondBranch
 
 instance (Binary v, Binary a) => Binary (CondBranch v a)
 instance (Structured v, Structured a) => Structured (CondBranch v a)
-instance (NFData v, NFData a) => NFData (CondBranch v a) where rnf = genericRnf
+instance (NFData v, NFData a) => NFData (CondBranch v a)
 
 condIfThen :: Condition v -> CondTree v a -> CondBranch v a
 condIfThen c t = CondBranch c t Nothing

--- a/Cabal-syntax/src/Distribution/Types/Condition.hs
+++ b/Cabal-syntax/src/Distribution/Types/Condition.hs
@@ -100,7 +100,7 @@ instance MonadPlus Condition where
 
 instance Binary c => Binary (Condition c)
 instance Structured c => Structured (Condition c)
-instance NFData c => NFData (Condition c) where rnf = genericRnf
+instance NFData c => NFData (Condition c)
 
 -- | Simplify the condition and return its free variables.
 simplifyCondition

--- a/Cabal-syntax/src/Distribution/Types/ConfVar.hs
+++ b/Cabal-syntax/src/Distribution/Types/ConfVar.hs
@@ -24,4 +24,4 @@ data ConfVar
 instance Binary ConfVar
 instance Structured ConfVar
 
-instance NFData ConfVar where rnf = genericRnf
+instance NFData ConfVar

--- a/Cabal-syntax/src/Distribution/Types/Dependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/Dependency.hs
@@ -70,7 +70,7 @@ mkDependency pn vr lb = Dependency pn vr (NES.map conv lb)
 
 instance Binary Dependency
 instance Structured Dependency
-instance NFData Dependency where rnf = genericRnf
+instance NFData Dependency
 
 -- |
 --

--- a/Cabal-syntax/src/Distribution/Types/ExeDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/ExeDependency.hs
@@ -29,7 +29,7 @@ data ExeDependency
 
 instance Binary ExeDependency
 instance Structured ExeDependency
-instance NFData ExeDependency where rnf = genericRnf
+instance NFData ExeDependency
 
 instance Pretty ExeDependency where
   pretty (ExeDependency name exe ver) =

--- a/Cabal-syntax/src/Distribution/Types/Executable.hs
+++ b/Cabal-syntax/src/Distribution/Types/Executable.hs
@@ -33,7 +33,7 @@ instance L.HasBuildInfo Executable where
 
 instance Binary Executable
 instance Structured Executable
-instance NFData Executable where rnf = genericRnf
+instance NFData Executable
 
 instance Monoid Executable where
   mempty =

--- a/Cabal-syntax/src/Distribution/Types/ExecutableScope.hs
+++ b/Cabal-syntax/src/Distribution/Types/ExecutableScope.hs
@@ -32,7 +32,7 @@ instance Parsec ExecutableScope where
 
 instance Binary ExecutableScope
 instance Structured ExecutableScope
-instance NFData ExecutableScope where rnf = genericRnf
+instance NFData ExecutableScope
 
 -- | 'Any' like semigroup, where 'ExecutablePrivate' is 'Any True'
 instance Semigroup ExecutableScope where

--- a/Cabal-syntax/src/Distribution/Types/ExposedModule.hs
+++ b/Cabal-syntax/src/Distribution/Types/ExposedModule.hs
@@ -42,4 +42,4 @@ instance Parsec ExposedModule where
 
 instance Binary ExposedModule
 instance Structured ExposedModule
-instance NFData ExposedModule where rnf = genericRnf
+instance NFData ExposedModule

--- a/Cabal-syntax/src/Distribution/Types/Flag.hs
+++ b/Cabal-syntax/src/Distribution/Types/Flag.hs
@@ -61,7 +61,7 @@ data PackageFlag = MkPackageFlag
 
 instance Binary PackageFlag
 instance Structured PackageFlag
-instance NFData PackageFlag where rnf = genericRnf
+instance NFData PackageFlag
 
 -- | A 'PackageFlag' initialized with default parameters.
 emptyFlag :: FlagName -> PackageFlag

--- a/Cabal-syntax/src/Distribution/Types/ForeignLib.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLib.hs
@@ -85,7 +85,7 @@ instance Read LibVersionInfo where
 
 instance Binary LibVersionInfo
 instance Structured LibVersionInfo
-instance NFData LibVersionInfo where rnf = genericRnf
+instance NFData LibVersionInfo
 
 instance Pretty LibVersionInfo where
   pretty (LibVersionInfo c r a) =
@@ -138,7 +138,7 @@ instance L.HasBuildInfo ForeignLib where
 
 instance Binary ForeignLib
 instance Structured ForeignLib
-instance NFData ForeignLib where rnf = genericRnf
+instance NFData ForeignLib
 
 instance Semigroup ForeignLib where
   a <> b =

--- a/Cabal-syntax/src/Distribution/Types/ForeignLibOption.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLibOption.hs
@@ -36,4 +36,4 @@ instance Parsec ForeignLibOption where
 
 instance Binary ForeignLibOption
 instance Structured ForeignLibOption
-instance NFData ForeignLibOption where rnf = genericRnf
+instance NFData ForeignLibOption

--- a/Cabal-syntax/src/Distribution/Types/ForeignLibType.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLibType.hs
@@ -44,7 +44,7 @@ instance Parsec ForeignLibType where
 
 instance Binary ForeignLibType
 instance Structured ForeignLibType
-instance NFData ForeignLibType where rnf = genericRnf
+instance NFData ForeignLibType
 
 instance Semigroup ForeignLibType where
   ForeignLibTypeUnknown <> b = b

--- a/Cabal-syntax/src/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal-syntax/src/Distribution/Types/GenericPackageDescription.hs
@@ -78,7 +78,7 @@ instance Package GenericPackageDescription where
 
 instance Binary GenericPackageDescription
 instance Structured GenericPackageDescription
-instance NFData GenericPackageDescription where rnf = genericRnf
+instance NFData GenericPackageDescription
 
 emptyGenericPackageDescription :: GenericPackageDescription
 emptyGenericPackageDescription = GenericPackageDescription emptyPackageDescription Nothing [] Nothing [] [] [] [] []

--- a/Cabal-syntax/src/Distribution/Types/IncludeRenaming.hs
+++ b/Cabal-syntax/src/Distribution/Types/IncludeRenaming.hs
@@ -31,7 +31,7 @@ data IncludeRenaming = IncludeRenaming
 instance Binary IncludeRenaming
 instance Structured IncludeRenaming
 
-instance NFData IncludeRenaming where rnf = genericRnf
+instance NFData IncludeRenaming
 
 -- | The 'defaultIncludeRenaming' applied when you only @build-depends@
 -- on a package.

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -100,7 +100,7 @@ data InstalledPackageInfo = InstalledPackageInfo
 instance Binary InstalledPackageInfo
 instance Structured InstalledPackageInfo
 
-instance NFData InstalledPackageInfo where rnf = genericRnf
+instance NFData InstalledPackageInfo
 
 instance Package.HasMungedPackageId InstalledPackageInfo where
   mungedId = mungedPackageId

--- a/Cabal-syntax/src/Distribution/Types/LegacyExeDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/LegacyExeDependency.hs
@@ -30,7 +30,7 @@ data LegacyExeDependency
 
 instance Binary LegacyExeDependency
 instance Structured LegacyExeDependency
-instance NFData LegacyExeDependency where rnf = genericRnf
+instance NFData LegacyExeDependency
 
 instance Pretty LegacyExeDependency where
   pretty (LegacyExeDependency name ver) =

--- a/Cabal-syntax/src/Distribution/Types/Library.hs
+++ b/Cabal-syntax/src/Distribution/Types/Library.hs
@@ -38,7 +38,7 @@ instance L.HasBuildInfo Library where
 
 instance Binary Library
 instance Structured Library
-instance NFData Library where rnf = genericRnf
+instance NFData Library
 
 emptyLibrary :: Library
 emptyLibrary =

--- a/Cabal-syntax/src/Distribution/Types/LibraryName.hs
+++ b/Cabal-syntax/src/Distribution/Types/LibraryName.hs
@@ -33,7 +33,7 @@ data LibraryName
 
 instance Binary LibraryName
 instance Structured LibraryName
-instance NFData LibraryName where rnf = genericRnf
+instance NFData LibraryName
 
 -- | Pretty print 'LibraryName' in build-target-ish syntax.
 --

--- a/Cabal-syntax/src/Distribution/Types/LibraryVisibility.hs
+++ b/Cabal-syntax/src/Distribution/Types/LibraryVisibility.hs
@@ -39,7 +39,7 @@ instance Parsec LibraryVisibility where
 
 instance Binary LibraryVisibility
 instance Structured LibraryVisibility
-instance NFData LibraryVisibility where rnf = genericRnf
+instance NFData LibraryVisibility
 
 instance Semigroup LibraryVisibility where
   LibraryVisibilityPrivate <> LibraryVisibilityPrivate = LibraryVisibilityPrivate

--- a/Cabal-syntax/src/Distribution/Types/Mixin.hs
+++ b/Cabal-syntax/src/Distribution/Types/Mixin.hs
@@ -36,7 +36,7 @@ data Mixin = Mixin
 instance Binary Mixin
 instance Structured Mixin
 
-instance NFData Mixin where rnf = genericRnf
+instance NFData Mixin
 
 instance Pretty Mixin where
   pretty (Mixin pn LMainLibName incl) = pretty pn <+> pretty incl

--- a/Cabal-syntax/src/Distribution/Types/ModuleReexport.hs
+++ b/Cabal-syntax/src/Distribution/Types/ModuleReexport.hs
@@ -28,7 +28,7 @@ data ModuleReexport = ModuleReexport
 
 instance Binary ModuleReexport
 instance Structured ModuleReexport
-instance NFData ModuleReexport where rnf = genericRnf
+instance NFData ModuleReexport
 
 instance Pretty ModuleReexport where
   pretty (ModuleReexport mpkgname origname newname) =

--- a/Cabal-syntax/src/Distribution/Types/ModuleRenaming.hs
+++ b/Cabal-syntax/src/Distribution/Types/ModuleRenaming.hs
@@ -68,7 +68,7 @@ isDefaultRenaming _ = False
 instance Binary ModuleRenaming
 instance Structured ModuleRenaming
 
-instance NFData ModuleRenaming where rnf = genericRnf
+instance NFData ModuleRenaming
 
 -- NB: parentheses are mandatory, because later we may extend this syntax
 -- to allow "hiding (A, B)" or other modifier words.

--- a/Cabal-syntax/src/Distribution/Types/MungedPackageName.hs
+++ b/Cabal-syntax/src/Distribution/Types/MungedPackageName.hs
@@ -35,7 +35,7 @@ data MungedPackageName = MungedPackageName !PackageName !LibraryName
 
 instance Binary MungedPackageName
 instance Structured MungedPackageName
-instance NFData MungedPackageName where rnf = genericRnf
+instance NFData MungedPackageName
 
 -- | Computes the package name for a library.  If this is the public
 -- library, it will just be the original package name; otherwise,

--- a/Cabal-syntax/src/Distribution/Types/PackageDescription.hs
+++ b/Cabal-syntax/src/Distribution/Types/PackageDescription.hs
@@ -156,7 +156,7 @@ data PackageDescription = PackageDescription
 instance Binary PackageDescription
 instance Structured PackageDescription
 
-instance NFData PackageDescription where rnf = genericRnf
+instance NFData PackageDescription
 
 instance Package PackageDescription where
   packageId = package

--- a/Cabal-syntax/src/Distribution/Types/PackageVersionConstraint.hs
+++ b/Cabal-syntax/src/Distribution/Types/PackageVersionConstraint.hs
@@ -30,7 +30,7 @@ data PackageVersionConstraint = PackageVersionConstraint PackageName VersionRang
 
 instance Binary PackageVersionConstraint
 instance Structured PackageVersionConstraint
-instance NFData PackageVersionConstraint where rnf = genericRnf
+instance NFData PackageVersionConstraint
 
 instance Pretty PackageVersionConstraint where
   -- Cannot do: PackageVersionConstraint have to be parseable

--- a/Cabal-syntax/src/Distribution/Types/PkgconfigDependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/PkgconfigDependency.hs
@@ -27,7 +27,7 @@ data PkgconfigDependency
 
 instance Binary PkgconfigDependency
 instance Structured PkgconfigDependency
-instance NFData PkgconfigDependency where rnf = genericRnf
+instance NFData PkgconfigDependency
 
 instance Pretty PkgconfigDependency where
   pretty (PkgconfigDependency name PcAnyVersion) = pretty name

--- a/Cabal-syntax/src/Distribution/Types/PkgconfigVersion.hs
+++ b/Cabal-syntax/src/Distribution/Types/PkgconfigVersion.hs
@@ -36,7 +36,7 @@ instance Ord PkgconfigVersion where
 
 instance Binary PkgconfigVersion
 instance Structured PkgconfigVersion
-instance NFData PkgconfigVersion where rnf = genericRnf
+instance NFData PkgconfigVersion
 
 instance Pretty PkgconfigVersion where
   pretty (PkgconfigVersion bs) = PP.text (BS8.unpack bs)

--- a/Cabal-syntax/src/Distribution/Types/PkgconfigVersionRange.hs
+++ b/Cabal-syntax/src/Distribution/Types/PkgconfigVersionRange.hs
@@ -41,7 +41,7 @@ data PkgconfigVersionRange
 
 instance Binary PkgconfigVersionRange
 instance Structured PkgconfigVersionRange
-instance NFData PkgconfigVersionRange where rnf = genericRnf
+instance NFData PkgconfigVersionRange
 
 instance Pretty PkgconfigVersionRange where
   pretty = pp 0

--- a/Cabal-syntax/src/Distribution/Types/SetupBuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/SetupBuildInfo.hs
@@ -29,7 +29,7 @@ data SetupBuildInfo = SetupBuildInfo
 
 instance Binary SetupBuildInfo
 instance Structured SetupBuildInfo
-instance NFData SetupBuildInfo where rnf = genericRnf
+instance NFData SetupBuildInfo
 
 instance Monoid SetupBuildInfo where
   mempty = SetupBuildInfo [] False

--- a/Cabal-syntax/src/Distribution/Types/SourceRepo.hs
+++ b/Cabal-syntax/src/Distribution/Types/SourceRepo.hs
@@ -93,7 +93,7 @@ emptySourceRepo kind =
 
 instance Binary SourceRepo
 instance Structured SourceRepo
-instance NFData SourceRepo where rnf = genericRnf
+instance NFData SourceRepo
 
 -- | What this repo info is for, what it represents.
 data RepoKind
@@ -110,7 +110,7 @@ data RepoKind
 
 instance Binary RepoKind
 instance Structured RepoKind
-instance NFData RepoKind where rnf = genericRnf
+instance NFData RepoKind
 
 -- | An enumeration of common source control systems. The fields used in the
 -- 'SourceRepo' depend on the type of repo. The tools and methods used to
@@ -130,7 +130,7 @@ data KnownRepoType
 
 instance Binary KnownRepoType
 instance Structured KnownRepoType
-instance NFData KnownRepoType where rnf = genericRnf
+instance NFData KnownRepoType
 
 instance Parsec KnownRepoType where
   parsec = do
@@ -150,7 +150,7 @@ data RepoType
 
 instance Binary RepoType
 instance Structured RepoType
-instance NFData RepoType where rnf = genericRnf
+instance NFData RepoType
 
 knownRepoTypes :: [KnownRepoType]
 knownRepoTypes = [minBound .. maxBound]

--- a/Cabal-syntax/src/Distribution/Types/TestSuite.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestSuite.hs
@@ -36,7 +36,7 @@ instance L.HasBuildInfo TestSuite where
 instance Binary TestSuite
 instance Structured TestSuite
 
-instance NFData TestSuite where rnf = genericRnf
+instance NFData TestSuite
 
 instance Monoid TestSuite where
   mempty =

--- a/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
@@ -35,7 +35,7 @@ data TestSuiteInterface
 instance Binary TestSuiteInterface
 instance Structured TestSuiteInterface
 
-instance NFData TestSuiteInterface where rnf = genericRnf
+instance NFData TestSuiteInterface
 
 instance Monoid TestSuiteInterface where
   mempty = TestSuiteUnsupported (TestTypeUnknown mempty nullVersion)

--- a/Cabal-syntax/src/Distribution/Types/TestType.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestType.hs
@@ -30,7 +30,7 @@ data TestType
 instance Binary TestType
 instance Structured TestType
 
-instance NFData TestType where rnf = genericRnf
+instance NFData TestType
 
 knownTestTypes :: [TestType]
 knownTestTypes =

--- a/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionRange/Internal.hs
@@ -64,7 +64,7 @@ data VersionRange
 
 instance Binary VersionRange
 instance Structured VersionRange
-instance NFData VersionRange where rnf = genericRnf
+instance NFData VersionRange
 
 -- | The version range @-any@. That is, a version range containing all
 -- versions.

--- a/Cabal-syntax/src/Distribution/Utils/Path.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Path.hs
@@ -231,7 +231,7 @@ instance Binary (SymbolicPathX allowAbsolute from to)
 instance
   (Typeable allowAbsolute, Typeable from, Typeable to)
   => Structured (SymbolicPathX allowAbsolute from to)
-instance NFData (SymbolicPathX allowAbsolute from to) where rnf = genericRnf
+instance NFData (SymbolicPathX allowAbsolute from to)
 
 -- | Extract the 'FilePath' underlying a 'SymbolicPath' or 'RelativePath',
 -- without interpreting it.

--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -64,7 +64,7 @@ data Language
 instance Binary Language
 instance Structured Language
 
-instance NFData Language where rnf = genericRnf
+instance NFData Language
 
 -- | List of known (supported) languages for GHC, oldest first.
 knownLanguages :: [Language]
@@ -120,7 +120,7 @@ data Extension
 instance Binary Extension
 instance Structured Extension
 
-instance NFData Extension where rnf = genericRnf
+instance NFData Extension
 
 -- | Known Haskell language extensions, including deprecated and undocumented
 -- ones.
@@ -571,7 +571,7 @@ data KnownExtension
 instance Binary KnownExtension
 instance Structured KnownExtension
 
-instance NFData KnownExtension where rnf = genericRnf
+instance NFData KnownExtension
 
 -- | Extensions that have been deprecated, possibly paired with another
 -- extension that replaces it.

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -44,7 +44,7 @@ library
     , base       >= 4.13     && < 5
     , bytestring >= 0.10.8   && < 0.13
     , containers >= 0.5.8.2  && < 0.9
-    , deepseq    >= 1.3.0.1  && < 1.7
+    , deepseq    >= 1.4      && < 1.7
     , directory  >= 1.2.7    && < 1.4
     , filepath   >= 1.4.2    && < 1.6
     , pretty     >= 1.1.1    && < 1.2

--- a/changelog.d/pr-11967.md
+++ b/changelog.d/pr-11967.md
@@ -1,0 +1,8 @@
+---
+synopsis: Require `deepseq-1.4.0.0` or newer
+packages: [Cabal-syntax, Cabal]
+prs: 11967
+---
+
+Drop compatibility layer for `deepseq < 1.4`, now `Cabal-syntax` and `Cabal`
+require `deepseq-1.4.0.0` (which is 11 years old) or newer.


### PR DESCRIPTION
`deepseq-1.4` is 12 years old now, there is no reason to remain compatible with even earlier releases.

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)