### PR TITLE
Run `cabal check` on CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -153,6 +153,9 @@ jobs:
           fi
           echo "FLAGS=$FLAGS" >> "$GITHUB_ENV"
 
+      - name: Run cabal check
+        run: make check
+
       - name: Validate build
         run: sh validate.sh $FLAGS -s build
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,15 @@ FORMAT_DIRS_TODO := \
 	cabal-testsuite/static \
 	solver-benchmarks
 
+.PHONY: check
+check:
+	@cd Cabal && cabal check | grep -q "No errors or warnings could be found in the package."
+	@cd cabal-install && cabal check | grep -q "No errors or warnings could be found in the package."
+	@cd Cabal-syntax && cabal check | grep -q "No errors or warnings could be found in the package."
+	@cd Cabal-hooks && cabal check | grep -q "No errors or warnings could be found in the package."
+	@cd hooks-exe && cabal check | grep -q "No errors or warnings could be found in the package."
+	@cd cabal-install-solver && cabal check | grep -q "No errors or warnings could be found in the package."
+
 .PHONY: style-todo
 style-todo: ## Configured for fourmolu, avoiding GHC parser failures.
 	@fourmolu -q $(FORMAT_DIRS_TODO) > /dev/null


### PR DESCRIPTION
This was part of the [pre-flight checklist](https://github.com/haskell/cabal/wiki/Making-a-release#c1-preflight-checks), which I would like to get rid of.

https://github.com/haskell/cabal/wiki/Making-a-release/_compare/b28070de27840372e94dec1f685b6fcc00e5a414...b91547b5d7713283754058ea20152d9e915ba043