### PR TITLE
Run `ghc-supported-extensions` on CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -262,6 +262,9 @@ jobs:
       # one possibly nightmarish final conditional. 'fail-fast' gets us
       # partway there, at least, but is still imperfect.
 
+      - name: Check that language extensions are registered for this GHC version
+        run: cabal run ghc-supported-extensions ghc
+
   validate-old-ghcs:
     name: Validate old ghcs ${{ matrix.extra-ghc }}
     # latest/latest doesn't have the old packages the old ghcs depend on

--- a/Cabal-tests/exes/GhcSupportedExtensions.hs
+++ b/Cabal-tests/exes/GhcSupportedExtensions.hs
@@ -11,7 +11,6 @@ import Distribution.Text (display, simpleParse)
 import Distribution.Verbosity (Verbosity (..), defaultVerbosityHandles, normal)
 import Language.Haskell.Extension (Extension (..), knownLanguages)
 
-import Data.List ((\\))
 import System.Environment (getArgs, getProgName)
 
 -- | Language editions as Extensions.
@@ -61,11 +60,8 @@ checkProblems implemented =
   -- Extensions that ghc knows about but that are not registered except for the known languages.
   let unregistered = [ext | ext <- implemented, not (registered ext), ext `notElem` langsAsExts]
 
-      -- check if someone has forgotten to update the `langsAsExts` exceptions list...
-      badExceptions = langsAsExts \\ implemented
-
       -- exceptions that are now registered
-      badExceptions' = filter registered langsAsExts
+      badExceptions = filter registered langsAsExts
    in catMaybes
         [ check unregistered $
             unlines
@@ -77,17 +73,9 @@ checkProblems implemented =
         , check badExceptions $
             unlines
               [ "Error in the extension exception list. The following extensions"
-              , "are listed as exceptions but are not even implemented by GHC:"
-              , "  " ++ intercalate "\n  " (map display badExceptions)
-              , "Please fix this test program by correcting the list of"
-              , "exceptions."
-              ]
-        , check badExceptions' $
-            unlines
-              [ "Error in the extension exception list. The following extensions"
               , "are listed as exceptions to registration but they are in fact"
               , "now registered in Language.Haskell.Extension:"
-              , "  " ++ intercalate "\n  " (map display badExceptions')
+              , "  " ++ intercalate "\n  " (map display badExceptions)
               , "Please fix this test program by correcting the list of"
               , "exceptions."
               ]


### PR DESCRIPTION
This was part of the [pre-flight checklist](https://github.com/haskell/cabal/wiki/Making-a-release#c1-preflight-checks), which I would like to get rid of.

https://github.com/haskell/cabal/wiki/Making-a-release/_compare/b91547b5d7713283754058ea20152d9e915ba043...2c02bf94536d0669a7742882cb46a97b5eda422c