### PR TITLE
Run `cabal outdated` on CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -188,6 +188,9 @@ jobs:
           fi
           echo "FLAGS=$FLAGS" >> "$GITHUB_ENV"
 
+      - name: Run cabal outdated
+        run: make outdated # never ever disabled this, not even temporarily, adjust the corresponding `make` target instead
+
       - name: Validate build
         run: sh validate.sh $FLAGS -s build
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,37 @@ FORMAT_DIRS_TODO := \
 	cabal-testsuite/static \
 	solver-benchmarks
 
+.PHONY: outdated
+outdated:
+	# To temporarily disable strict checks for a package, only comment out
+	# `--exit-code`, so that you still get the informational output.
+	#
+	# Example:
+	#
+	# To "disable" strict checks for the `Cabal` package, change
+	#
+	#     cd Cabal && cabal outdated --exit-code
+	#
+	# to
+	#
+	#     cd Cabal && cabal outdated # --exit-code
+	#
+	# If you temporarily disable strict checks for a package:
+	#
+	# - on `master`, then open a corresponding issue to re-enable it:
+	#
+	#   https://github.com/haskell/cabal/issues/new?labels=priority:+high+:fire:&title=re-enable+%60cabal+outdated%60+on+CI
+	#
+	# - on a release branch, then make sure that you run `make outdated`
+	#   manually before making a release
+	#
+	cd Cabal && cabal outdated --exit-code
+	cd cabal-install && cabal outdated --exit-code
+	cd Cabal-syntax && cabal outdated --exit-code
+	cd Cabal-hooks && cabal outdated --exit-code
+	cd hooks-exe && cabal outdated --exit-code
+	cd cabal-install-solver && cabal outdated --exit-code
+
 .PHONY: style-todo
 style-todo: ## Configured for fourmolu, avoiding GHC parser failures.
 	@fourmolu -q $(FORMAT_DIRS_TODO) > /dev/null


### PR DESCRIPTION
This was part of the [pre-flight checklist](https://github.com/haskell/cabal/wiki/Making-a-release#c1-preflight-checks), which I would like to get rid of.

https://github.com/haskell/cabal/wiki/Making-a-release/_compare/a04bbb077297d496d2609a5ca35619427c245fa0...1848c319688beed33254efcf612d01c737c8a78e