### PR TITLE
Add `cabal-version` advice to corresponding .cabal files

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,4 +1,14 @@
 cabal-version: 3.6
+-- ^ bundled with GHC 9.2.8 (2023-05-26)
+--
+-- https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history
+--
+-- * don't bump this for a minor release
+-- * make sure that this is not too recent (the corresponding `Cabal` library
+--   should be at least five years, or older)
+--
+-- https://cabal.readthedocs.io/en/stable/file-format-changelog.html
+
 name:          Cabal-syntax
 version:       3.17.0.0
 copyright:     2003-2025, Cabal Development Team (see AUTHORS file)

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,4 +1,14 @@
-cabal-version: 3.8
+cabal-version: 3.6
+-- ^ bundled with GHC 9.2.8 (2023-05-26)
+--
+-- https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history
+--
+-- * don't bump this for a minor release
+-- * make sure that this is not too recent (the corresponding `Cabal` library
+--   should be at least five years, or older)
+--
+-- https://cabal.readthedocs.io/en/stable/file-format-changelog.html
+
 name:          Cabal
 version:       3.17.0.0
 copyright:     2003-2025, Cabal Development Team (see AUTHORS file)


### PR DESCRIPTION
This was part of the [pre-flight checklist](https://github.com/haskell/cabal/wiki/Making-a-release#c1-preflight-checks), which I would like to get rid of.

The [original version](https://github.com/haskell/cabal/wiki/Making-a-release/_compare/47489b3a739dbfa9e44e33de6a7c13de5b6b7484...20708ef0819eecd09ea702bafb21105ba97c5605) of this was:

> * make sure `cabal-version` of Cabal and Cabal-syntax is within the backwards compat range (and not too ancient, either).

I interpreted this as:
1. `cabal-versions` should not be too recent
1. there is no important reason to bump the `cabal-version`
1. We don't want to use an ancient `cabal-versions` (for any definition of ancient)

From what I understand, for a release, the only thing that is critical is that it is not too recent.  If we make sure that we don't bump it too aggressively on `master`, then this will always be true.

So what does not too recent mean?

Naïvely, I assume we want the `.cabal` file to be parsable with any `Cabal` library that was bundled with any GHC version released within the last 5 years.

- I think technically, today this would be GHC 9.0.2 (`2021-12-25`) -> `cabal-version: 3.4`
- or, if we only go by the first minor release in a new major release series, then GHC 9.2.1 (`2021-09-29`) -> `cabal-version: 3.6`

https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history

If my understanding is correct, by which ever definition we go, I suggest that we stick with `3.6` (and don't go back to `3.4`).  But I also think that generally it makes sense to keep "LTS" GHCs in the support window.

So basically I suggest:
- stick with `cabal-version: 3.6` for now
- going forward, bump less aggressively

Observations:
- Unless you want to use new features, or possibly for dogfeeding, there is no important reason to bump `cabal-version`
- `cabal-version: 1.12` is completely adequate for many packages

---
Note, that the most recent version of this was less clear to me. With some mental gymnastics I could interpret it the complete opposite way around: https://github.com/haskell/cabal/wiki/Making-a-release/_compare/1848c319688beed33254efcf612d01c737c8a78e...72a2fa0f64643565e32994f7bdcdafb04bb4bee3

That's why I dug up the original version.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
