### PR TITLE
Document additional project config files are read from the root only

### DIFF
--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -36,6 +36,8 @@ options):
 
 Any call to ``cabal build`` will consider ``cabal.project*`` files from parent
 directories when there is none in the current directory.
+If found, the ``cabal.project`` file determines the project root and
+other ``cabal.project.*`` files are read from this location only.
 
 .. _conditionals and imports:
 


### PR DESCRIPTION
This documentation addition reflects my experiments with `3.16.1.0`, after struggling with a behavior I did not expected:
a `cabal.project.local` specifying local packages I was developing a subproject against stopped being read after a `cabal.project` file was added to the top level project root, thus reverting to the store version of the package specified in the subproject cabal file, and resulting in a wild-goose chase after an already fixed bug.

Hopefully this addition is enough to avoid this wrong expectation.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
