### PR TITLE
Update SPDX license list to version 3.28

### DIFF
--- a/Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs
@@ -30,87 +30,92 @@ import qualified Text.PrettyPrint as Disp
 -- LicenseExceptionId
 -------------------------------------------------------------------------------
 
--- | SPDX License Exceptions identifiers list v3.26
+-- | SPDX License Exceptions identifiers list v3.28
 data LicenseExceptionId
     = N_389_exception -- ^ @389-exception@, 389 Directory Server Exception
-    | Asterisk_exception -- ^ @Asterisk-exception@, Asterisk exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Asterisk_linking_protocols_exception -- ^ @Asterisk-linking-protocols-exception@, Asterisk linking protocols exception, SPDX License List 3.25, SPDX License List 3.26
+    | Asterisk_exception -- ^ @Asterisk-exception@, Asterisk exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Asterisk_linking_protocols_exception -- ^ @Asterisk-linking-protocols-exception@, Asterisk linking protocols exception, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Autoconf_exception_2_0 -- ^ @Autoconf-exception-2.0@, Autoconf exception 2.0
     | Autoconf_exception_3_0 -- ^ @Autoconf-exception-3.0@, Autoconf exception 3.0
-    | Autoconf_exception_generic_3_0 -- ^ @Autoconf-exception-generic-3.0@, Autoconf generic exception for GPL-3.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Autoconf_exception_generic -- ^ @Autoconf-exception-generic@, Autoconf generic exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Autoconf_exception_macro -- ^ @Autoconf-exception-macro@, Autoconf macro exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Bison_exception_1_24 -- ^ @Bison-exception-1.24@, Bison exception 1.24, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Autoconf_exception_generic_3_0 -- ^ @Autoconf-exception-generic-3.0@, Autoconf generic exception for GPL-3.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Autoconf_exception_generic -- ^ @Autoconf-exception-generic@, Autoconf generic exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Autoconf_exception_macro -- ^ @Autoconf-exception-macro@, Autoconf macro exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Bison_exception_1_24 -- ^ @Bison-exception-1.24@, Bison exception 1.24, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Bison_exception_2_2 -- ^ @Bison-exception-2.2@, Bison exception 2.2
     | Bootloader_exception -- ^ @Bootloader-exception@, Bootloader Distribution Exception
-    | CGAL_linking_exception -- ^ @CGAL-linking-exception@, CGAL Linking Exception, SPDX License List 3.26
+    | CGAL_linking_exception -- ^ @CGAL-linking-exception@, CGAL Linking Exception, SPDX License List 3.26, SPDX License List 3.28
+    | Classpath_exception_2_0_short -- ^ @Classpath-exception-2.0-short@, Classpath exception 2.0 - short, SPDX License List 3.28
     | Classpath_exception_2_0 -- ^ @Classpath-exception-2.0@, Classpath exception 2.0
     | CLISP_exception_2_0 -- ^ @CLISP-exception-2.0@, CLISP exception 2.0
-    | Cryptsetup_OpenSSL_exception -- ^ @cryptsetup-OpenSSL-exception@, cryptsetup OpenSSL exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Digia_Qt_LGPL_exception_1_1 -- ^ @Digia-Qt-LGPL-exception-1.1@, Digia Qt LGPL Exception version 1.1, SPDX License List 3.26
+    | Cryptsetup_OpenSSL_exception -- ^ @cryptsetup-OpenSSL-exception@, cryptsetup OpenSSL exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Digia_Qt_LGPL_exception_1_1 -- ^ @Digia-Qt-LGPL-exception-1.1@, Digia Qt LGPL Exception version 1.1, SPDX License List 3.26, SPDX License List 3.28
     | DigiRule_FOSS_exception -- ^ @DigiRule-FOSS-exception@, DigiRule FOSS License Exception
     | ECos_exception_2_0 -- ^ @eCos-exception-2.0@, eCos exception 2.0
-    | Erlang_otp_linking_exception -- ^ @erlang-otp-linking-exception@, Erlang/OTP Linking Exception, SPDX License List 3.25, SPDX License List 3.26
+    | Erlang_otp_linking_exception -- ^ @erlang-otp-linking-exception@, Erlang/OTP Linking Exception, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Fawkes_Runtime_exception -- ^ @Fawkes-Runtime-exception@, Fawkes Runtime Exception
     | FLTK_exception -- ^ @FLTK-exception@, FLTK exception
-    | Fmt_exception -- ^ @fmt-exception@, fmt exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Fmt_exception -- ^ @fmt-exception@, fmt exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Font_exception_2_0 -- ^ @Font-exception-2.0@, Font exception 2.0
     | Freertos_exception_2_0 -- ^ @freertos-exception-2.0@, FreeRTOS Exception 2.0
-    | GCC_exception_2_0_note -- ^ @GCC-exception-2.0-note@, GCC    Runtime Library exception 2.0 - note variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | GCC_exception_2_0_note -- ^ @GCC-exception-2.0-note@, GCC    Runtime Library exception 2.0 - note variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | GCC_exception_2_0 -- ^ @GCC-exception-2.0@, GCC Runtime Library exception 2.0
     | GCC_exception_3_1 -- ^ @GCC-exception-3.1@, GCC Runtime Library exception 3.1
-    | Gmsh_exception -- ^ @Gmsh-exception@, Gmsh exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GNAT_exception -- ^ @GNAT-exception@, GNAT exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GNOME_examples_exception -- ^ @GNOME-examples-exception@, GNOME examples exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GNU_compiler_exception -- ^ @GNU-compiler-exception@, GNU Compiler Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Gmsh_exception -- ^ @Gmsh-exception@, Gmsh exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GNAT_exception -- ^ @GNAT-exception@, GNAT exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GNOME_examples_exception -- ^ @GNOME-examples-exception@, GNOME examples exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GNU_compiler_exception -- ^ @GNU-compiler-exception@, GNU Compiler Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Gnu_javamail_exception -- ^ @gnu-javamail-exception@, GNU JavaMail exception
-    | GPL_3_0_389_ds_base_exception -- ^ @GPL-3.0-389-ds-base-exception@, GPL-3.0 389 DS Base Exception, SPDX License List 3.26
-    | GPL_3_0_interface_exception -- ^ @GPL-3.0-interface-exception@, GPL-3.0 Interface Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GPL_3_0_linking_exception -- ^ @GPL-3.0-linking-exception@, GPL-3.0 Linking Exception, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GPL_3_0_linking_source_exception -- ^ @GPL-3.0-linking-source-exception@, GPL-3.0 Linking Exception (with Corresponding Source), SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GPL_CC_1_0 -- ^ @GPL-CC-1.0@, GPL Cooperation Commitment 1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GStreamer_exception_2005 -- ^ @GStreamer-exception-2005@, GStreamer Exception (2005), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GStreamer_exception_2008 -- ^ @GStreamer-exception-2008@, GStreamer Exception (2008), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Harbour_exception -- ^ @harbour-exception@, harbour exception, SPDX License List 3.26
+    | GPL_3_0_389_ds_base_exception -- ^ @GPL-3.0-389-ds-base-exception@, GPL-3.0 389 DS Base Exception, SPDX License List 3.26, SPDX License List 3.28
+    | GPL_3_0_interface_exception -- ^ @GPL-3.0-interface-exception@, GPL-3.0 Interface Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GPL_3_0_linking_exception -- ^ @GPL-3.0-linking-exception@, GPL-3.0 Linking Exception, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GPL_3_0_linking_source_exception -- ^ @GPL-3.0-linking-source-exception@, GPL-3.0 Linking Exception (with Corresponding Source), SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GPL_CC_1_0 -- ^ @GPL-CC-1.0@, GPL Cooperation Commitment 1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GStreamer_exception_2005 -- ^ @GStreamer-exception-2005@, GStreamer Exception (2005), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GStreamer_exception_2008 -- ^ @GStreamer-exception-2008@, GStreamer Exception (2008), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Harbour_exception -- ^ @harbour-exception@, harbour exception, SPDX License List 3.26, SPDX License List 3.28
     | I2p_gpl_java_exception -- ^ @i2p-gpl-java-exception@, i2p GPL+Java Exception
-    | Independent_modules_exception -- ^ @Independent-modules-exception@, Independent Module Linking exception, SPDX License List 3.26
-    | KiCad_libraries_exception -- ^ @KiCad-libraries-exception@, KiCad Libraries Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | LGPL_3_0_linking_exception -- ^ @LGPL-3.0-linking-exception@, LGPL-3.0 Linking Exception, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Libpri_OpenH323_exception -- ^ @libpri-OpenH323-exception@, libpri OpenH323 exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Independent_modules_exception -- ^ @Independent-modules-exception@, Independent Module Linking exception, SPDX License List 3.26, SPDX License List 3.28
+    | KiCad_libraries_exception -- ^ @KiCad-libraries-exception@, KiCad Libraries Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Kvirc_openssl_exception -- ^ @kvirc-openssl-exception@, kvirc OpenSSL Exception, SPDX License List 3.28
+    | LGPL_3_0_linking_exception -- ^ @LGPL-3.0-linking-exception@, LGPL-3.0 Linking Exception, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Libpri_OpenH323_exception -- ^ @libpri-OpenH323-exception@, libpri OpenH323 exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Libtool_exception -- ^ @Libtool-exception@, Libtool Exception
     | Linux_syscall_note -- ^ @Linux-syscall-note@, Linux Syscall Note
-    | LLGPL -- ^ @LLGPL@, LLGPL Preamble, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | LLVM_exception -- ^ @LLVM-exception@, LLVM Exception, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | LLGPL -- ^ @LLGPL@, LLGPL Preamble, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | LLVM_exception -- ^ @LLVM-exception@, LLVM Exception, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | LZMA_exception -- ^ @LZMA-exception@, LZMA exception
     | Mif_exception -- ^ @mif-exception@, Macros and Inline Functions Exception
     | Nokia_Qt_exception_1_1 -- ^ @Nokia-Qt-exception-1.1@, Nokia Qt LGPL exception 1.1, SPDX License List 3.0, SPDX License List 3.2
-    | Mxml_exception -- ^ @mxml-exception@, mxml Exception, SPDX License List 3.26
-    | OCaml_LGPL_linking_exception -- ^ @OCaml-LGPL-linking-exception@, OCaml LGPL Linking Exception, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Mxml_exception -- ^ @mxml-exception@, mxml Exception, SPDX License List 3.26, SPDX License List 3.28
+    | OCaml_LGPL_linking_exception -- ^ @OCaml-LGPL-linking-exception@, OCaml LGPL Linking Exception, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OCCT_exception_1_0 -- ^ @OCCT-exception-1.0@, Open CASCADE Exception 1.0
-    | OpenJDK_assembly_exception_1_0 -- ^ @OpenJDK-assembly-exception-1.0@, OpenJDK Assembly exception 1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OpenJDK_assembly_exception_1_0 -- ^ @OpenJDK-assembly-exception-1.0@, OpenJDK Assembly exception 1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Openvpn_openssl_exception -- ^ @openvpn-openssl-exception@, OpenVPN OpenSSL Exception
-    | PCRE2_exception -- ^ @PCRE2-exception@, PCRE2 exception, SPDX License List 3.25, SPDX License List 3.26
-    | Polyparse_exception -- ^ @polyparse-exception@, Polyparse Exception, SPDX License List 3.26
-    | PS_or_PDF_font_exception_20170817 -- ^ @PS-or-PDF-font-exception-20170817@, PS/PDF font exception (2017-08-17), SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | QPL_1_0_INRIA_2004_exception -- ^ @QPL-1.0-INRIA-2004-exception@, INRIA QPL 1.0 2004 variant exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Qt_GPL_exception_1_0 -- ^ @Qt-GPL-exception-1.0@, Qt GPL exception 1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Qt_LGPL_exception_1_1 -- ^ @Qt-LGPL-exception-1.1@, Qt LGPL exception 1.1, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | PCRE2_exception -- ^ @PCRE2-exception@, PCRE2 exception, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Polyparse_exception -- ^ @polyparse-exception@, Polyparse Exception, SPDX License List 3.26, SPDX License List 3.28
+    | PS_or_PDF_font_exception_20170817 -- ^ @PS-or-PDF-font-exception-20170817@, PS/PDF font exception (2017-08-17), SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | QPL_1_0_INRIA_2004_exception -- ^ @QPL-1.0-INRIA-2004-exception@, INRIA QPL 1.0 2004 variant exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Qt_GPL_exception_1_0 -- ^ @Qt-GPL-exception-1.0@, Qt GPL exception 1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Qt_LGPL_exception_1_1 -- ^ @Qt-LGPL-exception-1.1@, Qt LGPL exception 1.1, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Qwt_exception_1_0 -- ^ @Qwt-exception-1.0@, Qwt exception 1.0
-    | Romic_exception -- ^ @romic-exception@, Romic Exception, SPDX License List 3.25, SPDX License List 3.26
-    | RRDtool_FLOSS_exception_2_0 -- ^ @RRDtool-FLOSS-exception-2.0@, RRDtool FLOSS exception 2.0, SPDX License List 3.25, SPDX License List 3.26
-    | SANE_exception -- ^ @SANE-exception@, SANE Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SHL_2_0 -- ^ @SHL-2.0@, Solderpad Hardware License v2.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SHL_2_1 -- ^ @SHL-2.1@, Solderpad Hardware License v2.1, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Stunnel_exception -- ^ @stunnel-exception@, stunnel Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SWI_exception -- ^ @SWI-exception@, SWI exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Swift_exception -- ^ @Swift-exception@, Swift Exception, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Texinfo_exception -- ^ @Texinfo-exception@, Texinfo exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Romic_exception -- ^ @romic-exception@, Romic Exception, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | RRDtool_FLOSS_exception_2_0 -- ^ @RRDtool-FLOSS-exception-2.0@, RRDtool FLOSS exception 2.0, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Rsync_linking_exception -- ^ @rsync-linking-exception@, rsync Linking Exception, SPDX License List 3.28
+    | SANE_exception -- ^ @SANE-exception@, SANE Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SHL_2_0 -- ^ @SHL-2.0@, Solderpad Hardware License v2.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SHL_2_1 -- ^ @SHL-2.1@, Solderpad Hardware License v2.1, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Simple_Library_Usage_exception -- ^ @Simple-Library-Usage-exception@, Simple Library Usage Exception, SPDX License List 3.28
+    | Sqlitestudio_OpenSSL_exception -- ^ @sqlitestudio-OpenSSL-exception@, sqlitestudio OpenSSL exception, SPDX License List 3.28
+    | Stunnel_exception -- ^ @stunnel-exception@, stunnel Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SWI_exception -- ^ @SWI-exception@, SWI exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Swift_exception -- ^ @Swift-exception@, Swift Exception, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Texinfo_exception -- ^ @Texinfo-exception@, Texinfo exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | U_boot_exception_2_0 -- ^ @u-boot-exception-2.0@, U-Boot exception 2.0
-    | UBDL_exception -- ^ @UBDL-exception@, Unmodified Binary Distribution exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Universal_FOSS_exception_1_0 -- ^ @Universal-FOSS-exception-1.0@, Universal FOSS Exception, Version 1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Vsftpd_openssl_exception -- ^ @vsftpd-openssl-exception@, vsftpd OpenSSL exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | UBDL_exception -- ^ @UBDL-exception@, Unmodified Binary Distribution exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Universal_FOSS_exception_1_0 -- ^ @Universal-FOSS-exception-1.0@, Universal FOSS Exception, Version 1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Vsftpd_openssl_exception -- ^ @vsftpd-openssl-exception@, vsftpd OpenSSL exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | WxWindows_exception_3_1 -- ^ @WxWindows-exception-3.1@, WxWindows Library Exception 3.1
-    | X11vnc_openssl_exception -- ^ @x11vnc-openssl-exception@, x11vnc OpenSSL Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | X11vnc_openssl_exception -- ^ @x11vnc-openssl-exception@, x11vnc OpenSSL Exception, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
   deriving (Eq, Ord, Enum, Bounded, Show, Read, Data, Generic)
 
 instance Binary LicenseExceptionId where
@@ -123,7 +128,7 @@ instance Binary LicenseExceptionId where
 
 -- note: remember to bump version each time the definition changes
 instance Structured LicenseExceptionId where
-    structure p = set typeVersion 307 $ nominalStructure p
+    structure p = set typeVersion 308 $ nominalStructure p
 
 instance Pretty LicenseExceptionId where
     pretty = Disp.text . licenseExceptionId
@@ -156,6 +161,7 @@ licenseExceptionId Bison_exception_1_24 = "Bison-exception-1.24"
 licenseExceptionId Bison_exception_2_2 = "Bison-exception-2.2"
 licenseExceptionId Bootloader_exception = "Bootloader-exception"
 licenseExceptionId CGAL_linking_exception = "CGAL-linking-exception"
+licenseExceptionId Classpath_exception_2_0_short = "Classpath-exception-2.0-short"
 licenseExceptionId Classpath_exception_2_0 = "Classpath-exception-2.0"
 licenseExceptionId CLISP_exception_2_0 = "CLISP-exception-2.0"
 licenseExceptionId Cryptsetup_OpenSSL_exception = "cryptsetup-OpenSSL-exception"
@@ -187,6 +193,7 @@ licenseExceptionId Harbour_exception = "harbour-exception"
 licenseExceptionId I2p_gpl_java_exception = "i2p-gpl-java-exception"
 licenseExceptionId Independent_modules_exception = "Independent-modules-exception"
 licenseExceptionId KiCad_libraries_exception = "KiCad-libraries-exception"
+licenseExceptionId Kvirc_openssl_exception = "kvirc-openssl-exception"
 licenseExceptionId LGPL_3_0_linking_exception = "LGPL-3.0-linking-exception"
 licenseExceptionId Libpri_OpenH323_exception = "libpri-OpenH323-exception"
 licenseExceptionId Libtool_exception = "Libtool-exception"
@@ -210,9 +217,12 @@ licenseExceptionId Qt_LGPL_exception_1_1 = "Qt-LGPL-exception-1.1"
 licenseExceptionId Qwt_exception_1_0 = "Qwt-exception-1.0"
 licenseExceptionId Romic_exception = "romic-exception"
 licenseExceptionId RRDtool_FLOSS_exception_2_0 = "RRDtool-FLOSS-exception-2.0"
+licenseExceptionId Rsync_linking_exception = "rsync-linking-exception"
 licenseExceptionId SANE_exception = "SANE-exception"
 licenseExceptionId SHL_2_0 = "SHL-2.0"
 licenseExceptionId SHL_2_1 = "SHL-2.1"
+licenseExceptionId Simple_Library_Usage_exception = "Simple-Library-Usage-exception"
+licenseExceptionId Sqlitestudio_OpenSSL_exception = "sqlitestudio-OpenSSL-exception"
 licenseExceptionId Stunnel_exception = "stunnel-exception"
 licenseExceptionId SWI_exception = "SWI-exception"
 licenseExceptionId Swift_exception = "Swift-exception"
@@ -238,6 +248,7 @@ licenseExceptionName Bison_exception_1_24 = "Bison exception 1.24"
 licenseExceptionName Bison_exception_2_2 = "Bison exception 2.2"
 licenseExceptionName Bootloader_exception = "Bootloader Distribution Exception"
 licenseExceptionName CGAL_linking_exception = "CGAL Linking Exception"
+licenseExceptionName Classpath_exception_2_0_short = "Classpath exception 2.0 - short"
 licenseExceptionName Classpath_exception_2_0 = "Classpath exception 2.0"
 licenseExceptionName CLISP_exception_2_0 = "CLISP exception 2.0"
 licenseExceptionName Cryptsetup_OpenSSL_exception = "cryptsetup OpenSSL exception"
@@ -269,6 +280,7 @@ licenseExceptionName Harbour_exception = "harbour exception"
 licenseExceptionName I2p_gpl_java_exception = "i2p GPL+Java Exception"
 licenseExceptionName Independent_modules_exception = "Independent Module Linking exception"
 licenseExceptionName KiCad_libraries_exception = "KiCad Libraries Exception"
+licenseExceptionName Kvirc_openssl_exception = "kvirc OpenSSL Exception"
 licenseExceptionName LGPL_3_0_linking_exception = "LGPL-3.0 Linking Exception"
 licenseExceptionName Libpri_OpenH323_exception = "libpri OpenH323 exception"
 licenseExceptionName Libtool_exception = "Libtool Exception"
@@ -292,9 +304,12 @@ licenseExceptionName Qt_LGPL_exception_1_1 = "Qt LGPL exception 1.1"
 licenseExceptionName Qwt_exception_1_0 = "Qwt exception 1.0"
 licenseExceptionName Romic_exception = "Romic Exception"
 licenseExceptionName RRDtool_FLOSS_exception_2_0 = "RRDtool FLOSS exception 2.0"
+licenseExceptionName Rsync_linking_exception = "rsync Linking Exception"
 licenseExceptionName SANE_exception = "SANE Exception"
 licenseExceptionName SHL_2_0 = "Solderpad Hardware License v2.0"
 licenseExceptionName SHL_2_1 = "Solderpad Hardware License v2.1"
+licenseExceptionName Simple_Library_Usage_exception = "Simple Library Usage Exception"
+licenseExceptionName Sqlitestudio_OpenSSL_exception = "sqlitestudio OpenSSL exception"
 licenseExceptionName Stunnel_exception = "stunnel Exception"
 licenseExceptionName SWI_exception = "SWI exception"
 licenseExceptionName Swift_exception = "Swift Exception"
@@ -533,6 +548,66 @@ licenseExceptionIdList LicenseListVersion_3_26 =
     , X11vnc_openssl_exception
     ]
     ++ bulkOfLicenses
+licenseExceptionIdList LicenseListVersion_3_28 =
+    [ Asterisk_exception
+    , Asterisk_linking_protocols_exception
+    , Autoconf_exception_generic_3_0
+    , Autoconf_exception_generic
+    , Autoconf_exception_macro
+    , Bison_exception_1_24
+    , CGAL_linking_exception
+    , Classpath_exception_2_0_short
+    , Cryptsetup_OpenSSL_exception
+    , Digia_Qt_LGPL_exception_1_1
+    , Erlang_otp_linking_exception
+    , Fmt_exception
+    , GCC_exception_2_0_note
+    , Gmsh_exception
+    , GNAT_exception
+    , GNOME_examples_exception
+    , GNU_compiler_exception
+    , GPL_3_0_389_ds_base_exception
+    , GPL_3_0_interface_exception
+    , GPL_3_0_linking_exception
+    , GPL_3_0_linking_source_exception
+    , GPL_CC_1_0
+    , GStreamer_exception_2005
+    , GStreamer_exception_2008
+    , Harbour_exception
+    , Independent_modules_exception
+    , KiCad_libraries_exception
+    , Kvirc_openssl_exception
+    , LGPL_3_0_linking_exception
+    , Libpri_OpenH323_exception
+    , LLGPL
+    , LLVM_exception
+    , Mxml_exception
+    , OCaml_LGPL_linking_exception
+    , OpenJDK_assembly_exception_1_0
+    , PCRE2_exception
+    , Polyparse_exception
+    , PS_or_PDF_font_exception_20170817
+    , QPL_1_0_INRIA_2004_exception
+    , Qt_GPL_exception_1_0
+    , Qt_LGPL_exception_1_1
+    , Romic_exception
+    , RRDtool_FLOSS_exception_2_0
+    , Rsync_linking_exception
+    , SANE_exception
+    , SHL_2_0
+    , SHL_2_1
+    , Simple_Library_Usage_exception
+    , Sqlitestudio_OpenSSL_exception
+    , Stunnel_exception
+    , SWI_exception
+    , Swift_exception
+    , Texinfo_exception
+    , UBDL_exception
+    , Universal_FOSS_exception_1_0
+    , Vsftpd_openssl_exception
+    , X11vnc_openssl_exception
+    ]
+    ++ bulkOfLicenses
 
 -- | Create a 'LicenseExceptionId' from a 'String'.
 mkLicenseExceptionId :: LicenseListVersion -> String -> Maybe LicenseExceptionId
@@ -545,6 +620,7 @@ mkLicenseExceptionId LicenseListVersion_3_16 s = Map.lookup s stringLookup_3_16
 mkLicenseExceptionId LicenseListVersion_3_23 s = Map.lookup s stringLookup_3_23
 mkLicenseExceptionId LicenseListVersion_3_25 s = Map.lookup s stringLookup_3_25
 mkLicenseExceptionId LicenseListVersion_3_26 s = Map.lookup s stringLookup_3_26
+mkLicenseExceptionId LicenseListVersion_3_28 s = Map.lookup s stringLookup_3_28
 
 stringLookup_3_0 :: Map String LicenseExceptionId
 stringLookup_3_0 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
@@ -581,6 +657,10 @@ stringLookup_3_25 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
 stringLookup_3_26 :: Map String LicenseExceptionId
 stringLookup_3_26 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
     licenseExceptionIdList LicenseListVersion_3_26
+
+stringLookup_3_28 :: Map String LicenseExceptionId
+stringLookup_3_28 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
+    licenseExceptionIdList LicenseListVersion_3_28
 
 --  | License exceptions in all SPDX License lists
 bulkOfLicenses :: [LicenseExceptionId]

--- a/Cabal-syntax/src/Distribution/SPDX/LicenseId.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseId.hs
@@ -33,18 +33,19 @@ import qualified Text.PrettyPrint as Disp
 -- LicenseId
 -------------------------------------------------------------------------------
 
--- | SPDX License identifiers list v3.26
+-- | SPDX License identifiers list v3.28
 data LicenseId
     = N_0BSD -- ^ @0BSD@, BSD Zero Clause License
-    | N_3D_Slicer_1_0 -- ^ @3D-Slicer-1.0@, 3D Slicer License v1.0, SPDX License List 3.25, SPDX License List 3.26
+    | N_3D_Slicer_1_0 -- ^ @3D-Slicer-1.0@, 3D Slicer License v1.0, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | AAL -- ^ @AAL@, Attribution Assurance License
     | Abstyles -- ^ @Abstyles@, Abstyles License
-    | AdaCore_doc -- ^ @AdaCore-doc@, AdaCore Doc License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | AdaCore_doc -- ^ @AdaCore-doc@, AdaCore Doc License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Adobe_2006 -- ^ @Adobe-2006@, Adobe Systems Incorporated Source Code License Agreement
-    | Adobe_Display_PostScript -- ^ @Adobe-Display-PostScript@, Adobe Display PostScript License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Adobe_Display_PostScript -- ^ @Adobe-Display-PostScript@, Adobe Display PostScript License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Adobe_Glyph -- ^ @Adobe-Glyph@, Adobe Glyph List License
-    | Adobe_Utopia -- ^ @Adobe-Utopia@, Adobe Utopia Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Adobe_Utopia -- ^ @Adobe-Utopia@, Adobe Utopia Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | ADSL -- ^ @ADSL@, Amazon Digital Services License
+    | Advanced_Cryptics_Dictionary -- ^ @Advanced-Cryptics-Dictionary@, Advanced Cryptics Dictionary License, SPDX License List 3.28
     | AFL_1_1 -- ^ @AFL-1.1@, Academic Free License v1.1
     | AFL_1_2 -- ^ @AFL-1.2@, Academic Free License v1.2
     | AFL_2_0 -- ^ @AFL-2.0@, Academic Free License v2.0
@@ -52,162 +53,168 @@ data LicenseId
     | AFL_3_0 -- ^ @AFL-3.0@, Academic Free License v3.0
     | Afmparse -- ^ @Afmparse@, Afmparse License
     | AGPL_1_0 -- ^ @AGPL-1.0@, Affero General Public License v1.0, SPDX License List 3.0
-    | AGPL_1_0_only -- ^ @AGPL-1.0-only@, Affero General Public License v1.0 only, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | AGPL_1_0_or_later -- ^ @AGPL-1.0-or-later@, Affero General Public License v1.0 or later, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | AGPL_1_0_only -- ^ @AGPL-1.0-only@, Affero General Public License v1.0 only, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | AGPL_1_0_or_later -- ^ @AGPL-1.0-or-later@, Affero General Public License v1.0 or later, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | AGPL_3_0_only -- ^ @AGPL-3.0-only@, GNU Affero General Public License v3.0 only
     | AGPL_3_0_or_later -- ^ @AGPL-3.0-or-later@, GNU Affero General Public License v3.0 or later
     | Aladdin -- ^ @Aladdin@, Aladdin Free Public License
-    | AMD_newlib -- ^ @AMD-newlib@, AMD newlib License, SPDX License List 3.25, SPDX License List 3.26
+    | ALGLIB_Documentation -- ^ @ALGLIB-Documentation@, ALGLIB Documentation License, SPDX License List 3.28
+    | AMD_newlib -- ^ @AMD-newlib@, AMD newlib License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | AMDPLPA -- ^ @AMDPLPA@, AMD's plpa_map.c License
-    | AML_glslang -- ^ @AML-glslang@, AML glslang variant License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | AML_glslang -- ^ @AML-glslang@, AML glslang variant License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | AML -- ^ @AML@, Apple MIT License
     | AMPAS -- ^ @AMPAS@, Academy of Motion Picture Arts and Sciences BSD
-    | ANTLR_PD_fallback -- ^ @ANTLR-PD-fallback@, ANTLR Software Rights Notice with license fallback, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | ANTLR_PD_fallback -- ^ @ANTLR-PD-fallback@, ANTLR Software Rights Notice with license fallback, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | ANTLR_PD -- ^ @ANTLR-PD@, ANTLR Software Rights Notice
-    | Any_OSI_perl_modules -- ^ @any-OSI-perl-modules@, Any OSI License - Perl Modules, SPDX License List 3.26
-    | Any_OSI -- ^ @any-OSI@, Any OSI License, SPDX License List 3.25, SPDX License List 3.26
+    | Any_OSI_perl_modules -- ^ @any-OSI-perl-modules@, Any OSI License - Perl Modules, SPDX License List 3.26, SPDX License List 3.28
+    | Any_OSI -- ^ @any-OSI@, Any OSI License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Apache_1_0 -- ^ @Apache-1.0@, Apache License 1.0
     | Apache_1_1 -- ^ @Apache-1.1@, Apache License 1.1
     | Apache_2_0 -- ^ @Apache-2.0@, Apache License 2.0
     | APAFML -- ^ @APAFML@, Adobe Postscript AFM License
     | APL_1_0 -- ^ @APL-1.0@, Adaptive Public License 1.0
-    | App_s2p -- ^ @App-s2p@, App::s2p License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | App_s2p -- ^ @App-s2p@, App::s2p License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | APSL_1_0 -- ^ @APSL-1.0@, Apple Public Source License 1.0
     | APSL_1_1 -- ^ @APSL-1.1@, Apple Public Source License 1.1
     | APSL_1_2 -- ^ @APSL-1.2@, Apple Public Source License 1.2
     | APSL_2_0 -- ^ @APSL-2.0@, Apple Public Source License 2.0
-    | Arphic_1999 -- ^ @Arphic-1999@, Arphic Public License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Arphic_1999 -- ^ @Arphic-1999@, Arphic Public License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Artistic_1_0_cl8 -- ^ @Artistic-1.0-cl8@, Artistic License 1.0 w/clause 8
     | Artistic_1_0_Perl -- ^ @Artistic-1.0-Perl@, Artistic License 1.0 (Perl)
     | Artistic_1_0 -- ^ @Artistic-1.0@, Artistic License 1.0
     | Artistic_2_0 -- ^ @Artistic-2.0@, Artistic License 2.0
-    | Artistic_dist -- ^ @Artistic-dist@, Artistic License 1.0 (dist), SPDX License List 3.26
-    | Aspell_RU -- ^ @Aspell-RU@, Aspell Russian License, SPDX License List 3.26
-    | ASWF_Digital_Assets_1_0 -- ^ @ASWF-Digital-Assets-1.0@, ASWF Digital Assets License version 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | ASWF_Digital_Assets_1_1 -- ^ @ASWF-Digital-Assets-1.1@, ASWF Digital Assets License 1.1, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Baekmuk -- ^ @Baekmuk@, Baekmuk License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Artistic_dist -- ^ @Artistic-dist@, Artistic License 1.0 (dist), SPDX License List 3.26, SPDX License List 3.28
+    | Aspell_RU -- ^ @Aspell-RU@, Aspell Russian License, SPDX License List 3.26, SPDX License List 3.28
+    | ASWF_Digital_Assets_1_0 -- ^ @ASWF-Digital-Assets-1.0@, ASWF Digital Assets License version 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | ASWF_Digital_Assets_1_1 -- ^ @ASWF-Digital-Assets-1.1@, ASWF Digital Assets License 1.1, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Baekmuk -- ^ @Baekmuk@, Baekmuk License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Bahyph -- ^ @Bahyph@, Bahyph License
     | Barr -- ^ @Barr@, Barr License
-    | Bcrypt_Solar_Designer -- ^ @bcrypt-Solar-Designer@, bcrypt Solar Designer License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Bcrypt_Solar_Designer -- ^ @bcrypt-Solar-Designer@, bcrypt Solar Designer License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Beerware -- ^ @Beerware@, Beerware License
-    | Bitstream_Charter -- ^ @Bitstream-Charter@, Bitstream Charter Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Bitstream_Vera -- ^ @Bitstream-Vera@, Bitstream Vera Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Bitstream_Charter -- ^ @Bitstream-Charter@, Bitstream Charter Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Bitstream_Vera -- ^ @Bitstream-Vera@, Bitstream Vera Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BitTorrent_1_0 -- ^ @BitTorrent-1.0@, BitTorrent Open Source License v1.0
     | BitTorrent_1_1 -- ^ @BitTorrent-1.1@, BitTorrent Open Source License v1.1
-    | Blessing -- ^ @blessing@, SQLite Blessing, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BlueOak_1_0_0 -- ^ @BlueOak-1.0.0@, Blue Oak Model License 1.0.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Boehm_GC_without_fee -- ^ @Boehm-GC-without-fee@, Boehm-Demers-Weiser GC License (without fee), SPDX License List 3.26
-    | Boehm_GC -- ^ @Boehm-GC@, Boehm-Demers-Weiser GC License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Blessing -- ^ @blessing@, SQLite Blessing, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BlueOak_1_0_0 -- ^ @BlueOak-1.0.0@, Blue Oak Model License 1.0.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Boehm_GC_without_fee -- ^ @Boehm-GC-without-fee@, Boehm-Demers-Weiser GC License (without fee), SPDX License List 3.26, SPDX License List 3.28
+    | Boehm_GC -- ^ @Boehm-GC@, Boehm-Demers-Weiser GC License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BOLA_1_1 -- ^ @BOLA-1.1@, Buena Onda License Agreement v1.1, SPDX License List 3.28
     | Borceux -- ^ @Borceux@, Borceux license
-    | Brian_Gladman_2_Clause -- ^ @Brian-Gladman-2-Clause@, Brian Gladman 2-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Brian_Gladman_3_Clause -- ^ @Brian-Gladman-3-Clause@, Brian Gladman 3-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Brian_Gladman_2_Clause -- ^ @Brian-Gladman-2-Clause@, Brian Gladman 2-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Brian_Gladman_3_Clause -- ^ @Brian-Gladman-3-Clause@, Brian Gladman 3-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_1_Clause -- ^ @BSD-1-Clause@, BSD 1-Clause License
     | BSD_2_Clause_FreeBSD -- ^ @BSD-2-Clause-FreeBSD@, BSD 2-Clause FreeBSD License, SPDX License List 3.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9
     | BSD_2_Clause_NetBSD -- ^ @BSD-2-Clause-NetBSD@, BSD 2-Clause NetBSD License, SPDX License List 3.0, SPDX License List 3.2, SPDX License List 3.6
-    | BSD_2_Clause_Darwin -- ^ @BSD-2-Clause-Darwin@, BSD 2-Clause - Ian Darwin variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_2_Clause_first_lines -- ^ @BSD-2-Clause-first-lines@, BSD 2-Clause - first lines requirement, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_2_Clause_Darwin -- ^ @BSD-2-Clause-Darwin@, BSD 2-Clause - Ian Darwin variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_2_Clause_first_lines -- ^ @BSD-2-Clause-first-lines@, BSD 2-Clause - first lines requirement, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_2_Clause_Patent -- ^ @BSD-2-Clause-Patent@, BSD-2-Clause Plus Patent License
-    | BSD_2_Clause_pkgconf_disclaimer -- ^ @BSD-2-Clause-pkgconf-disclaimer@, BSD 2-Clause pkgconf disclaimer variant, SPDX License List 3.26
-    | BSD_2_Clause_Views -- ^ @BSD-2-Clause-Views@, BSD 2-Clause with views sentence, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_2_Clause_pkgconf_disclaimer -- ^ @BSD-2-Clause-pkgconf-disclaimer@, BSD 2-Clause pkgconf disclaimer variant, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_2_Clause_Views -- ^ @BSD-2-Clause-Views@, BSD 2-Clause with views sentence, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_2_Clause -- ^ @BSD-2-Clause@, BSD 2-Clause "Simplified" License
-    | BSD_3_Clause_acpica -- ^ @BSD-3-Clause-acpica@, BSD 3-Clause acpica variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_3_Clause_acpica -- ^ @BSD-3-Clause-acpica@, BSD 3-Clause acpica variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_3_Clause_Attribution -- ^ @BSD-3-Clause-Attribution@, BSD with attribution
     | BSD_3_Clause_Clear -- ^ @BSD-3-Clause-Clear@, BSD 3-Clause Clear License
-    | BSD_3_Clause_flex -- ^ @BSD-3-Clause-flex@, BSD 3-Clause Flex variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_3_Clause_HP -- ^ @BSD-3-Clause-HP@, Hewlett-Packard BSD variant license, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_3_Clause_flex -- ^ @BSD-3-Clause-flex@, BSD 3-Clause Flex variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_3_Clause_HP -- ^ @BSD-3-Clause-HP@, Hewlett-Packard BSD variant license, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_3_Clause_LBNL -- ^ @BSD-3-Clause-LBNL@, Lawrence Berkeley National Labs BSD variant license
-    | BSD_3_Clause_Modification -- ^ @BSD-3-Clause-Modification@, BSD 3-Clause Modification, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_3_Clause_No_Military_License -- ^ @BSD-3-Clause-No-Military-License@, BSD 3-Clause No Military License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_3_Clause_Modification -- ^ @BSD-3-Clause-Modification@, BSD 3-Clause Modification, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_3_Clause_No_Military_License -- ^ @BSD-3-Clause-No-Military-License@, BSD 3-Clause No Military License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_3_Clause_No_Nuclear_License_2014 -- ^ @BSD-3-Clause-No-Nuclear-License-2014@, BSD 3-Clause No Nuclear License 2014
     | BSD_3_Clause_No_Nuclear_License -- ^ @BSD-3-Clause-No-Nuclear-License@, BSD 3-Clause No Nuclear License
     | BSD_3_Clause_No_Nuclear_Warranty -- ^ @BSD-3-Clause-No-Nuclear-Warranty@, BSD 3-Clause No Nuclear Warranty
-    | BSD_3_Clause_Open_MPI -- ^ @BSD-3-Clause-Open-MPI@, BSD 3-Clause Open MPI variant, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_3_Clause_Sun -- ^ @BSD-3-Clause-Sun@, BSD 3-Clause Sun Microsystems, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_3_Clause_Open_MPI -- ^ @BSD-3-Clause-Open-MPI@, BSD 3-Clause Open MPI variant, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_3_Clause_Sun -- ^ @BSD-3-Clause-Sun@, BSD 3-Clause Sun Microsystems, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_3_Clause_Tso -- ^ @BSD-3-Clause-Tso@, BSD 3-Clause Tso variant, SPDX License List 3.28
     | BSD_3_Clause -- ^ @BSD-3-Clause@, BSD 3-Clause "New" or "Revised" License
-    | BSD_4_Clause_Shortened -- ^ @BSD-4-Clause-Shortened@, BSD 4 Clause Shortened, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_4_Clause_Shortened -- ^ @BSD-4-Clause-Shortened@, BSD 4 Clause Shortened, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_4_Clause_UC -- ^ @BSD-4-Clause-UC@, BSD-4-Clause (University of California-Specific)
     | BSD_4_Clause -- ^ @BSD-4-Clause@, BSD 4-Clause "Original" or "Old" License
-    | BSD_4_3RENO -- ^ @BSD-4.3RENO@, BSD 4.3 RENO License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_4_3TAHOE -- ^ @BSD-4.3TAHOE@, BSD 4.3 TAHOE License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_Advertising_Acknowledgement -- ^ @BSD-Advertising-Acknowledgement@, BSD Advertising Acknowledgement License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_Attribution_HPND_disclaimer -- ^ @BSD-Attribution-HPND-disclaimer@, BSD with Attribution and HPND disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_Inferno_Nettverk -- ^ @BSD-Inferno-Nettverk@, BSD-Inferno-Nettverk, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_4_3RENO -- ^ @BSD-4.3RENO@, BSD 4.3 RENO License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_4_3TAHOE -- ^ @BSD-4.3TAHOE@, BSD 4.3 TAHOE License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_Advertising_Acknowledgement -- ^ @BSD-Advertising-Acknowledgement@, BSD Advertising Acknowledgement License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_Attribution_HPND_disclaimer -- ^ @BSD-Attribution-HPND-disclaimer@, BSD with Attribution and HPND disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_Inferno_Nettverk -- ^ @BSD-Inferno-Nettverk@, BSD-Inferno-Nettverk, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_Mark_Modifications -- ^ @BSD-Mark-Modifications@, BSD Mark Modifications License, SPDX License List 3.28
     | BSD_Protection -- ^ @BSD-Protection@, BSD Protection License
-    | BSD_Source_beginning_file -- ^ @BSD-Source-beginning-file@, BSD Source Code Attribution - beginning of file variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_Source_beginning_file -- ^ @BSD-Source-beginning-file@, BSD Source Code Attribution - beginning of file variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSD_Source_Code -- ^ @BSD-Source-Code@, BSD Source Code Attribution
-    | BSD_Systemics_W3Works -- ^ @BSD-Systemics-W3Works@, Systemics W3Works BSD variant license, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | BSD_Systemics -- ^ @BSD-Systemics@, Systemics BSD variant license, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | BSD_Systemics_W3Works -- ^ @BSD-Systemics-W3Works@, Systemics W3Works BSD variant license, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | BSD_Systemics -- ^ @BSD-Systemics@, Systemics BSD variant license, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | BSL_1_0 -- ^ @BSL-1.0@, Boost Software License 1.0
     | Bzip2_1_0_5 -- ^ @bzip2-1.0.5@, bzip2 and libbzip2 License v1.0.5, SPDX License List 3.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10
-    | BUSL_1_1 -- ^ @BUSL-1.1@, Business Source License 1.1, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Buddy -- ^ @Buddy@, Buddy License, SPDX License List 3.28
+    | BUSL_1_1 -- ^ @BUSL-1.1@, Business Source License 1.1, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Bzip2_1_0_6 -- ^ @bzip2-1.0.6@, bzip2 and libbzip2 License v1.0.6
-    | C_UDA_1_0 -- ^ @C-UDA-1.0@, Computational Use of Data Agreement v1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CAL_1_0_Combined_Work_Exception -- ^ @CAL-1.0-Combined-Work-Exception@, Cryptographic Autonomy License 1.0 (Combined Work Exception), SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CAL_1_0 -- ^ @CAL-1.0@, Cryptographic Autonomy License 1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Caldera_no_preamble -- ^ @Caldera-no-preamble@, Caldera License (without preamble), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | C_UDA_1_0 -- ^ @C-UDA-1.0@, Computational Use of Data Agreement v1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CAL_1_0_Combined_Work_Exception -- ^ @CAL-1.0-Combined-Work-Exception@, Cryptographic Autonomy License 1.0 (Combined Work Exception), SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CAL_1_0 -- ^ @CAL-1.0@, Cryptographic Autonomy License 1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Caldera_no_preamble -- ^ @Caldera-no-preamble@, Caldera License (without preamble), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Caldera -- ^ @Caldera@, Caldera License
-    | Catharon -- ^ @Catharon@, Catharon License, SPDX License List 3.25, SPDX License List 3.26
+    | CAPEC_tou -- ^ @CAPEC-tou@, Common Attack    Pattern Enumeration and Classification License, SPDX License List 3.28
+    | Catharon -- ^ @Catharon@, Catharon License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CATOSL_1_1 -- ^ @CATOSL-1.1@, Computer Associates Trusted Open Source License 1.1
     | CC_BY_1_0 -- ^ @CC-BY-1.0@, Creative Commons Attribution 1.0 Generic
     | CC_BY_2_0 -- ^ @CC-BY-2.0@, Creative Commons Attribution 2.0 Generic
-    | CC_BY_2_5_AU -- ^ @CC-BY-2.5-AU@, Creative Commons Attribution 2.5 Australia, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_2_5_AU -- ^ @CC-BY-2.5-AU@, Creative Commons Attribution 2.5 Australia, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_2_5 -- ^ @CC-BY-2.5@, Creative Commons Attribution 2.5 Generic
-    | CC_BY_3_0_AT -- ^ @CC-BY-3.0-AT@, Creative Commons Attribution 3.0 Austria, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_3_0_AU -- ^ @CC-BY-3.0-AU@, Creative Commons Attribution 3.0 Australia, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_3_0_DE -- ^ @CC-BY-3.0-DE@, Creative Commons Attribution 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_3_0_IGO -- ^ @CC-BY-3.0-IGO@, Creative Commons Attribution 3.0 IGO, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_3_0_NL -- ^ @CC-BY-3.0-NL@, Creative Commons Attribution 3.0 Netherlands, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_3_0_US -- ^ @CC-BY-3.0-US@, Creative Commons Attribution 3.0 United States, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_3_0_AT -- ^ @CC-BY-3.0-AT@, Creative Commons Attribution 3.0 Austria, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_3_0_AU -- ^ @CC-BY-3.0-AU@, Creative Commons Attribution 3.0 Australia, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_3_0_DE -- ^ @CC-BY-3.0-DE@, Creative Commons Attribution 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_3_0_IGO -- ^ @CC-BY-3.0-IGO@, Creative Commons Attribution 3.0 IGO, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_3_0_NL -- ^ @CC-BY-3.0-NL@, Creative Commons Attribution 3.0 Netherlands, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_3_0_US -- ^ @CC-BY-3.0-US@, Creative Commons Attribution 3.0 United States, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_3_0 -- ^ @CC-BY-3.0@, Creative Commons Attribution 3.0 Unported
     | CC_BY_4_0 -- ^ @CC-BY-4.0@, Creative Commons Attribution 4.0 International
     | CC_BY_NC_1_0 -- ^ @CC-BY-NC-1.0@, Creative Commons Attribution Non Commercial 1.0 Generic
     | CC_BY_NC_2_0 -- ^ @CC-BY-NC-2.0@, Creative Commons Attribution Non Commercial 2.0 Generic
     | CC_BY_NC_2_5 -- ^ @CC-BY-NC-2.5@, Creative Commons Attribution Non Commercial 2.5 Generic
-    | CC_BY_NC_3_0_DE -- ^ @CC-BY-NC-3.0-DE@, Creative Commons Attribution Non Commercial 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_NC_3_0_DE -- ^ @CC-BY-NC-3.0-DE@, Creative Commons Attribution Non Commercial 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_NC_3_0 -- ^ @CC-BY-NC-3.0@, Creative Commons Attribution Non Commercial 3.0 Unported
     | CC_BY_NC_4_0 -- ^ @CC-BY-NC-4.0@, Creative Commons Attribution Non Commercial 4.0 International
     | CC_BY_NC_ND_1_0 -- ^ @CC-BY-NC-ND-1.0@, Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic
     | CC_BY_NC_ND_2_0 -- ^ @CC-BY-NC-ND-2.0@, Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic
     | CC_BY_NC_ND_2_5 -- ^ @CC-BY-NC-ND-2.5@, Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic
-    | CC_BY_NC_ND_3_0_DE -- ^ @CC-BY-NC-ND-3.0-DE@, Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_NC_ND_3_0_IGO -- ^ @CC-BY-NC-ND-3.0-IGO@, Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_NC_ND_3_0_DE -- ^ @CC-BY-NC-ND-3.0-DE@, Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_NC_ND_3_0_IGO -- ^ @CC-BY-NC-ND-3.0-IGO@, Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_NC_ND_3_0 -- ^ @CC-BY-NC-ND-3.0@, Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported
     | CC_BY_NC_ND_4_0 -- ^ @CC-BY-NC-ND-4.0@, Creative Commons Attribution Non Commercial No Derivatives 4.0 International
     | CC_BY_NC_SA_1_0 -- ^ @CC-BY-NC-SA-1.0@, Creative Commons Attribution Non Commercial Share Alike 1.0 Generic
-    | CC_BY_NC_SA_2_0_DE -- ^ @CC-BY-NC-SA-2.0-DE@, Creative Commons Attribution Non Commercial Share Alike 2.0 Germany, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_NC_SA_2_0_FR -- ^ @CC-BY-NC-SA-2.0-FR@, Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_NC_SA_2_0_UK -- ^ @CC-BY-NC-SA-2.0-UK@, Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_NC_SA_2_0_DE -- ^ @CC-BY-NC-SA-2.0-DE@, Creative Commons Attribution Non Commercial Share Alike 2.0 Germany, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_NC_SA_2_0_FR -- ^ @CC-BY-NC-SA-2.0-FR@, Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_NC_SA_2_0_UK -- ^ @CC-BY-NC-SA-2.0-UK@, Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_NC_SA_2_0 -- ^ @CC-BY-NC-SA-2.0@, Creative Commons Attribution Non Commercial Share Alike 2.0 Generic
     | CC_BY_NC_SA_2_5 -- ^ @CC-BY-NC-SA-2.5@, Creative Commons Attribution Non Commercial Share Alike 2.5 Generic
-    | CC_BY_NC_SA_3_0_DE -- ^ @CC-BY-NC-SA-3.0-DE@, Creative Commons Attribution Non Commercial Share Alike 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_NC_SA_3_0_IGO -- ^ @CC-BY-NC-SA-3.0-IGO@, Creative Commons Attribution Non Commercial Share Alike 3.0 IGO, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_NC_SA_3_0_DE -- ^ @CC-BY-NC-SA-3.0-DE@, Creative Commons Attribution Non Commercial Share Alike 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_NC_SA_3_0_IGO -- ^ @CC-BY-NC-SA-3.0-IGO@, Creative Commons Attribution Non Commercial Share Alike 3.0 IGO, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_NC_SA_3_0 -- ^ @CC-BY-NC-SA-3.0@, Creative Commons Attribution Non Commercial Share Alike 3.0 Unported
     | CC_BY_NC_SA_4_0 -- ^ @CC-BY-NC-SA-4.0@, Creative Commons Attribution Non Commercial Share Alike 4.0 International
     | CC_BY_ND_1_0 -- ^ @CC-BY-ND-1.0@, Creative Commons Attribution No Derivatives 1.0 Generic
     | CC_BY_ND_2_0 -- ^ @CC-BY-ND-2.0@, Creative Commons Attribution No Derivatives 2.0 Generic
     | CC_BY_ND_2_5 -- ^ @CC-BY-ND-2.5@, Creative Commons Attribution No Derivatives 2.5 Generic
-    | CC_BY_ND_3_0_DE -- ^ @CC-BY-ND-3.0-DE@, Creative Commons Attribution No Derivatives 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_ND_3_0_DE -- ^ @CC-BY-ND-3.0-DE@, Creative Commons Attribution No Derivatives 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_ND_3_0 -- ^ @CC-BY-ND-3.0@, Creative Commons Attribution No Derivatives 3.0 Unported
     | CC_BY_ND_4_0 -- ^ @CC-BY-ND-4.0@, Creative Commons Attribution No Derivatives 4.0 International
     | CC_BY_SA_1_0 -- ^ @CC-BY-SA-1.0@, Creative Commons Attribution Share Alike 1.0 Generic
-    | CC_BY_SA_2_0_UK -- ^ @CC-BY-SA-2.0-UK@, Creative Commons Attribution Share Alike 2.0 England and Wales, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_SA_2_0_UK -- ^ @CC-BY-SA-2.0-UK@, Creative Commons Attribution Share Alike 2.0 England and Wales, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_SA_2_0 -- ^ @CC-BY-SA-2.0@, Creative Commons Attribution Share Alike 2.0 Generic
-    | CC_BY_SA_2_1_JP -- ^ @CC-BY-SA-2.1-JP@, Creative Commons Attribution Share Alike 2.1 Japan, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_SA_2_1_JP -- ^ @CC-BY-SA-2.1-JP@, Creative Commons Attribution Share Alike 2.1 Japan, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_SA_2_5 -- ^ @CC-BY-SA-2.5@, Creative Commons Attribution Share Alike 2.5 Generic
-    | CC_BY_SA_3_0_AT -- ^ @CC-BY-SA-3.0-AT@, Creative Commons Attribution Share Alike 3.0 Austria, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_SA_3_0_DE -- ^ @CC-BY-SA-3.0-DE@, Creative Commons Attribution Share Alike 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_BY_SA_3_0_IGO -- ^ @CC-BY-SA-3.0-IGO@, Creative Commons Attribution-ShareAlike 3.0 IGO, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CC_BY_SA_3_0_AT -- ^ @CC-BY-SA-3.0-AT@, Creative Commons Attribution Share Alike 3.0 Austria, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_SA_3_0_DE -- ^ @CC-BY-SA-3.0-DE@, Creative Commons Attribution Share Alike 3.0 Germany, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_BY_SA_3_0_IGO -- ^ @CC-BY-SA-3.0-IGO@, Creative Commons Attribution-ShareAlike 3.0 IGO, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CC_BY_SA_3_0 -- ^ @CC-BY-SA-3.0@, Creative Commons Attribution Share Alike 3.0 Unported
     | CC_BY_SA_4_0 -- ^ @CC-BY-SA-4.0@, Creative Commons Attribution Share Alike 4.0 International
-    | CC_PDDC -- ^ @CC-PDDC@, Creative Commons Public Domain Dedication and Certification, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CC_PDM_1_0 -- ^ @CC-PDM-1.0@, Creative    Commons Public Domain Mark 1.0 Universal, SPDX License List 3.26
-    | CC_SA_1_0 -- ^ @CC-SA-1.0@, Creative Commons Share Alike 1.0 Generic, SPDX License List 3.26
+    | CC_PDDC -- ^ @CC-PDDC@, Creative Commons Public Domain Dedication and Certification, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CC_PDM_1_0 -- ^ @CC-PDM-1.0@, Creative    Commons Public Domain Mark 1.0 Universal, SPDX License List 3.26, SPDX License List 3.28
+    | CC_SA_1_0 -- ^ @CC-SA-1.0@, Creative Commons Share Alike 1.0 Generic, SPDX License List 3.26, SPDX License List 3.28
     | CC0_1_0 -- ^ @CC0-1.0@, Creative Commons Zero v1.0 Universal
     | CDDL_1_0 -- ^ @CDDL-1.0@, Common Development and Distribution License 1.0
     | CDDL_1_1 -- ^ @CDDL-1.1@, Common Development and Distribution License 1.1
-    | CDL_1_0 -- ^ @CDL-1.0@, Common Documentation License 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CDL_1_0 -- ^ @CDL-1.0@, Common Documentation License 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CDLA_Permissive_1_0 -- ^ @CDLA-Permissive-1.0@, Community Data License Agreement Permissive 1.0
-    | CDLA_Permissive_2_0 -- ^ @CDLA-Permissive-2.0@, Community Data License Agreement Permissive 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CDLA_Permissive_2_0 -- ^ @CDLA-Permissive-2.0@, Community Data License Agreement Permissive 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CDLA_Sharing_1_0 -- ^ @CDLA-Sharing-1.0@, Community Data License Agreement Sharing 1.0
     | CECILL_1_0 -- ^ @CECILL-1.0@, CeCILL Free Software License Agreement v1.0
     | CECILL_1_1 -- ^ @CECILL-1.1@, CeCILL Free Software License Agreement v1.1
@@ -215,116 +222,119 @@ data LicenseId
     | CECILL_2_1 -- ^ @CECILL-2.1@, CeCILL Free Software License Agreement v2.1
     | CECILL_B -- ^ @CECILL-B@, CeCILL-B Free Software License Agreement
     | CECILL_C -- ^ @CECILL-C@, CeCILL-C Free Software License Agreement
-    | CERN_OHL_1_1 -- ^ @CERN-OHL-1.1@, CERN Open Hardware Licence v1.1, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CERN_OHL_1_2 -- ^ @CERN-OHL-1.2@, CERN Open Hardware Licence v1.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CERN_OHL_P_2_0 -- ^ @CERN-OHL-P-2.0@, CERN Open Hardware Licence Version 2 - Permissive, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CERN_OHL_S_2_0 -- ^ @CERN-OHL-S-2.0@, CERN Open Hardware Licence Version 2 - Strongly Reciprocal, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CERN_OHL_W_2_0 -- ^ @CERN-OHL-W-2.0@, CERN Open Hardware Licence Version 2 - Weakly Reciprocal, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CFITSIO -- ^ @CFITSIO@, CFITSIO License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Check_cvs -- ^ @check-cvs@, check-cvs License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Checkmk -- ^ @checkmk@, Checkmk License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | CERN_OHL_1_1 -- ^ @CERN-OHL-1.1@, CERN Open Hardware Licence v1.1, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CERN_OHL_1_2 -- ^ @CERN-OHL-1.2@, CERN Open Hardware Licence v1.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CERN_OHL_P_2_0 -- ^ @CERN-OHL-P-2.0@, CERN Open Hardware Licence Version 2 - Permissive, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CERN_OHL_S_2_0 -- ^ @CERN-OHL-S-2.0@, CERN Open Hardware Licence Version 2 - Strongly Reciprocal, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CERN_OHL_W_2_0 -- ^ @CERN-OHL-W-2.0@, CERN Open Hardware Licence Version 2 - Weakly Reciprocal, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CFITSIO -- ^ @CFITSIO@, CFITSIO License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Check_cvs -- ^ @check-cvs@, check-cvs License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Checkmk -- ^ @checkmk@, Checkmk License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | ClArtistic -- ^ @ClArtistic@, Clarified Artistic License
-    | Clips -- ^ @Clips@, Clips License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CMU_Mach_nodoc -- ^ @CMU-Mach-nodoc@, CMU    Mach - no notices-in-documentation variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | CMU_Mach -- ^ @CMU-Mach@, CMU Mach License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Clips -- ^ @Clips@, Clips License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CMU_Mach_nodoc -- ^ @CMU-Mach-nodoc@, CMU    Mach - no notices-in-documentation variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | CMU_Mach -- ^ @CMU-Mach@, CMU Mach License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CNRI_Jython -- ^ @CNRI-Jython@, CNRI Jython License
     | CNRI_Python_GPL_Compatible -- ^ @CNRI-Python-GPL-Compatible@, CNRI Python Open Source GPL Compatible License Agreement
     | CNRI_Python -- ^ @CNRI-Python@, CNRI Python License
-    | COIL_1_0 -- ^ @COIL-1.0@, Copyfree Open Innovation License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Community_Spec_1_0 -- ^ @Community-Spec-1.0@, Community Specification License 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | COIL_1_0 -- ^ @COIL-1.0@, Copyfree Open Innovation License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Community_Spec_1_0 -- ^ @Community-Spec-1.0@, Community Specification License 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Condor_1_1 -- ^ @Condor-1.1@, Condor Public License v1.1
-    | Copyleft_next_0_3_0 -- ^ @copyleft-next-0.3.0@, copyleft-next 0.3.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Copyleft_next_0_3_1 -- ^ @copyleft-next-0.3.1@, copyleft-next 0.3.1, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Cornell_Lossless_JPEG -- ^ @Cornell-Lossless-JPEG@, Cornell Lossless JPEG License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Copyleft_next_0_3_0 -- ^ @copyleft-next-0.3.0@, copyleft-next 0.3.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Copyleft_next_0_3_1 -- ^ @copyleft-next-0.3.1@, copyleft-next 0.3.1, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Cornell_Lossless_JPEG -- ^ @Cornell-Lossless-JPEG@, Cornell Lossless JPEG License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | CPAL_1_0 -- ^ @CPAL-1.0@, Common Public Attribution License 1.0
     | CPL_1_0 -- ^ @CPL-1.0@, Common Public License 1.0
     | CPOL_1_02 -- ^ @CPOL-1.02@, Code Project Open License 1.02
-    | Cronyx -- ^ @Cronyx@, Cronyx License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Cronyx -- ^ @Cronyx@, Cronyx License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Crossword -- ^ @Crossword@, Crossword License
-    | CryptoSwift -- ^ @CryptoSwift@, CryptoSwift License, SPDX License List 3.26
+    | CryptoSwift -- ^ @CryptoSwift@, CryptoSwift License, SPDX License List 3.26, SPDX License List 3.28
     | CrystalStacker -- ^ @CrystalStacker@, CrystalStacker License
     | CUA_OPL_1_0 -- ^ @CUA-OPL-1.0@, CUA Office Public License v1.0
     | Cube -- ^ @Cube@, Cube License
     | Curl -- ^ @curl@, curl License
-    | Cve_tou -- ^ @cve-tou@, Common Vulnerability Enumeration ToU License, SPDX License List 3.25, SPDX License List 3.26
+    | Cve_tou -- ^ @cve-tou@, Common Vulnerability Enumeration ToU License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | D_FSL_1_0 -- ^ @D-FSL-1.0@, Deutsche Freie Software Lizenz
-    | DEC_3_Clause -- ^ @DEC-3-Clause@, DEC 3-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | DEC_3_Clause -- ^ @DEC-3-Clause@, DEC 3-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Diffmark -- ^ @diffmark@, diffmark license
-    | DL_DE_BY_2_0 -- ^ @DL-DE-BY-2.0@, Data licence Germany – attribution – version 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | DL_DE_ZERO_2_0 -- ^ @DL-DE-ZERO-2.0@, Data licence Germany – zero – version 2.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | DocBook_DTD -- ^ @DocBook-DTD@, DocBook DTD License, SPDX License List 3.26
-    | DocBook_Schema -- ^ @DocBook-Schema@, DocBook Schema License, SPDX License List 3.25, SPDX License List 3.26
-    | DocBook_Stylesheet -- ^ @DocBook-Stylesheet@, DocBook Stylesheet License, SPDX License List 3.26
-    | DocBook_XML -- ^ @DocBook-XML@, DocBook XML License, SPDX License List 3.25, SPDX License List 3.26
+    | DL_DE_BY_2_0 -- ^ @DL-DE-BY-2.0@, Data licence Germany – attribution – version 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | DL_DE_ZERO_2_0 -- ^ @DL-DE-ZERO-2.0@, Data licence Germany – zero – version 2.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | DocBook_DTD -- ^ @DocBook-DTD@, DocBook DTD License, SPDX License List 3.26, SPDX License List 3.28
+    | DocBook_Schema -- ^ @DocBook-Schema@, DocBook Schema License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | DocBook_Stylesheet -- ^ @DocBook-Stylesheet@, DocBook Stylesheet License, SPDX License List 3.26, SPDX License List 3.28
+    | DocBook_XML -- ^ @DocBook-XML@, DocBook XML License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | DOC -- ^ @DOC@, DOC License
     | Dotseqn -- ^ @Dotseqn@, Dotseqn License
-    | DRL_1_0 -- ^ @DRL-1.0@, Detection Rule License 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | DRL_1_1 -- ^ @DRL-1.1@, Detection Rule License 1.1, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | DRL_1_0 -- ^ @DRL-1.0@, Detection Rule License 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | DRL_1_1 -- ^ @DRL-1.1@, Detection Rule License 1.1, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | DSDP -- ^ @DSDP@, DSDP License
-    | Dtoa -- ^ @dtoa@, David M. Gay dtoa License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Dtoa -- ^ @dtoa@, David M. Gay dtoa License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Dvipdfm -- ^ @dvipdfm@, dvipdfm License
     | ECL_1_0 -- ^ @ECL-1.0@, Educational Community License v1.0
     | ECL_2_0 -- ^ @ECL-2.0@, Educational Community License v2.0
     | EFL_1_0 -- ^ @EFL-1.0@, Eiffel Forum License v1.0
     | EFL_2_0 -- ^ @EFL-2.0@, Eiffel Forum License v2.0
     | EGenix -- ^ @eGenix@, eGenix.com Public License 1.1.0
-    | Elastic_2_0 -- ^ @Elastic-2.0@, Elastic License 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Elastic_2_0 -- ^ @Elastic-2.0@, Elastic License 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Entessa -- ^ @Entessa@, Entessa Public License v1.0
-    | EPICS -- ^ @EPICS@, EPICS Open License, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | EPICS -- ^ @EPICS@, EPICS Open License, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | EPL_1_0 -- ^ @EPL-1.0@, Eclipse Public License 1.0
     | EPL_2_0 -- ^ @EPL-2.0@, Eclipse Public License 2.0
     | ErlPL_1_1 -- ^ @ErlPL-1.1@, Erlang Public License v1.1
-    | Etalab_2_0 -- ^ @etalab-2.0@, Etalab Open License 2.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | ESA_PL_permissive_2_4 -- ^ @ESA-PL-permissive-2.4@, European Space Agency Public License – v2.4 – Permissive (Type 3), SPDX License List 3.28
+    | ESA_PL_strong_copyleft_2_4 -- ^ @ESA-PL-strong-copyleft-2.4@, European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1), SPDX License List 3.28
+    | ESA_PL_weak_copyleft_2_4 -- ^ @ESA-PL-weak-copyleft-2.4@, European Space Agency Public License – v2.4 – Weak Copyleft (Type 2), SPDX License List 3.28
+    | Etalab_2_0 -- ^ @etalab-2.0@, Etalab Open License 2.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | EUDatagrid -- ^ @EUDatagrid@, EU DataGrid Software License
     | EUPL_1_0 -- ^ @EUPL-1.0@, European Union Public License 1.0
     | EUPL_1_1 -- ^ @EUPL-1.1@, European Union Public License 1.1
     | EUPL_1_2 -- ^ @EUPL-1.2@, European Union Public License 1.2
     | Eurosym -- ^ @Eurosym@, Eurosym License
     | Fair -- ^ @Fair@, Fair License
-    | FBM -- ^ @FBM@, Fuzzy Bitmap License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | FDK_AAC -- ^ @FDK-AAC@, Fraunhofer FDK AAC Codec Library, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Ferguson_Twofish -- ^ @Ferguson-Twofish@, Ferguson Twofish License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | FBM -- ^ @FBM@, Fuzzy Bitmap License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | FDK_AAC -- ^ @FDK-AAC@, Fraunhofer FDK AAC Codec Library, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Ferguson_Twofish -- ^ @Ferguson-Twofish@, Ferguson Twofish License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Frameworx_1_0 -- ^ @Frameworx-1.0@, Frameworx Open License 1.0
-    | FreeBSD_DOC -- ^ @FreeBSD-DOC@, FreeBSD Documentation License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | FreeBSD_DOC -- ^ @FreeBSD-DOC@, FreeBSD Documentation License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | FreeImage -- ^ @FreeImage@, FreeImage Public License v1.0
-    | FSFAP_no_warranty_disclaimer -- ^ @FSFAP-no-warranty-disclaimer@, FSF All Permissive License (without Warranty), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | FSFAP_no_warranty_disclaimer -- ^ @FSFAP-no-warranty-disclaimer@, FSF All Permissive License (without Warranty), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | FSFAP -- ^ @FSFAP@, FSF All Permissive License
-    | FSFULLRSD -- ^ @FSFULLRSD@, FSF Unlimited License (with License Retention and Short Disclaimer), SPDX License List 3.26
-    | FSFULLRWD -- ^ @FSFULLRWD@, FSF Unlimited License (With License Retention and Warranty Disclaimer), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | FSFULLRSD -- ^ @FSFULLRSD@, FSF Unlimited License (with License Retention and Short Disclaimer), SPDX License List 3.26, SPDX License List 3.28
+    | FSFULLRWD -- ^ @FSFULLRWD@, FSF Unlimited License (With License Retention and Warranty Disclaimer), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | FSFULLR -- ^ @FSFULLR@, FSF Unlimited License (with License Retention)
     | FSFUL -- ^ @FSFUL@, FSF Unlimited License
-    | FSL_1_1_ALv2 -- ^ @FSL-1.1-ALv2@, Functional Source License, Version 1.1, ALv2 Future License, SPDX License List 3.26
-    | FSL_1_1_MIT -- ^ @FSL-1.1-MIT@, Functional Source License, Version 1.1, MIT Future License, SPDX License List 3.26
+    | FSL_1_1_ALv2 -- ^ @FSL-1.1-ALv2@, Functional Source License, Version 1.1, ALv2 Future License, SPDX License List 3.26, SPDX License List 3.28
+    | FSL_1_1_MIT -- ^ @FSL-1.1-MIT@, Functional Source License, Version 1.1, MIT Future License, SPDX License List 3.26, SPDX License List 3.28
     | FTL -- ^ @FTL@, Freetype Project License
-    | Furuseth -- ^ @Furuseth@, Furuseth License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Fwlw -- ^ @fwlw@, fwlw License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Game_Programming_Gems -- ^ @Game-Programming-Gems@, Game Programming Gems License, SPDX License List 3.26
-    | GCR_docs -- ^ @GCR-docs@, Gnome GCR Documentation License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GD -- ^ @GD@, GD License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Generic_xts -- ^ @generic-xts@, Generic XTS License, SPDX License List 3.26
-    | GFDL_1_1_invariants_only -- ^ @GFDL-1.1-invariants-only@, GNU Free Documentation License v1.1 only - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_1_invariants_or_later -- ^ @GFDL-1.1-invariants-or-later@, GNU Free Documentation License v1.1 or later - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_1_no_invariants_only -- ^ @GFDL-1.1-no-invariants-only@, GNU Free Documentation License v1.1 only - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_1_no_invariants_or_later -- ^ @GFDL-1.1-no-invariants-or-later@, GNU Free Documentation License v1.1 or later - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Furuseth -- ^ @Furuseth@, Furuseth License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Fwlw -- ^ @fwlw@, fwlw License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Game_Programming_Gems -- ^ @Game-Programming-Gems@, Game Programming Gems License, SPDX License List 3.26, SPDX License List 3.28
+    | GCR_docs -- ^ @GCR-docs@, Gnome GCR Documentation License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GD -- ^ @GD@, GD License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Generic_xts -- ^ @generic-xts@, Generic XTS License, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_1_invariants_only -- ^ @GFDL-1.1-invariants-only@, GNU Free Documentation License v1.1 only - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_1_invariants_or_later -- ^ @GFDL-1.1-invariants-or-later@, GNU Free Documentation License v1.1 or later - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_1_no_invariants_only -- ^ @GFDL-1.1-no-invariants-only@, GNU Free Documentation License v1.1 only - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_1_no_invariants_or_later -- ^ @GFDL-1.1-no-invariants-or-later@, GNU Free Documentation License v1.1 or later - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | GFDL_1_1_only -- ^ @GFDL-1.1-only@, GNU Free Documentation License v1.1 only
     | GFDL_1_1_or_later -- ^ @GFDL-1.1-or-later@, GNU Free Documentation License v1.1 or later
-    | GFDL_1_2_invariants_only -- ^ @GFDL-1.2-invariants-only@, GNU Free Documentation License v1.2 only - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_2_invariants_or_later -- ^ @GFDL-1.2-invariants-or-later@, GNU Free Documentation License v1.2 or later - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_2_no_invariants_only -- ^ @GFDL-1.2-no-invariants-only@, GNU Free Documentation License v1.2 only - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_2_no_invariants_or_later -- ^ @GFDL-1.2-no-invariants-or-later@, GNU Free Documentation License v1.2 or later - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | GFDL_1_2_invariants_only -- ^ @GFDL-1.2-invariants-only@, GNU Free Documentation License v1.2 only - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_2_invariants_or_later -- ^ @GFDL-1.2-invariants-or-later@, GNU Free Documentation License v1.2 or later - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_2_no_invariants_only -- ^ @GFDL-1.2-no-invariants-only@, GNU Free Documentation License v1.2 only - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_2_no_invariants_or_later -- ^ @GFDL-1.2-no-invariants-or-later@, GNU Free Documentation License v1.2 or later - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | GFDL_1_2_only -- ^ @GFDL-1.2-only@, GNU Free Documentation License v1.2 only
     | GFDL_1_2_or_later -- ^ @GFDL-1.2-or-later@, GNU Free Documentation License v1.2 or later
-    | GFDL_1_3_invariants_only -- ^ @GFDL-1.3-invariants-only@, GNU Free Documentation License v1.3 only - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_3_invariants_or_later -- ^ @GFDL-1.3-invariants-or-later@, GNU Free Documentation License v1.3 or later - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_3_no_invariants_only -- ^ @GFDL-1.3-no-invariants-only@, GNU Free Documentation License v1.3 only - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | GFDL_1_3_no_invariants_or_later -- ^ @GFDL-1.3-no-invariants-or-later@, GNU Free Documentation License v1.3 or later - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | GFDL_1_3_invariants_only -- ^ @GFDL-1.3-invariants-only@, GNU Free Documentation License v1.3 only - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_3_invariants_or_later -- ^ @GFDL-1.3-invariants-or-later@, GNU Free Documentation License v1.3 or later - invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_3_no_invariants_only -- ^ @GFDL-1.3-no-invariants-only@, GNU Free Documentation License v1.3 only - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | GFDL_1_3_no_invariants_or_later -- ^ @GFDL-1.3-no-invariants-or-later@, GNU Free Documentation License v1.3 or later - no invariants, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | GFDL_1_3_only -- ^ @GFDL-1.3-only@, GNU Free Documentation License v1.3 only
     | GFDL_1_3_or_later -- ^ @GFDL-1.3-or-later@, GNU Free Documentation License v1.3 or later
     | Giftware -- ^ @Giftware@, Giftware License
     | GL2PS -- ^ @GL2PS@, GL2PS License
     | Glide -- ^ @Glide@, 3dfx Glide License
     | Glulxe -- ^ @Glulxe@, Glulxe License
-    | GLWTPL -- ^ @GLWTPL@, Good Luck With That Public License, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | GLWTPL -- ^ @GLWTPL@, Good Luck With That Public License, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Gnuplot -- ^ @gnuplot@, gnuplot License
     | GPL_1_0_only -- ^ @GPL-1.0-only@, GNU General Public License v1.0 only
     | GPL_1_0_or_later -- ^ @GPL-1.0-or-later@, GNU General Public License v1.0 or later
@@ -332,72 +342,76 @@ data LicenseId
     | GPL_2_0_or_later -- ^ @GPL-2.0-or-later@, GNU General Public License v2.0 or later
     | GPL_3_0_only -- ^ @GPL-3.0-only@, GNU General Public License v3.0 only
     | GPL_3_0_or_later -- ^ @GPL-3.0-or-later@, GNU General Public License v3.0 or later
-    | Graphics_Gems -- ^ @Graphics-Gems@, Graphics Gems License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Graphics_Gems -- ^ @Graphics-Gems@, Graphics Gems License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | GSOAP_1_3b -- ^ @gSOAP-1.3b@, gSOAP Public License v1.3b
-    | Gtkbook -- ^ @gtkbook@, gtkbook License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Gutmann -- ^ @Gutmann@, Gutmann License, SPDX License List 3.25, SPDX License List 3.26
+    | Gtkbook -- ^ @gtkbook@, gtkbook License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Gutmann -- ^ @Gutmann@, Gutmann License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | HaskellReport -- ^ @HaskellReport@, Haskell Language Report License
-    | HDF5 -- ^ @HDF5@, HDF5 License, SPDX License List 3.26
-    | Hdparm -- ^ @hdparm@, hdparm License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HIDAPI -- ^ @HIDAPI@, HIDAPI License, SPDX License List 3.25, SPDX License List 3.26
-    | Hippocratic_2_1 -- ^ @Hippocratic-2.1@, Hippocratic License 2.1, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HP_1986 -- ^ @HP-1986@, Hewlett-Packard 1986 License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HP_1989 -- ^ @HP-1989@, Hewlett-Packard 1989 License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_DEC -- ^ @HPND-DEC@, Historical Permission Notice and Disclaimer - DEC variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_doc_sell -- ^ @HPND-doc-sell@, Historical Permission Notice and Disclaimer - documentation sell variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_doc -- ^ @HPND-doc@, Historical Permission Notice and Disclaimer - documentation variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_export_US_acknowledgement -- ^ @HPND-export-US-acknowledgement@, HPND with US Government export control warning and acknowledgment, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_export_US_modify -- ^ @HPND-export-US-modify@, HPND with US Government export control warning and modification rqmt, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_export_US -- ^ @HPND-export-US@, HPND with US Government export control warning, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_export2_US -- ^ @HPND-export2-US@, HPND with US Government export control and 2 disclaimers, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_Fenneberg_Livingston -- ^ @HPND-Fenneberg-Livingston@, Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_INRIA_IMAG -- ^ @HPND-INRIA-IMAG@, Historical Permission Notice and Disclaimer    - INRIA-IMAG variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_Intel -- ^ @HPND-Intel@, Historical Permission Notice and Disclaimer - Intel variant, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_Kevlin_Henney -- ^ @HPND-Kevlin-Henney@, Historical Permission Notice and Disclaimer - Kevlin Henney variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_Markus_Kuhn -- ^ @HPND-Markus-Kuhn@, Historical Permission Notice and Disclaimer - Markus Kuhn variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_merchantability_variant -- ^ @HPND-merchantability-variant@, Historical Permission Notice and Disclaimer - merchantability variant, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_MIT_disclaimer -- ^ @HPND-MIT-disclaimer@, Historical Permission Notice and Disclaimer with MIT disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_Netrek -- ^ @HPND-Netrek@, Historical Permission Notice and Disclaimer - Netrek variant, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_Pbmplus -- ^ @HPND-Pbmplus@, Historical Permission Notice and Disclaimer - Pbmplus variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_sell_MIT_disclaimer_xserver -- ^ @HPND-sell-MIT-disclaimer-xserver@, Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_sell_regexpr -- ^ @HPND-sell-regexpr@, Historical Permission Notice and Disclaimer - sell regexpr variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_sell_variant_MIT_disclaimer_rev -- ^ @HPND-sell-variant-MIT-disclaimer-rev@, HPND sell variant with MIT disclaimer - reverse, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_sell_variant_MIT_disclaimer -- ^ @HPND-sell-variant-MIT-disclaimer@, HPND sell variant with MIT disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_sell_variant -- ^ @HPND-sell-variant@, Historical Permission Notice and Disclaimer - sell variant, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_UC_export_US -- ^ @HPND-UC-export-US@, Historical Permission Notice and Disclaimer - University of California, US export warning, SPDX License List 3.25, SPDX License List 3.26
-    | HPND_UC -- ^ @HPND-UC@, Historical Permission Notice and Disclaimer - University of California variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | HDF5 -- ^ @HDF5@, HDF5 License, SPDX License List 3.26, SPDX License List 3.28
+    | Hdparm -- ^ @hdparm@, hdparm License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HIDAPI -- ^ @HIDAPI@, HIDAPI License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Hippocratic_2_1 -- ^ @Hippocratic-2.1@, Hippocratic License 2.1, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HP_1986 -- ^ @HP-1986@, Hewlett-Packard 1986 License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HP_1989 -- ^ @HP-1989@, Hewlett-Packard 1989 License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_DEC -- ^ @HPND-DEC@, Historical Permission Notice and Disclaimer - DEC variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_doc_sell -- ^ @HPND-doc-sell@, Historical Permission Notice and Disclaimer - documentation sell variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_doc -- ^ @HPND-doc@, Historical Permission Notice and Disclaimer - documentation variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_export_US_acknowledgement -- ^ @HPND-export-US-acknowledgement@, HPND with US Government export control warning and acknowledgment, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_export_US_modify -- ^ @HPND-export-US-modify@, HPND with US Government export control warning and modification rqmt, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_export_US -- ^ @HPND-export-US@, HPND with US Government export control warning, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_export2_US -- ^ @HPND-export2-US@, HPND with US Government export control and 2 disclaimers, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_Fenneberg_Livingston -- ^ @HPND-Fenneberg-Livingston@, Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_INRIA_IMAG -- ^ @HPND-INRIA-IMAG@, Historical Permission Notice and Disclaimer    - INRIA-IMAG variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_Intel -- ^ @HPND-Intel@, Historical Permission Notice and Disclaimer - Intel variant, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_Kevlin_Henney -- ^ @HPND-Kevlin-Henney@, Historical Permission Notice and Disclaimer - Kevlin Henney variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_Markus_Kuhn -- ^ @HPND-Markus-Kuhn@, Historical Permission Notice and Disclaimer - Markus Kuhn variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_merchantability_variant -- ^ @HPND-merchantability-variant@, Historical Permission Notice and Disclaimer - merchantability variant, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_MIT_disclaimer -- ^ @HPND-MIT-disclaimer@, Historical Permission Notice and Disclaimer with MIT disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_Netrek -- ^ @HPND-Netrek@, Historical Permission Notice and Disclaimer - Netrek variant, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_Pbmplus -- ^ @HPND-Pbmplus@, Historical Permission Notice and Disclaimer - Pbmplus variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_sell_MIT_disclaimer_xserver -- ^ @HPND-sell-MIT-disclaimer-xserver@, Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_sell_regexpr -- ^ @HPND-sell-regexpr@, Historical Permission Notice and Disclaimer - sell regexpr variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_sell_variant_critical_systems -- ^ @HPND-sell-variant-critical-systems@, HPND - sell variant with safety critical systems clause, SPDX License List 3.28
+    | HPND_sell_variant_MIT_disclaimer_rev -- ^ @HPND-sell-variant-MIT-disclaimer-rev@, HPND sell variant with MIT disclaimer - reverse, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_sell_variant_MIT_disclaimer -- ^ @HPND-sell-variant-MIT-disclaimer@, HPND sell variant with MIT disclaimer, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_sell_variant -- ^ @HPND-sell-variant@, Historical Permission Notice and Disclaimer - sell variant, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_SMC -- ^ @HPND-SMC@, Historical Permission Notice and Disclaimer - SMC variant, SPDX License List 3.28
+    | HPND_UC_export_US -- ^ @HPND-UC-export-US@, Historical Permission Notice and Disclaimer - University of California, US export warning, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | HPND_UC -- ^ @HPND-UC@, Historical Permission Notice and Disclaimer - University of California variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | HPND -- ^ @HPND@, Historical Permission Notice and Disclaimer
-    | HTMLTIDY -- ^ @HTMLTIDY@, HTML Tidy License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | HTMLTIDY -- ^ @HTMLTIDY@, HTML Tidy License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Hyphen_bulgarian -- ^ @hyphen-bulgarian@, hyphen-bulgarian License, SPDX License List 3.28
     | IBM_pibs -- ^ @IBM-pibs@, IBM PowerPC Initialization and Boot Software
     | ICU -- ^ @ICU@, ICU License
-    | IEC_Code_Components_EULA -- ^ @IEC-Code-Components-EULA@, IEC    Code Components End-user licence agreement, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | IJG_short -- ^ @IJG-short@, Independent JPEG Group License - short, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | IEC_Code_Components_EULA -- ^ @IEC-Code-Components-EULA@, IEC    Code Components End-user licence agreement, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | IJG_short -- ^ @IJG-short@, Independent JPEG Group License - short, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | IJG -- ^ @IJG@, Independent JPEG Group License
     | ImageMagick -- ^ @ImageMagick@, ImageMagick License
     | IMatix -- ^ @iMatix@, iMatix Standard Function Library Agreement
     | Imlib2 -- ^ @Imlib2@, Imlib2 License
     | Info_ZIP -- ^ @Info-ZIP@, Info-ZIP License
-    | Inner_Net_2_0 -- ^ @Inner-Net-2.0@, Inner Net License v2.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | InnoSetup -- ^ @InnoSetup@, Inno Setup License, SPDX License List 3.26
+    | Inner_Net_2_0 -- ^ @Inner-Net-2.0@, Inner Net License v2.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | InnoSetup -- ^ @InnoSetup@, Inno Setup License, SPDX License List 3.26, SPDX License List 3.28
     | Intel_ACPI -- ^ @Intel-ACPI@, Intel ACPI Software License Agreement
     | Intel -- ^ @Intel@, Intel Open Source License
     | Interbase_1_0 -- ^ @Interbase-1.0@, Interbase Public License v1.0
     | IPA -- ^ @IPA@, IPA Font License
     | IPL_1_0 -- ^ @IPL-1.0@, IBM Public License v1.0
-    | ISC_Veillard -- ^ @ISC-Veillard@, ISC Veillard variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | ISC_Veillard -- ^ @ISC-Veillard@, ISC Veillard variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | ISC -- ^ @ISC@, ISC License
-    | Jam -- ^ @Jam@, Jam License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | ISO_permission -- ^ @ISO-permission@, ISO permission notice, SPDX License List 3.28
+    | Jam -- ^ @Jam@, Jam License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | JasPer_2_0 -- ^ @JasPer-2.0@, JasPer License
-    | Jove -- ^ @jove@, Jove License, SPDX License List 3.26
-    | JPL_image -- ^ @JPL-image@, JPL Image Use Policy, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | JPNIC -- ^ @JPNIC@, Japan Network Information Center License, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Jove -- ^ @jove@, Jove License, SPDX License List 3.26, SPDX License List 3.28
+    | JPL_image -- ^ @JPL-image@, JPL Image Use Policy, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | JPNIC -- ^ @JPNIC@, Japan Network Information Center License, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | JSON -- ^ @JSON@, JSON License
-    | Kastrup -- ^ @Kastrup@, Kastrup License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Kazlib -- ^ @Kazlib@, Kazlib License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Knuth_CTAN -- ^ @Knuth-CTAN@, Knuth CTAN License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Kastrup -- ^ @Kastrup@, Kastrup License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Kazlib -- ^ @Kazlib@, Kazlib License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Knuth_CTAN -- ^ @Knuth-CTAN@, Knuth CTAN License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | LAL_1_2 -- ^ @LAL-1.2@, Licence Art Libre 1.2
     | LAL_1_3 -- ^ @LAL-1.3@, Licence Art Libre 1.3
-    | Latex2e_translated_notice -- ^ @Latex2e-translated-notice@, Latex2e with translated notice permission, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Latex2e_translated_notice -- ^ @Latex2e-translated-notice@, Latex2e with translated notice permission, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Latex2e -- ^ @Latex2e@, Latex2e License
     | Leptonica -- ^ @Leptonica@, Leptonica License
     | LGPL_2_0_only -- ^ @LGPL-2.0-only@, GNU Library General Public License v2 only
@@ -407,22 +421,22 @@ data LicenseId
     | LGPL_3_0_only -- ^ @LGPL-3.0-only@, GNU Lesser General Public License v3.0 only
     | LGPL_3_0_or_later -- ^ @LGPL-3.0-or-later@, GNU Lesser General Public License v3.0 or later
     | LGPLLR -- ^ @LGPLLR@, Lesser General Public License For Linguistic Resources
-    | Libpng_1_6_35 -- ^ @libpng-1.6.35@, PNG Reference Library License v1 (for libpng 0.5 through 1.6.35, SPDX License List 3.26
-    | Libpng_2_0 -- ^ @libpng-2.0@, PNG Reference Library version 2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Libpng_1_6_35 -- ^ @libpng-1.6.35@, PNG Reference Library License v1 (for libpng 0.5 through 1.6.35), SPDX License List 3.26, SPDX License List 3.28
+    | Libpng_2_0 -- ^ @libpng-2.0@, PNG Reference Library version 2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Libpng -- ^ @Libpng@, libpng License
-    | Libselinux_1_0 -- ^ @libselinux-1.0@, libselinux public domain notice, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Libselinux_1_0 -- ^ @libselinux-1.0@, libselinux public domain notice, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Libtiff -- ^ @libtiff@, libtiff License
-    | Libutil_David_Nugent -- ^ @libutil-David-Nugent@, libutil David Nugent License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Libutil_David_Nugent -- ^ @libutil-David-Nugent@, libutil David Nugent License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | LiLiQ_P_1_1 -- ^ @LiLiQ-P-1.1@, Licence Libre du Québec – Permissive version 1.1
     | LiLiQ_R_1_1 -- ^ @LiLiQ-R-1.1@, Licence Libre du Québec – Réciprocité version 1.1
     | LiLiQ_Rplus_1_1 -- ^ @LiLiQ-Rplus-1.1@, Licence Libre du Québec – Réciprocité forte version 1.1
-    | Linux_man_pages_1_para -- ^ @Linux-man-pages-1-para@, Linux man-pages - 1 paragraph, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Linux_man_pages_copyleft_2_para -- ^ @Linux-man-pages-copyleft-2-para@, Linux man-pages Copyleft - 2 paragraphs, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Linux_man_pages_copyleft_var -- ^ @Linux-man-pages-copyleft-var@, Linux man-pages Copyleft Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Linux_man_pages_copyleft -- ^ @Linux-man-pages-copyleft@, Linux man-pages Copyleft, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Linux_OpenIB -- ^ @Linux-OpenIB@, Linux Kernel Variant of OpenIB.org license, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | LOOP -- ^ @LOOP@, Common Lisp LOOP License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | LPD_document -- ^ @LPD-document@, LPD Documentation License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Linux_man_pages_1_para -- ^ @Linux-man-pages-1-para@, Linux man-pages - 1 paragraph, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Linux_man_pages_copyleft_2_para -- ^ @Linux-man-pages-copyleft-2-para@, Linux man-pages Copyleft - 2 paragraphs, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Linux_man_pages_copyleft_var -- ^ @Linux-man-pages-copyleft-var@, Linux man-pages Copyleft Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Linux_man_pages_copyleft -- ^ @Linux-man-pages-copyleft@, Linux man-pages Copyleft, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Linux_OpenIB -- ^ @Linux-OpenIB@, Linux Kernel Variant of OpenIB.org license, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | LOOP -- ^ @LOOP@, Common Lisp LOOP License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | LPD_document -- ^ @LPD-document@, LPD Documentation License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | LPL_1_02 -- ^ @LPL-1.02@, Lucent Public License v1.02
     | LPL_1_0 -- ^ @LPL-1.0@, Lucent Public License Version 1.0
     | LPPL_1_0 -- ^ @LPPL-1.0@, LaTeX Project Public License v1.0
@@ -430,73 +444,76 @@ data LicenseId
     | LPPL_1_2 -- ^ @LPPL-1.2@, LaTeX Project Public License v1.2
     | LPPL_1_3a -- ^ @LPPL-1.3a@, LaTeX Project Public License v1.3a
     | LPPL_1_3c -- ^ @LPPL-1.3c@, LaTeX Project Public License v1.3c
-    | Lsof -- ^ @lsof@, lsof License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Lucida_Bitmap_Fonts -- ^ @Lucida-Bitmap-Fonts@, Lucida Bitmap Fonts License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | LZMA_SDK_9_11_to_9_20 -- ^ @LZMA-SDK-9.11-to-9.20@, LZMA SDK License (versions 9.11 to 9.20), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | LZMA_SDK_9_22 -- ^ @LZMA-SDK-9.22@, LZMA SDK License (versions 9.22 and beyond), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Mackerras_3_Clause_acknowledgment -- ^ @Mackerras-3-Clause-acknowledgment@, Mackerras 3-Clause - acknowledgment variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Mackerras_3_Clause -- ^ @Mackerras-3-Clause@, Mackerras 3-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Magaz -- ^ @magaz@, magaz License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Mailprio -- ^ @mailprio@, mailprio License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Lsof -- ^ @lsof@, lsof License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Lucida_Bitmap_Fonts -- ^ @Lucida-Bitmap-Fonts@, Lucida Bitmap Fonts License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | LZMA_SDK_9_11_to_9_20 -- ^ @LZMA-SDK-9.11-to-9.20@, LZMA SDK License (versions 9.11 to 9.20), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | LZMA_SDK_9_22 -- ^ @LZMA-SDK-9.22@, LZMA SDK License (versions 9.22 and beyond), SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Mackerras_3_Clause_acknowledgment -- ^ @Mackerras-3-Clause-acknowledgment@, Mackerras 3-Clause - acknowledgment variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Mackerras_3_Clause -- ^ @Mackerras-3-Clause@, Mackerras 3-Clause License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Magaz -- ^ @magaz@, magaz License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Mailprio -- ^ @mailprio@, mailprio License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | MakeIndex -- ^ @MakeIndex@, MakeIndex License
-    | Man2html -- ^ @man2html@, man2html License, SPDX License List 3.26
-    | Martin_Birgmeier -- ^ @Martin-Birgmeier@, Martin Birgmeier License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | McPhee_slideshow -- ^ @McPhee-slideshow@, McPhee Slideshow License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Metamail -- ^ @metamail@, metamail License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Minpack -- ^ @Minpack@, Minpack License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | MIPS -- ^ @MIPS@, MIPS License, SPDX License List 3.26
+    | Man2html -- ^ @man2html@, man2html License, SPDX License List 3.26, SPDX License List 3.28
+    | Martin_Birgmeier -- ^ @Martin-Birgmeier@, Martin Birgmeier License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | McPhee_slideshow -- ^ @McPhee-slideshow@, McPhee Slideshow License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Metamail -- ^ @metamail@, metamail License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Minpack -- ^ @Minpack@, Minpack License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MIPS -- ^ @MIPS@, MIPS License, SPDX License List 3.26, SPDX License List 3.28
     | MirOS -- ^ @MirOS@, The MirOS Licence
-    | MIT_0 -- ^ @MIT-0@, MIT No Attribution, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | MIT_0 -- ^ @MIT-0@, MIT No Attribution, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | MIT_advertising -- ^ @MIT-advertising@, Enlightenment License (e16)
-    | MIT_Click -- ^ @MIT-Click@, MIT Click License, SPDX License List 3.26
+    | MIT_Click -- ^ @MIT-Click@, MIT Click License, SPDX License List 3.26, SPDX License List 3.28
     | MIT_CMU -- ^ @MIT-CMU@, CMU License
     | MIT_enna -- ^ @MIT-enna@, enna License
     | MIT_feh -- ^ @MIT-feh@, feh License
-    | MIT_Festival -- ^ @MIT-Festival@, MIT Festival Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | MIT_Khronos_old -- ^ @MIT-Khronos-old@, MIT Khronos - old variant, SPDX License List 3.25, SPDX License List 3.26
-    | MIT_Modern_Variant -- ^ @MIT-Modern-Variant@, MIT License Modern Variant, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | MIT_open_group -- ^ @MIT-open-group@, MIT Open Group variant, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | MIT_testregex -- ^ @MIT-testregex@, MIT testregex Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | MIT_Wu -- ^ @MIT-Wu@, MIT Tom Wu Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | MIT_Festival -- ^ @MIT-Festival@, MIT Festival Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MIT_Khronos_old -- ^ @MIT-Khronos-old@, MIT Khronos - old variant, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MIT_Modern_Variant -- ^ @MIT-Modern-Variant@, MIT License Modern Variant, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MIT_open_group -- ^ @MIT-open-group@, MIT Open Group variant, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MIT_STK -- ^ @MIT-STK@, MIT-STK License, SPDX License List 3.28
+    | MIT_testregex -- ^ @MIT-testregex@, MIT testregex Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MIT_Wu -- ^ @MIT-Wu@, MIT Tom Wu Variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | MITNFA -- ^ @MITNFA@, MIT +no-false-attribs license
     | MIT -- ^ @MIT@, MIT License
-    | MMIXware -- ^ @MMIXware@, MMIXware License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | MMIXware -- ^ @MMIXware@, MMIXware License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MMPL_1_0_1 -- ^ @MMPL-1.0.1@, Minecraft Mod Public License v1.0.1, SPDX License List 3.28
     | Motosoto -- ^ @Motosoto@, Motosoto License
-    | MPEG_SSG -- ^ @MPEG-SSG@, MPEG Software Simulation, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Mpi_permissive -- ^ @mpi-permissive@, mpi Permissive License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | MPEG_SSG -- ^ @MPEG-SSG@, MPEG Software Simulation, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Mpi_permissive -- ^ @mpi-permissive@, mpi Permissive License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Mpich2 -- ^ @mpich2@, mpich2 License
     | MPL_1_0 -- ^ @MPL-1.0@, Mozilla Public License 1.0
     | MPL_1_1 -- ^ @MPL-1.1@, Mozilla Public License 1.1
     | MPL_2_0_no_copyleft_exception -- ^ @MPL-2.0-no-copyleft-exception@, Mozilla Public License 2.0 (no copyleft exception)
     | MPL_2_0 -- ^ @MPL-2.0@, Mozilla Public License 2.0
-    | Mplus -- ^ @mplus@, mplus Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | MS_LPL -- ^ @MS-LPL@, Microsoft Limited Public License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Mplus -- ^ @mplus@, mplus Font License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MS_LPL -- ^ @MS-LPL@, Microsoft Limited Public License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | MS_PL -- ^ @MS-PL@, Microsoft Public License
     | MS_RL -- ^ @MS-RL@, Microsoft Reciprocal License
     | MTLL -- ^ @MTLL@, Matrix Template Library License
-    | MulanPSL_1_0 -- ^ @MulanPSL-1.0@, Mulan Permissive Software License, Version 1, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | MulanPSL_2_0 -- ^ @MulanPSL-2.0@, Mulan Permissive Software License, Version 2, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | MulanPSL_1_0 -- ^ @MulanPSL-1.0@, Mulan Permissive Software License, Version 1, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | MulanPSL_2_0 -- ^ @MulanPSL-2.0@, Mulan Permissive Software License, Version 2, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Multics -- ^ @Multics@, Multics License
     | Mup -- ^ @Mup@, Mup License
-    | NAIST_2003 -- ^ @NAIST-2003@, Nara Institute of Science and Technology License (2003), SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | NAIST_2003 -- ^ @NAIST-2003@, Nara Institute of Science and Technology License (2003), SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | NASA_1_3 -- ^ @NASA-1.3@, NASA Open Source Agreement 1.3
     | Naumen -- ^ @Naumen@, Naumen Public License
     | NBPL_1_0 -- ^ @NBPL-1.0@, Net Boolean Public License v1
-    | NCBI_PD -- ^ @NCBI-PD@, NCBI Public Domain Notice, SPDX License List 3.25, SPDX License List 3.26
-    | NCGL_UK_2_0 -- ^ @NCGL-UK-2.0@, Non-Commercial Government Licence, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | NCL -- ^ @NCL@, NCL Source Code License, SPDX License List 3.25, SPDX License List 3.26
+    | NCBI_PD -- ^ @NCBI-PD@, NCBI Public Domain Notice, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | NCGL_UK_2_0 -- ^ @NCGL-UK-2.0@, Non-Commercial Government Licence, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | NCL -- ^ @NCL@, NCL Source Code License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | NCSA -- ^ @NCSA@, University of Illinois/NCSA Open Source License
     | Net_SNMP -- ^ @Net-SNMP@, Net-SNMP License, SPDX License List 3.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23
     | NetCDF -- ^ @NetCDF@, NetCDF license
     | Newsletr -- ^ @Newsletr@, Newsletr License
     | NGPL -- ^ @NGPL@, Nethack General Public License
-    | Ngrep -- ^ @ngrep@, ngrep License, SPDX License List 3.26
-    | NICTA_1_0 -- ^ @NICTA-1.0@, NICTA Public Software License, Version 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | NIST_PD_fallback -- ^ @NIST-PD-fallback@, NIST Public Domain Notice with license fallback, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | NIST_PD -- ^ @NIST-PD@, NIST Public Domain Notice, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | NIST_Software -- ^ @NIST-Software@, NIST Software License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Ngrep -- ^ @ngrep@, ngrep License, SPDX License List 3.26, SPDX License List 3.28
+    | NICTA_1_0 -- ^ @NICTA-1.0@, NICTA Public Software License, Version 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | NIST_PD_fallback -- ^ @NIST-PD-fallback@, NIST Public Domain Notice with license fallback, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | NIST_PD_TNT -- ^ @NIST-PD-TNT@, NIST    Public Domain Notice TNT variant, SPDX License List 3.28
+    | NIST_PD -- ^ @NIST-PD@, NIST Public Domain Notice, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | NIST_Software -- ^ @NIST-Software@, NIST Software License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | NLOD_1_0 -- ^ @NLOD-1.0@, Norwegian Licence for Open Government Data (NLOD) 1.0
-    | NLOD_2_0 -- ^ @NLOD-2.0@, Norwegian Licence for Open Government Data (NLOD) 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | NLOD_2_0 -- ^ @NLOD-2.0@, Norwegian Licence for Open Government Data (NLOD) 2.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | NLPL -- ^ @NLPL@, No Limit Public License
     | Nokia -- ^ @Nokia@, Nokia Open Source License
     | NOSL -- ^ @NOSL@, Netizen Open Source License
@@ -505,28 +522,28 @@ data LicenseId
     | NPL_1_1 -- ^ @NPL-1.1@, Netscape Public License v1.1
     | NPOSL_3_0 -- ^ @NPOSL-3.0@, Non-Profit Open Software License 3.0
     | NRL -- ^ @NRL@, NRL License
-    | NTIA_PD -- ^ @NTIA-PD@, NTIA Public Domain Notice, SPDX License List 3.26
-    | NTP_0 -- ^ @NTP-0@, NTP No Attribution, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | NTIA_PD -- ^ @NTIA-PD@, NTIA Public Domain Notice, SPDX License List 3.26, SPDX License List 3.28
+    | NTP_0 -- ^ @NTP-0@, NTP No Attribution, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | NTP -- ^ @NTP@, NTP License
-    | O_UDA_1_0 -- ^ @O-UDA-1.0@, Open Use of Data Agreement v1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OAR -- ^ @OAR@, OAR License, SPDX License List 3.25, SPDX License List 3.26
+    | O_UDA_1_0 -- ^ @O-UDA-1.0@, Open Use of Data Agreement v1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OAR -- ^ @OAR@, OAR License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OCCT_PL -- ^ @OCCT-PL@, Open CASCADE Technology Public License
     | OCLC_2_0 -- ^ @OCLC-2.0@, OCLC Research Public License 2.0
     | ODbL_1_0 -- ^ @ODbL-1.0@, Open Data Commons Open Database License v1.0
-    | ODC_By_1_0 -- ^ @ODC-By-1.0@, Open Data Commons Attribution License v1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OFFIS -- ^ @OFFIS@, OFFIS License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OFL_1_0_no_RFN -- ^ @OFL-1.0-no-RFN@, SIL Open Font License 1.0 with no Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OFL_1_0_RFN -- ^ @OFL-1.0-RFN@, SIL Open Font License 1.0 with Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | ODC_By_1_0 -- ^ @ODC-By-1.0@, Open Data Commons Attribution License v1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OFFIS -- ^ @OFFIS@, OFFIS License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OFL_1_0_no_RFN -- ^ @OFL-1.0-no-RFN@, SIL Open Font License 1.0 with no Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OFL_1_0_RFN -- ^ @OFL-1.0-RFN@, SIL Open Font License 1.0 with Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OFL_1_0 -- ^ @OFL-1.0@, SIL Open Font License 1.0
-    | OFL_1_1_no_RFN -- ^ @OFL-1.1-no-RFN@, SIL Open Font License 1.1 with no Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OFL_1_1_RFN -- ^ @OFL-1.1-RFN@, SIL Open Font License 1.1 with Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OFL_1_1_no_RFN -- ^ @OFL-1.1-no-RFN@, SIL Open Font License 1.1 with no Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OFL_1_1_RFN -- ^ @OFL-1.1-RFN@, SIL Open Font License 1.1 with Reserved Font Name, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OFL_1_1 -- ^ @OFL-1.1@, SIL Open Font License 1.1
-    | OGC_1_0 -- ^ @OGC-1.0@, OGC Software License, Version 1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OGDL_Taiwan_1_0 -- ^ @OGDL-Taiwan-1.0@, Taiwan Open Government Data License, version 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OGL_Canada_2_0 -- ^ @OGL-Canada-2.0@, Open Government Licence - Canada, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OGL_UK_1_0 -- ^ @OGL-UK-1.0@, Open Government Licence v1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OGL_UK_2_0 -- ^ @OGL-UK-2.0@, Open Government Licence v2.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OGL_UK_3_0 -- ^ @OGL-UK-3.0@, Open Government Licence v3.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OGC_1_0 -- ^ @OGC-1.0@, OGC Software License, Version 1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OGDL_Taiwan_1_0 -- ^ @OGDL-Taiwan-1.0@, Taiwan Open Government Data License, version 1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OGL_Canada_2_0 -- ^ @OGL-Canada-2.0@, Open Government Licence - Canada, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OGL_UK_1_0 -- ^ @OGL-UK-1.0@, Open Government Licence v1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OGL_UK_2_0 -- ^ @OGL-UK-2.0@, Open Government Licence v2.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OGL_UK_3_0 -- ^ @OGL-UK-3.0@, Open Government Licence v3.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OGTSL -- ^ @OGTSL@, Open Group Test Suite License
     | OLDAP_1_1 -- ^ @OLDAP-1.1@, Open LDAP Public License v1.1
     | OLDAP_1_2 -- ^ @OLDAP-1.2@, Open LDAP Public License v1.2
@@ -544,45 +561,49 @@ data LicenseId
     | OLDAP_2_6 -- ^ @OLDAP-2.6@, Open LDAP Public License v2.6
     | OLDAP_2_7 -- ^ @OLDAP-2.7@, Open LDAP Public License v2.7
     | OLDAP_2_8 -- ^ @OLDAP-2.8@, Open LDAP Public License v2.8
-    | OLFL_1_3 -- ^ @OLFL-1.3@, Open Logistics Foundation License Version 1.3, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OLFL_1_3 -- ^ @OLFL-1.3@, Open Logistics Foundation License Version 1.3, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OML -- ^ @OML@, Open Market License
-    | OpenPBS_2_3 -- ^ @OpenPBS-2.3@, OpenPBS v2.3 Software License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OpenSSL_standalone -- ^ @OpenSSL-standalone@, OpenSSL License - standalone, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OpenMDW_1_0 -- ^ @OpenMDW-1.0@, OpenMDW License Agreement v1.0, SPDX License List 3.28
+    | OpenPBS_2_3 -- ^ @OpenPBS-2.3@, OpenPBS v2.3 Software License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OpenSSL_standalone -- ^ @OpenSSL-standalone@, OpenSSL License - standalone, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OpenSSL -- ^ @OpenSSL@, OpenSSL License
-    | OpenVision -- ^ @OpenVision@, OpenVision License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OpenVision -- ^ @OpenVision@, OpenVision License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | OPL_1_0 -- ^ @OPL-1.0@, Open Public License v1.0
-    | OPL_UK_3_0 -- ^ @OPL-UK-3.0@, United    Kingdom Open Parliament Licence v3.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | OPUBL_1_0 -- ^ @OPUBL-1.0@, Open Publication License v1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OPL_UK_3_0 -- ^ @OPL-UK-3.0@, United    Kingdom Open Parliament Licence v3.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OPUBL_1_0 -- ^ @OPUBL-1.0@, Open Publication License v1.0, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | OSC_1_0 -- ^ @OSC-1.0@, OSC License 1.0, SPDX License List 3.28
     | OSET_PL_2_1 -- ^ @OSET-PL-2.1@, OSET Public License version 2.1
     | OSL_1_0 -- ^ @OSL-1.0@, Open Software License 1.0
     | OSL_1_1 -- ^ @OSL-1.1@, Open Software License 1.1
     | OSL_2_0 -- ^ @OSL-2.0@, Open Software License 2.0
     | OSL_2_1 -- ^ @OSL-2.1@, Open Software License 2.1
     | OSL_3_0 -- ^ @OSL-3.0@, Open Software License 3.0
-    | PADL -- ^ @PADL@, PADL License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Parity_6_0_0 -- ^ @Parity-6.0.0@, The Parity Public License 6.0.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Parity_7_0_0 -- ^ @Parity-7.0.0@, The Parity Public License 7.0.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | OSSP -- ^ @OSSP@, OSSP License, SPDX License List 3.28
+    | PADL -- ^ @PADL@, PADL License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | ParaType_Free_Font_1_3 -- ^ @ParaType-Free-Font-1.3@, ParaType Free Font Licensing Agreement v1.3, SPDX License List 3.28
+    | Parity_6_0_0 -- ^ @Parity-6.0.0@, The Parity Public License 6.0.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Parity_7_0_0 -- ^ @Parity-7.0.0@, The Parity Public License 7.0.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | PDDL_1_0 -- ^ @PDDL-1.0@, Open Data Commons Public Domain Dedication & License 1.0
     | PHP_3_01 -- ^ @PHP-3.01@, PHP License v3.01
     | PHP_3_0 -- ^ @PHP-3.0@, PHP License v3.0
-    | Pixar -- ^ @Pixar@, Pixar License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Pkgconf -- ^ @pkgconf@, pkgconf License, SPDX License List 3.25, SPDX License List 3.26
+    | Pixar -- ^ @Pixar@, Pixar License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Pkgconf -- ^ @pkgconf@, pkgconf License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Plexus -- ^ @Plexus@, Plexus Classworlds License
-    | Pnmstitch -- ^ @pnmstitch@, pnmstitch License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | PolyForm_Noncommercial_1_0_0 -- ^ @PolyForm-Noncommercial-1.0.0@, PolyForm Noncommercial License 1.0.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | PolyForm_Small_Business_1_0_0 -- ^ @PolyForm-Small-Business-1.0.0@, PolyForm Small Business License 1.0.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Pnmstitch -- ^ @pnmstitch@, pnmstitch License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | PolyForm_Noncommercial_1_0_0 -- ^ @PolyForm-Noncommercial-1.0.0@, PolyForm Noncommercial License 1.0.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | PolyForm_Small_Business_1_0_0 -- ^ @PolyForm-Small-Business-1.0.0@, PolyForm Small Business License 1.0.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | PostgreSQL -- ^ @PostgreSQL@, PostgreSQL License
-    | PPL -- ^ @PPL@, Peer Production License, SPDX License List 3.25, SPDX License List 3.26
-    | PSF_2_0 -- ^ @PSF-2.0@, Python Software Foundation License 2.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | PPL -- ^ @PPL@, Peer Production License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | PSF_2_0 -- ^ @PSF-2.0@, Python Software Foundation License 2.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Psfrag -- ^ @psfrag@, psfrag License
     | Psutils -- ^ @psutils@, psutils License
-    | Python_2_0_1 -- ^ @Python-2.0.1@, Python License 2.0.1, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Python_2_0_1 -- ^ @Python-2.0.1@, Python License 2.0.1, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Python_2_0 -- ^ @Python-2.0@, Python License 2.0
-    | Python_ldap -- ^ @python-ldap@, Python ldap License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Python_ldap -- ^ @python-ldap@, Python ldap License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Qhull -- ^ @Qhull@, Qhull License
-    | QPL_1_0_INRIA_2004 -- ^ @QPL-1.0-INRIA-2004@, Q Public License 1.0 - INRIA 2004 variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | QPL_1_0_INRIA_2004 -- ^ @QPL-1.0-INRIA-2004@, Q Public License 1.0 - INRIA 2004 variant, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | QPL_1_0 -- ^ @QPL-1.0@, Q Public License 1.0
-    | Radvd -- ^ @radvd@, radvd License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Radvd -- ^ @radvd@, radvd License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Rdisc -- ^ @Rdisc@, Rdisc License
     | RHeCos_1_1 -- ^ @RHeCos-1.1@, Red Hat eCos Public License v1.1
     | RPL_1_1 -- ^ @RPL-1.1@, Reciprocal Public License 1.1
@@ -590,114 +611,122 @@ data LicenseId
     | RPSL_1_0 -- ^ @RPSL-1.0@, RealNetworks Public Source License v1.0
     | RSA_MD -- ^ @RSA-MD@, RSA Message-Digest License
     | RSCPL -- ^ @RSCPL@, Ricoh Source Code Public License
-    | Ruby_pty -- ^ @Ruby-pty@, Ruby pty extension license, SPDX License List 3.25, SPDX License List 3.26
+    | Ruby_pty -- ^ @Ruby-pty@, Ruby pty extension license, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Ruby -- ^ @Ruby@, Ruby License
-    | SAX_PD_2_0 -- ^ @SAX-PD-2.0@, Sax Public Domain Notice 2.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | SAX_PD_2_0 -- ^ @SAX-PD-2.0@, Sax Public Domain Notice 2.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | SAX_PD -- ^ @SAX-PD@, Sax Public Domain Notice
     | Saxpath -- ^ @Saxpath@, Saxpath License
     | SCEA -- ^ @SCEA@, SCEA Shared Source License
-    | SchemeReport -- ^ @SchemeReport@, Scheme Language Report License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Sendmail_8_23 -- ^ @Sendmail-8.23@, Sendmail License 8.23, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Sendmail_Open_Source_1_1 -- ^ @Sendmail-Open-Source-1.1@, Sendmail Open Source License v1.1, SPDX License List 3.26
+    | SchemeReport -- ^ @SchemeReport@, Scheme Language Report License, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Sendmail_8_23 -- ^ @Sendmail-8.23@, Sendmail License 8.23, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Sendmail_Open_Source_1_1 -- ^ @Sendmail-Open-Source-1.1@, Sendmail Open Source License v1.1, SPDX License List 3.26, SPDX License List 3.28
     | Sendmail -- ^ @Sendmail@, Sendmail License
     | SGI_B_1_0 -- ^ @SGI-B-1.0@, SGI Free Software License B v1.0
     | SGI_B_1_1 -- ^ @SGI-B-1.1@, SGI Free Software License B v1.1
     | SGI_B_2_0 -- ^ @SGI-B-2.0@, SGI Free Software License B v2.0
-    | SGI_OpenGL -- ^ @SGI-OpenGL@, SGI OpenGL License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SGP4 -- ^ @SGP4@, SGP4 Permission Notice, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SHL_0_51 -- ^ @SHL-0.51@, Solderpad Hardware License, Version 0.51, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SHL_0_5 -- ^ @SHL-0.5@, Solderpad Hardware License v0.5, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | SGI_OpenGL -- ^ @SGI-OpenGL@, SGI OpenGL License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SGMLUG_PM -- ^ @SGMLUG-PM@, SGMLUG Parser Materials License, SPDX License List 3.28
+    | SGP4 -- ^ @SGP4@, SGP4 Permission Notice, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SHL_0_51 -- ^ @SHL-0.51@, Solderpad Hardware License, Version 0.51, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SHL_0_5 -- ^ @SHL-0.5@, Solderpad Hardware License v0.5, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | SimPL_2_0 -- ^ @SimPL-2.0@, Simple Public License 2.0
     | SISSL_1_2 -- ^ @SISSL-1.2@, Sun Industry Standards Source License v1.2
     | SISSL -- ^ @SISSL@, Sun Industry Standards Source License v1.1
     | Sleepycat -- ^ @Sleepycat@, Sleepycat License
-    | SL -- ^ @SL@, SL License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SMAIL_GPL -- ^ @SMAIL-GPL@, SMAIL General Public License, SPDX License List 3.26
+    | SL -- ^ @SL@, SL License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SMAIL_GPL -- ^ @SMAIL-GPL@, SMAIL General Public License, SPDX License List 3.26, SPDX License List 3.28
     | SMLNJ -- ^ @SMLNJ@, Standard ML of New Jersey License
     | SMPPL -- ^ @SMPPL@, Secure Messaging Protocol Public License
     | SNIA -- ^ @SNIA@, SNIA Public License 1.1
-    | Snprintf -- ^ @snprintf@, snprintf License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SOFA -- ^ @SOFA@, SOFA Software License, SPDX License List 3.26
-    | SoftSurfer -- ^ @softSurfer@, softSurfer License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Soundex -- ^ @Soundex@, Soundex License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Snprintf -- ^ @snprintf@, snprintf License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SOFA -- ^ @SOFA@, SOFA Software License, SPDX License List 3.26, SPDX License List 3.28
+    | SoftSurfer -- ^ @softSurfer@, softSurfer License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Soundex -- ^ @Soundex@, Soundex License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Spencer_86 -- ^ @Spencer-86@, Spencer License 86
     | Spencer_94 -- ^ @Spencer-94@, Spencer License 94
     | Spencer_99 -- ^ @Spencer-99@, Spencer License 99
     | SPL_1_0 -- ^ @SPL-1.0@, Sun Public License v1.0
-    | Ssh_keyscan -- ^ @ssh-keyscan@, ssh-keyscan License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SSH_OpenSSH -- ^ @SSH-OpenSSH@, SSH OpenSSH license, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SSH_short -- ^ @SSH-short@, SSH short notice, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SSLeay_standalone -- ^ @SSLeay-standalone@, SSLeay License - standalone, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SSPL_1_0 -- ^ @SSPL-1.0@, Server Side Public License, v 1, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Ssh_keyscan -- ^ @ssh-keyscan@, ssh-keyscan License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SSH_OpenSSH -- ^ @SSH-OpenSSH@, SSH OpenSSH license, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SSH_short -- ^ @SSH-short@, SSH short notice, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SSLeay_standalone -- ^ @SSLeay-standalone@, SSLeay License - standalone, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SSPL_1_0 -- ^ @SSPL-1.0@, Server Side Public License, v 1, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | SugarCRM_1_1_3 -- ^ @SugarCRM-1.1.3@, SugarCRM Public License v1.1.3
-    | Sun_PPP_2000 -- ^ @Sun-PPP-2000@, Sun PPP License (2000), SPDX License List 3.25, SPDX License List 3.26
-    | Sun_PPP -- ^ @Sun-PPP@, Sun PPP License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | SunPro -- ^ @SunPro@, SunPro License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | SUL_1_0 -- ^ @SUL-1.0@, Sustainable Use License v1.0, SPDX License List 3.28
+    | Sun_PPP_2000 -- ^ @Sun-PPP-2000@, Sun PPP License (2000), SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Sun_PPP -- ^ @Sun-PPP@, Sun PPP License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | SunPro -- ^ @SunPro@, SunPro License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | SWL -- ^ @SWL@, Scheme Widget Library (SWL) Software License Agreement
-    | Swrule -- ^ @swrule@, swrule License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Symlinks -- ^ @Symlinks@, Symlinks License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | TAPR_OHL_1_0 -- ^ @TAPR-OHL-1.0@, TAPR Open Hardware License v1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Swrule -- ^ @swrule@, swrule License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Symlinks -- ^ @Symlinks@, Symlinks License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | TAPR_OHL_1_0 -- ^ @TAPR-OHL-1.0@, TAPR Open Hardware License v1.0, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | TCL -- ^ @TCL@, TCL/TK License
     | TCP_wrappers -- ^ @TCP-wrappers@, TCP Wrappers License
-    | TermReadKey -- ^ @TermReadKey@, TermReadKey License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | TGPPL_1_0 -- ^ @TGPPL-1.0@, Transitive Grace Period Public Licence 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | ThirdEye -- ^ @ThirdEye@, ThirdEye License, SPDX License List 3.26
-    | Threeparttable -- ^ @threeparttable@, threeparttable License, SPDX License List 3.25, SPDX License List 3.26
+    | TekHVC -- ^ @TekHVC@, TekHVC License, SPDX License List 3.28
+    | TermReadKey -- ^ @TermReadKey@, TermReadKey License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | TGPPL_1_0 -- ^ @TGPPL-1.0@, Transitive Grace Period Public Licence 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | ThirdEye -- ^ @ThirdEye@, ThirdEye License, SPDX License List 3.26, SPDX License List 3.28
+    | Threeparttable -- ^ @threeparttable@, threeparttable License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | TMate -- ^ @TMate@, TMate Open Source License
     | TORQUE_1_1 -- ^ @TORQUE-1.1@, TORQUE v2.5+ Software License v1.1
     | TOSL -- ^ @TOSL@, Trusster Open Source License
-    | TPDL -- ^ @TPDL@, Time::ParseDate License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | TPL_1_0 -- ^ @TPL-1.0@, THOR Public License 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | TrustedQSL -- ^ @TrustedQSL@, TrustedQSL License, SPDX License List 3.26
-    | TTWL -- ^ @TTWL@, Text-Tabs+Wrap License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | TTYP0 -- ^ @TTYP0@, TTYP0 License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | TU_Berlin_1_0 -- ^ @TU-Berlin-1.0@, Technische Universitaet Berlin License 1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | TU_Berlin_2_0 -- ^ @TU-Berlin-2.0@, Technische Universitaet Berlin License 2.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Ubuntu_font_1_0 -- ^ @Ubuntu-font-1.0@, Ubuntu Font Licence v1.0, SPDX License List 3.25, SPDX License List 3.26
-    | UCAR -- ^ @UCAR@, UCAR License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | UCL_1_0 -- ^ @UCL-1.0@, Upstream Compatibility License v1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Ulem -- ^ @ulem@, ulem License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | UMich_Merit -- ^ @UMich-Merit@, Michigan/Merit Networks License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Unicode_3_0 -- ^ @Unicode-3.0@, Unicode License v3, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | TPDL -- ^ @TPDL@, Time::ParseDate License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | TPL_1_0 -- ^ @TPL-1.0@, THOR Public License 1.0, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | TrustedQSL -- ^ @TrustedQSL@, TrustedQSL License, SPDX License List 3.26, SPDX License List 3.28
+    | TTWL -- ^ @TTWL@, Text-Tabs+Wrap License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | TTYP0 -- ^ @TTYP0@, TTYP0 License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | TU_Berlin_1_0 -- ^ @TU-Berlin-1.0@, Technische Universitaet Berlin License 1.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | TU_Berlin_2_0 -- ^ @TU-Berlin-2.0@, Technische Universitaet Berlin License 2.0, SPDX License List 3.2, SPDX License List 3.6, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Ubuntu_font_1_0 -- ^ @Ubuntu-font-1.0@, Ubuntu Font Licence v1.0, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | UCAR -- ^ @UCAR@, UCAR License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | UCL_1_0 -- ^ @UCL-1.0@, Upstream Compatibility License v1.0, SPDX License List 3.9, SPDX License List 3.10, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Ulem -- ^ @ulem@, ulem License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | UMich_Merit -- ^ @UMich-Merit@, Michigan/Merit Networks License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Unicode_3_0 -- ^ @Unicode-3.0@, Unicode License v3, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Unicode_DFS_2015 -- ^ @Unicode-DFS-2015@, Unicode License Agreement - Data Files and Software (2015)
     | Unicode_DFS_2016 -- ^ @Unicode-DFS-2016@, Unicode License Agreement - Data Files and Software (2016)
     | Unicode_TOU -- ^ @Unicode-TOU@, Unicode Terms of Use
-    | UnixCrypt -- ^ @UnixCrypt@, UnixCrypt License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Unlicense_libtelnet -- ^ @Unlicense-libtelnet@, Unlicense - libtelnet variant, SPDX License List 3.26
-    | Unlicense_libwhirlpool -- ^ @Unlicense-libwhirlpool@, Unlicense - libwhirlpool variant, SPDX License List 3.26
+    | UnixCrypt -- ^ @UnixCrypt@, UnixCrypt License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Unlicense_libtelnet -- ^ @Unlicense-libtelnet@, Unlicense - libtelnet variant, SPDX License List 3.26, SPDX License List 3.28
+    | Unlicense_libwhirlpool -- ^ @Unlicense-libwhirlpool@, Unlicense - libwhirlpool variant, SPDX License List 3.26, SPDX License List 3.28
     | Unlicense -- ^ @Unlicense@, The Unlicense
+    | UnRAR -- ^ @UnRAR@, UnRAR License, SPDX License List 3.28
     | UPL_1_0 -- ^ @UPL-1.0@, Universal Permissive License v1.0
-    | URT_RLE -- ^ @URT-RLE@, Utah Raster Toolkit Run Length Encoded License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | URT_RLE -- ^ @URT-RLE@, Utah Raster Toolkit Run Length Encoded License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Vim -- ^ @Vim@, Vim License
+    | Vixie_Cron -- ^ @Vixie-Cron@, Vixie Cron License, SPDX License List 3.28
     | VOSTROM -- ^ @VOSTROM@, VOSTROM Public License for Open Source
     | VSL_1_0 -- ^ @VSL-1.0@, Vovida Software License v1.0
     | W3C_19980720 -- ^ @W3C-19980720@, W3C Software Notice and License (1998-07-20)
     | W3C_20150513 -- ^ @W3C-20150513@, W3C Software Notice and Document License (2015-05-13)
     | W3C -- ^ @W3C@, W3C Software Notice and License (2002-12-31)
-    | W3m -- ^ @w3m@, w3m License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | W3m -- ^ @w3m@, w3m License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Watcom_1_0 -- ^ @Watcom-1.0@, Sybase Open Watcom Public License 1.0
-    | Widget_Workshop -- ^ @Widget-Workshop@, Widget Workshop License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Widget_Workshop -- ^ @Widget-Workshop@, Widget Workshop License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | WordNet -- ^ @WordNet@, WordNet License, SPDX License List 3.28
     | Wsuipa -- ^ @Wsuipa@, Wsuipa License
+    | WTFNMFPL -- ^ @WTFNMFPL@, Do What The F*ck You Want To But It's Not My Fault Public License, SPDX License List 3.28
     | WTFPL -- ^ @WTFPL@, Do What The F*ck You Want To Public License
-    | Wwl -- ^ @wwl@, WWL License, SPDX License List 3.26
-    | X11_distribute_modifications_variant -- ^ @X11-distribute-modifications-variant@, X11 License Distribution Modification Variant, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | X11_swapped -- ^ @X11-swapped@, X11 swapped final paragraphs, SPDX License List 3.25, SPDX License List 3.26
+    | Wwl -- ^ @wwl@, WWL License, SPDX License List 3.26, SPDX License List 3.28
+    | X11_distribute_modifications_variant -- ^ @X11-distribute-modifications-variant@, X11 License Distribution Modification Variant, SPDX License List 3.16, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | X11_no_permit_persons -- ^ @X11-no-permit-persons@, X11 no permit persons clause, SPDX License List 3.28
+    | X11_swapped -- ^ @X11-swapped@, X11 swapped final paragraphs, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | X11 -- ^ @X11@, X11 License
-    | Xdebug_1_03 -- ^ @Xdebug-1.03@, Xdebug License v 1.03, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Xdebug_1_03 -- ^ @Xdebug-1.03@, Xdebug License v 1.03, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Xerox -- ^ @Xerox@, Xerox License
-    | Xfig -- ^ @Xfig@, Xfig License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Xfig -- ^ @Xfig@, Xfig License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | XFree86_1_1 -- ^ @XFree86-1.1@, XFree86 License 1.1
     | Xinetd -- ^ @xinetd@, xinetd License
-    | Xkeyboard_config_Zinoviev -- ^ @xkeyboard-config-Zinoviev@, xkeyboard-config Zinoviev License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
-    | Xlock -- ^ @xlock@, xlock License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Xkeyboard_config_Zinoviev -- ^ @xkeyboard-config-Zinoviev@, xkeyboard-config Zinoviev License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
+    | Xlock -- ^ @xlock@, xlock License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Xnet -- ^ @Xnet@, X.Net License
     | Xpp -- ^ @xpp@, XPP License
     | XSkat -- ^ @XSkat@, XSkat License
-    | Xzoom -- ^ @xzoom@, xzoom License, SPDX License List 3.25, SPDX License List 3.26
+    | Xzoom -- ^ @xzoom@, xzoom License, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | YPL_1_0 -- ^ @YPL-1.0@, Yahoo! Public License v1.0
     | YPL_1_1 -- ^ @YPL-1.1@, Yahoo! Public License v1.1
     | Zed -- ^ @Zed@, Zed License
-    | Zeeff -- ^ @Zeeff@, Zeeff License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26
+    | Zeeff -- ^ @Zeeff@, Zeeff License, SPDX License List 3.23, SPDX License List 3.25, SPDX License List 3.26, SPDX License List 3.28
     | Zend_2_0 -- ^ @Zend-2.0@, Zend License v2.0
     | Zimbra_1_3 -- ^ @Zimbra-1.3@, Zimbra Public License v1.3
     | Zimbra_1_4 -- ^ @Zimbra-1.4@, Zimbra Public License v1.4
@@ -720,7 +749,7 @@ instance Binary LicenseId where
 
 -- note: remember to bump version each time the definition changes
 instance Structured LicenseId where
-    structure p = set typeVersion 307 $ nominalStructure p
+    structure p = set typeVersion 308 $ nominalStructure p
 
 instance Pretty LicenseId where
     pretty = Disp.text . licenseId
@@ -798,6 +827,7 @@ licenseId Adobe_Display_PostScript = "Adobe-Display-PostScript"
 licenseId Adobe_Glyph = "Adobe-Glyph"
 licenseId Adobe_Utopia = "Adobe-Utopia"
 licenseId ADSL = "ADSL"
+licenseId Advanced_Cryptics_Dictionary = "Advanced-Cryptics-Dictionary"
 licenseId AFL_1_1 = "AFL-1.1"
 licenseId AFL_1_2 = "AFL-1.2"
 licenseId AFL_2_0 = "AFL-2.0"
@@ -810,6 +840,7 @@ licenseId AGPL_1_0_or_later = "AGPL-1.0-or-later"
 licenseId AGPL_3_0_only = "AGPL-3.0-only"
 licenseId AGPL_3_0_or_later = "AGPL-3.0-or-later"
 licenseId Aladdin = "Aladdin"
+licenseId ALGLIB_Documentation = "ALGLIB-Documentation"
 licenseId AMD_newlib = "AMD-newlib"
 licenseId AMDPLPA = "AMDPLPA"
 licenseId AML_glslang = "AML-glslang"
@@ -851,6 +882,7 @@ licenseId Blessing = "blessing"
 licenseId BlueOak_1_0_0 = "BlueOak-1.0.0"
 licenseId Boehm_GC_without_fee = "Boehm-GC-without-fee"
 licenseId Boehm_GC = "Boehm-GC"
+licenseId BOLA_1_1 = "BOLA-1.1"
 licenseId Borceux = "Borceux"
 licenseId Brian_Gladman_2_Clause = "Brian-Gladman-2-Clause"
 licenseId Brian_Gladman_3_Clause = "Brian-Gladman-3-Clause"
@@ -876,6 +908,7 @@ licenseId BSD_3_Clause_No_Nuclear_License = "BSD-3-Clause-No-Nuclear-License"
 licenseId BSD_3_Clause_No_Nuclear_Warranty = "BSD-3-Clause-No-Nuclear-Warranty"
 licenseId BSD_3_Clause_Open_MPI = "BSD-3-Clause-Open-MPI"
 licenseId BSD_3_Clause_Sun = "BSD-3-Clause-Sun"
+licenseId BSD_3_Clause_Tso = "BSD-3-Clause-Tso"
 licenseId BSD_3_Clause = "BSD-3-Clause"
 licenseId BSD_4_Clause_Shortened = "BSD-4-Clause-Shortened"
 licenseId BSD_4_Clause_UC = "BSD-4-Clause-UC"
@@ -885,6 +918,7 @@ licenseId BSD_4_3TAHOE = "BSD-4.3TAHOE"
 licenseId BSD_Advertising_Acknowledgement = "BSD-Advertising-Acknowledgement"
 licenseId BSD_Attribution_HPND_disclaimer = "BSD-Attribution-HPND-disclaimer"
 licenseId BSD_Inferno_Nettverk = "BSD-Inferno-Nettverk"
+licenseId BSD_Mark_Modifications = "BSD-Mark-Modifications"
 licenseId BSD_Protection = "BSD-Protection"
 licenseId BSD_Source_beginning_file = "BSD-Source-beginning-file"
 licenseId BSD_Source_Code = "BSD-Source-Code"
@@ -892,6 +926,7 @@ licenseId BSD_Systemics_W3Works = "BSD-Systemics-W3Works"
 licenseId BSD_Systemics = "BSD-Systemics"
 licenseId BSL_1_0 = "BSL-1.0"
 licenseId Bzip2_1_0_5 = "bzip2-1.0.5"
+licenseId Buddy = "Buddy"
 licenseId BUSL_1_1 = "BUSL-1.1"
 licenseId Bzip2_1_0_6 = "bzip2-1.0.6"
 licenseId C_UDA_1_0 = "C-UDA-1.0"
@@ -899,6 +934,7 @@ licenseId CAL_1_0_Combined_Work_Exception = "CAL-1.0-Combined-Work-Exception"
 licenseId CAL_1_0 = "CAL-1.0"
 licenseId Caldera_no_preamble = "Caldera-no-preamble"
 licenseId Caldera = "Caldera"
+licenseId CAPEC_tou = "CAPEC-tou"
 licenseId Catharon = "Catharon"
 licenseId CATOSL_1_1 = "CATOSL-1.1"
 licenseId CC_BY_1_0 = "CC-BY-1.0"
@@ -1027,6 +1063,9 @@ licenseId EPICS = "EPICS"
 licenseId EPL_1_0 = "EPL-1.0"
 licenseId EPL_2_0 = "EPL-2.0"
 licenseId ErlPL_1_1 = "ErlPL-1.1"
+licenseId ESA_PL_permissive_2_4 = "ESA-PL-permissive-2.4"
+licenseId ESA_PL_strong_copyleft_2_4 = "ESA-PL-strong-copyleft-2.4"
+licenseId ESA_PL_weak_copyleft_2_4 = "ESA-PL-weak-copyleft-2.4"
 licenseId Etalab_2_0 = "etalab-2.0"
 licenseId EUDatagrid = "EUDatagrid"
 licenseId EUPL_1_0 = "EUPL-1.0"
@@ -1114,13 +1153,16 @@ licenseId HPND_Netrek = "HPND-Netrek"
 licenseId HPND_Pbmplus = "HPND-Pbmplus"
 licenseId HPND_sell_MIT_disclaimer_xserver = "HPND-sell-MIT-disclaimer-xserver"
 licenseId HPND_sell_regexpr = "HPND-sell-regexpr"
+licenseId HPND_sell_variant_critical_systems = "HPND-sell-variant-critical-systems"
 licenseId HPND_sell_variant_MIT_disclaimer_rev = "HPND-sell-variant-MIT-disclaimer-rev"
 licenseId HPND_sell_variant_MIT_disclaimer = "HPND-sell-variant-MIT-disclaimer"
 licenseId HPND_sell_variant = "HPND-sell-variant"
+licenseId HPND_SMC = "HPND-SMC"
 licenseId HPND_UC_export_US = "HPND-UC-export-US"
 licenseId HPND_UC = "HPND-UC"
 licenseId HPND = "HPND"
 licenseId HTMLTIDY = "HTMLTIDY"
+licenseId Hyphen_bulgarian = "hyphen-bulgarian"
 licenseId IBM_pibs = "IBM-pibs"
 licenseId ICU = "ICU"
 licenseId IEC_Code_Components_EULA = "IEC-Code-Components-EULA"
@@ -1139,6 +1181,7 @@ licenseId IPA = "IPA"
 licenseId IPL_1_0 = "IPL-1.0"
 licenseId ISC_Veillard = "ISC-Veillard"
 licenseId ISC = "ISC"
+licenseId ISO_permission = "ISO-permission"
 licenseId Jam = "Jam"
 licenseId JasPer_2_0 = "JasPer-2.0"
 licenseId Jove = "jove"
@@ -1209,11 +1252,13 @@ licenseId MIT_Festival = "MIT-Festival"
 licenseId MIT_Khronos_old = "MIT-Khronos-old"
 licenseId MIT_Modern_Variant = "MIT-Modern-Variant"
 licenseId MIT_open_group = "MIT-open-group"
+licenseId MIT_STK = "MIT-STK"
 licenseId MIT_testregex = "MIT-testregex"
 licenseId MIT_Wu = "MIT-Wu"
 licenseId MITNFA = "MITNFA"
 licenseId MIT = "MIT"
 licenseId MMIXware = "MMIXware"
+licenseId MMPL_1_0_1 = "MMPL-1.0.1"
 licenseId Motosoto = "Motosoto"
 licenseId MPEG_SSG = "MPEG-SSG"
 licenseId Mpi_permissive = "mpi-permissive"
@@ -1246,6 +1291,7 @@ licenseId NGPL = "NGPL"
 licenseId Ngrep = "ngrep"
 licenseId NICTA_1_0 = "NICTA-1.0"
 licenseId NIST_PD_fallback = "NIST-PD-fallback"
+licenseId NIST_PD_TNT = "NIST-PD-TNT"
 licenseId NIST_PD = "NIST-PD"
 licenseId NIST_Software = "NIST-Software"
 licenseId NLOD_1_0 = "NLOD-1.0"
@@ -1299,6 +1345,7 @@ licenseId OLDAP_2_7 = "OLDAP-2.7"
 licenseId OLDAP_2_8 = "OLDAP-2.8"
 licenseId OLFL_1_3 = "OLFL-1.3"
 licenseId OML = "OML"
+licenseId OpenMDW_1_0 = "OpenMDW-1.0"
 licenseId OpenPBS_2_3 = "OpenPBS-2.3"
 licenseId OpenSSL_standalone = "OpenSSL-standalone"
 licenseId OpenSSL = "OpenSSL"
@@ -1306,13 +1353,16 @@ licenseId OpenVision = "OpenVision"
 licenseId OPL_1_0 = "OPL-1.0"
 licenseId OPL_UK_3_0 = "OPL-UK-3.0"
 licenseId OPUBL_1_0 = "OPUBL-1.0"
+licenseId OSC_1_0 = "OSC-1.0"
 licenseId OSET_PL_2_1 = "OSET-PL-2.1"
 licenseId OSL_1_0 = "OSL-1.0"
 licenseId OSL_1_1 = "OSL-1.1"
 licenseId OSL_2_0 = "OSL-2.0"
 licenseId OSL_2_1 = "OSL-2.1"
 licenseId OSL_3_0 = "OSL-3.0"
+licenseId OSSP = "OSSP"
 licenseId PADL = "PADL"
+licenseId ParaType_Free_Font_1_3 = "ParaType-Free-Font-1.3"
 licenseId Parity_6_0_0 = "Parity-6.0.0"
 licenseId Parity_7_0_0 = "Parity-7.0.0"
 licenseId PDDL_1_0 = "PDDL-1.0"
@@ -1357,6 +1407,7 @@ licenseId SGI_B_1_0 = "SGI-B-1.0"
 licenseId SGI_B_1_1 = "SGI-B-1.1"
 licenseId SGI_B_2_0 = "SGI-B-2.0"
 licenseId SGI_OpenGL = "SGI-OpenGL"
+licenseId SGMLUG_PM = "SGMLUG-PM"
 licenseId SGP4 = "SGP4"
 licenseId SHL_0_51 = "SHL-0.51"
 licenseId SHL_0_5 = "SHL-0.5"
@@ -1383,6 +1434,7 @@ licenseId SSH_short = "SSH-short"
 licenseId SSLeay_standalone = "SSLeay-standalone"
 licenseId SSPL_1_0 = "SSPL-1.0"
 licenseId SugarCRM_1_1_3 = "SugarCRM-1.1.3"
+licenseId SUL_1_0 = "SUL-1.0"
 licenseId Sun_PPP_2000 = "Sun-PPP-2000"
 licenseId Sun_PPP = "Sun-PPP"
 licenseId SunPro = "SunPro"
@@ -1392,6 +1444,7 @@ licenseId Symlinks = "Symlinks"
 licenseId TAPR_OHL_1_0 = "TAPR-OHL-1.0"
 licenseId TCL = "TCL"
 licenseId TCP_wrappers = "TCP-wrappers"
+licenseId TekHVC = "TekHVC"
 licenseId TermReadKey = "TermReadKey"
 licenseId TGPPL_1_0 = "TGPPL-1.0"
 licenseId ThirdEye = "ThirdEye"
@@ -1419,9 +1472,11 @@ licenseId UnixCrypt = "UnixCrypt"
 licenseId Unlicense_libtelnet = "Unlicense-libtelnet"
 licenseId Unlicense_libwhirlpool = "Unlicense-libwhirlpool"
 licenseId Unlicense = "Unlicense"
+licenseId UnRAR = "UnRAR"
 licenseId UPL_1_0 = "UPL-1.0"
 licenseId URT_RLE = "URT-RLE"
 licenseId Vim = "Vim"
+licenseId Vixie_Cron = "Vixie-Cron"
 licenseId VOSTROM = "VOSTROM"
 licenseId VSL_1_0 = "VSL-1.0"
 licenseId W3C_19980720 = "W3C-19980720"
@@ -1430,10 +1485,13 @@ licenseId W3C = "W3C"
 licenseId W3m = "w3m"
 licenseId Watcom_1_0 = "Watcom-1.0"
 licenseId Widget_Workshop = "Widget-Workshop"
+licenseId WordNet = "WordNet"
 licenseId Wsuipa = "Wsuipa"
+licenseId WTFNMFPL = "WTFNMFPL"
 licenseId WTFPL = "WTFPL"
 licenseId Wwl = "wwl"
 licenseId X11_distribute_modifications_variant = "X11-distribute-modifications-variant"
+licenseId X11_no_permit_persons = "X11-no-permit-persons"
 licenseId X11_swapped = "X11-swapped"
 licenseId X11 = "X11"
 licenseId Xdebug_1_03 = "Xdebug-1.03"
@@ -1472,6 +1530,7 @@ licenseName Adobe_Display_PostScript = "Adobe Display PostScript License"
 licenseName Adobe_Glyph = "Adobe Glyph List License"
 licenseName Adobe_Utopia = "Adobe Utopia Font License"
 licenseName ADSL = "Amazon Digital Services License"
+licenseName Advanced_Cryptics_Dictionary = "Advanced Cryptics Dictionary License"
 licenseName AFL_1_1 = "Academic Free License v1.1"
 licenseName AFL_1_2 = "Academic Free License v1.2"
 licenseName AFL_2_0 = "Academic Free License v2.0"
@@ -1484,6 +1543,7 @@ licenseName AGPL_1_0_or_later = "Affero General Public License v1.0 or later"
 licenseName AGPL_3_0_only = "GNU Affero General Public License v3.0 only"
 licenseName AGPL_3_0_or_later = "GNU Affero General Public License v3.0 or later"
 licenseName Aladdin = "Aladdin Free Public License"
+licenseName ALGLIB_Documentation = "ALGLIB Documentation License"
 licenseName AMD_newlib = "AMD newlib License"
 licenseName AMDPLPA = "AMD's plpa_map.c License"
 licenseName AML_glslang = "AML glslang variant License"
@@ -1525,6 +1585,7 @@ licenseName Blessing = "SQLite Blessing"
 licenseName BlueOak_1_0_0 = "Blue Oak Model License 1.0.0"
 licenseName Boehm_GC_without_fee = "Boehm-Demers-Weiser GC License (without fee)"
 licenseName Boehm_GC = "Boehm-Demers-Weiser GC License"
+licenseName BOLA_1_1 = "Buena Onda License Agreement v1.1"
 licenseName Borceux = "Borceux license"
 licenseName Brian_Gladman_2_Clause = "Brian Gladman 2-Clause License"
 licenseName Brian_Gladman_3_Clause = "Brian Gladman 3-Clause License"
@@ -1550,6 +1611,7 @@ licenseName BSD_3_Clause_No_Nuclear_License = "BSD 3-Clause No Nuclear License"
 licenseName BSD_3_Clause_No_Nuclear_Warranty = "BSD 3-Clause No Nuclear Warranty"
 licenseName BSD_3_Clause_Open_MPI = "BSD 3-Clause Open MPI variant"
 licenseName BSD_3_Clause_Sun = "BSD 3-Clause Sun Microsystems"
+licenseName BSD_3_Clause_Tso = "BSD 3-Clause Tso variant"
 licenseName BSD_3_Clause = "BSD 3-Clause \"New\" or \"Revised\" License"
 licenseName BSD_4_Clause_Shortened = "BSD 4 Clause Shortened"
 licenseName BSD_4_Clause_UC = "BSD-4-Clause (University of California-Specific)"
@@ -1559,6 +1621,7 @@ licenseName BSD_4_3TAHOE = "BSD 4.3 TAHOE License"
 licenseName BSD_Advertising_Acknowledgement = "BSD Advertising Acknowledgement License"
 licenseName BSD_Attribution_HPND_disclaimer = "BSD with Attribution and HPND disclaimer"
 licenseName BSD_Inferno_Nettverk = "BSD-Inferno-Nettverk"
+licenseName BSD_Mark_Modifications = "BSD Mark Modifications License"
 licenseName BSD_Protection = "BSD Protection License"
 licenseName BSD_Source_beginning_file = "BSD Source Code Attribution - beginning of file variant"
 licenseName BSD_Source_Code = "BSD Source Code Attribution"
@@ -1566,6 +1629,7 @@ licenseName BSD_Systemics_W3Works = "Systemics W3Works BSD variant license"
 licenseName BSD_Systemics = "Systemics BSD variant license"
 licenseName BSL_1_0 = "Boost Software License 1.0"
 licenseName Bzip2_1_0_5 = "bzip2 and libbzip2 License v1.0.5"
+licenseName Buddy = "Buddy License"
 licenseName BUSL_1_1 = "Business Source License 1.1"
 licenseName Bzip2_1_0_6 = "bzip2 and libbzip2 License v1.0.6"
 licenseName C_UDA_1_0 = "Computational Use of Data Agreement v1.0"
@@ -1573,6 +1637,7 @@ licenseName CAL_1_0_Combined_Work_Exception = "Cryptographic Autonomy License 1.
 licenseName CAL_1_0 = "Cryptographic Autonomy License 1.0"
 licenseName Caldera_no_preamble = "Caldera License (without preamble)"
 licenseName Caldera = "Caldera License"
+licenseName CAPEC_tou = "Common Attack    Pattern Enumeration and Classification License"
 licenseName Catharon = "Catharon License"
 licenseName CATOSL_1_1 = "Computer Associates Trusted Open Source License 1.1"
 licenseName CC_BY_1_0 = "Creative Commons Attribution 1.0 Generic"
@@ -1701,6 +1766,9 @@ licenseName EPICS = "EPICS Open License"
 licenseName EPL_1_0 = "Eclipse Public License 1.0"
 licenseName EPL_2_0 = "Eclipse Public License 2.0"
 licenseName ErlPL_1_1 = "Erlang Public License v1.1"
+licenseName ESA_PL_permissive_2_4 = "European Space Agency Public License \8211 v2.4 \8211 Permissive (Type 3)"
+licenseName ESA_PL_strong_copyleft_2_4 = "European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1)"
+licenseName ESA_PL_weak_copyleft_2_4 = "European Space Agency Public License \8211 v2.4 \8211 Weak Copyleft (Type 2)"
 licenseName Etalab_2_0 = "Etalab Open License 2.0"
 licenseName EUDatagrid = "EU DataGrid Software License"
 licenseName EUPL_1_0 = "European Union Public License 1.0"
@@ -1788,13 +1856,16 @@ licenseName HPND_Netrek = "Historical Permission Notice and Disclaimer - Netrek 
 licenseName HPND_Pbmplus = "Historical Permission Notice and Disclaimer - Pbmplus variant"
 licenseName HPND_sell_MIT_disclaimer_xserver = "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer"
 licenseName HPND_sell_regexpr = "Historical Permission Notice and Disclaimer - sell regexpr variant"
+licenseName HPND_sell_variant_critical_systems = "HPND - sell variant with safety critical systems clause"
 licenseName HPND_sell_variant_MIT_disclaimer_rev = "HPND sell variant with MIT disclaimer - reverse"
 licenseName HPND_sell_variant_MIT_disclaimer = "HPND sell variant with MIT disclaimer"
 licenseName HPND_sell_variant = "Historical Permission Notice and Disclaimer - sell variant"
+licenseName HPND_SMC = "Historical Permission Notice and Disclaimer - SMC variant"
 licenseName HPND_UC_export_US = "Historical Permission Notice and Disclaimer - University of California, US export warning"
 licenseName HPND_UC = "Historical Permission Notice and Disclaimer - University of California variant"
 licenseName HPND = "Historical Permission Notice and Disclaimer"
 licenseName HTMLTIDY = "HTML Tidy License"
+licenseName Hyphen_bulgarian = "hyphen-bulgarian License"
 licenseName IBM_pibs = "IBM PowerPC Initialization and Boot Software"
 licenseName ICU = "ICU License"
 licenseName IEC_Code_Components_EULA = "IEC    Code Components End-user licence agreement"
@@ -1813,6 +1884,7 @@ licenseName IPA = "IPA Font License"
 licenseName IPL_1_0 = "IBM Public License v1.0"
 licenseName ISC_Veillard = "ISC Veillard variant"
 licenseName ISC = "ISC License"
+licenseName ISO_permission = "ISO permission notice"
 licenseName Jam = "Jam License"
 licenseName JasPer_2_0 = "JasPer License"
 licenseName Jove = "Jove License"
@@ -1834,7 +1906,7 @@ licenseName LGPL_2_1_or_later = "GNU Lesser General Public License v2.1 or later
 licenseName LGPL_3_0_only = "GNU Lesser General Public License v3.0 only"
 licenseName LGPL_3_0_or_later = "GNU Lesser General Public License v3.0 or later"
 licenseName LGPLLR = "Lesser General Public License For Linguistic Resources"
-licenseName Libpng_1_6_35 = "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35"
+licenseName Libpng_1_6_35 = "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)"
 licenseName Libpng_2_0 = "PNG Reference Library version 2"
 licenseName Libpng = "libpng License"
 licenseName Libselinux_1_0 = "libselinux public domain notice"
@@ -1883,11 +1955,13 @@ licenseName MIT_Festival = "MIT Festival Variant"
 licenseName MIT_Khronos_old = "MIT Khronos - old variant"
 licenseName MIT_Modern_Variant = "MIT License Modern Variant"
 licenseName MIT_open_group = "MIT Open Group variant"
+licenseName MIT_STK = "MIT-STK License"
 licenseName MIT_testregex = "MIT testregex Variant"
 licenseName MIT_Wu = "MIT Tom Wu Variant"
 licenseName MITNFA = "MIT +no-false-attribs license"
 licenseName MIT = "MIT License"
 licenseName MMIXware = "MMIXware License"
+licenseName MMPL_1_0_1 = "Minecraft Mod Public License v1.0.1"
 licenseName Motosoto = "Motosoto License"
 licenseName MPEG_SSG = "MPEG Software Simulation"
 licenseName Mpi_permissive = "mpi Permissive License"
@@ -1920,6 +1994,7 @@ licenseName NGPL = "Nethack General Public License"
 licenseName Ngrep = "ngrep License"
 licenseName NICTA_1_0 = "NICTA Public Software License, Version 1.0"
 licenseName NIST_PD_fallback = "NIST Public Domain Notice with license fallback"
+licenseName NIST_PD_TNT = "NIST    Public Domain Notice TNT variant"
 licenseName NIST_PD = "NIST Public Domain Notice"
 licenseName NIST_Software = "NIST Software License"
 licenseName NLOD_1_0 = "Norwegian Licence for Open Government Data (NLOD) 1.0"
@@ -1973,6 +2048,7 @@ licenseName OLDAP_2_7 = "Open LDAP Public License v2.7"
 licenseName OLDAP_2_8 = "Open LDAP Public License v2.8"
 licenseName OLFL_1_3 = "Open Logistics Foundation License Version 1.3"
 licenseName OML = "Open Market License"
+licenseName OpenMDW_1_0 = "OpenMDW License Agreement v1.0"
 licenseName OpenPBS_2_3 = "OpenPBS v2.3 Software License"
 licenseName OpenSSL_standalone = "OpenSSL License - standalone"
 licenseName OpenSSL = "OpenSSL License"
@@ -1980,13 +2056,16 @@ licenseName OpenVision = "OpenVision License"
 licenseName OPL_1_0 = "Open Public License v1.0"
 licenseName OPL_UK_3_0 = "United    Kingdom Open Parliament Licence v3.0"
 licenseName OPUBL_1_0 = "Open Publication License v1.0"
+licenseName OSC_1_0 = "OSC License 1.0"
 licenseName OSET_PL_2_1 = "OSET Public License version 2.1"
 licenseName OSL_1_0 = "Open Software License 1.0"
 licenseName OSL_1_1 = "Open Software License 1.1"
 licenseName OSL_2_0 = "Open Software License 2.0"
 licenseName OSL_2_1 = "Open Software License 2.1"
 licenseName OSL_3_0 = "Open Software License 3.0"
+licenseName OSSP = "OSSP License"
 licenseName PADL = "PADL License"
+licenseName ParaType_Free_Font_1_3 = "ParaType Free Font Licensing Agreement v1.3"
 licenseName Parity_6_0_0 = "The Parity Public License 6.0.0"
 licenseName Parity_7_0_0 = "The Parity Public License 7.0.0"
 licenseName PDDL_1_0 = "Open Data Commons Public Domain Dedication & License 1.0"
@@ -2031,6 +2110,7 @@ licenseName SGI_B_1_0 = "SGI Free Software License B v1.0"
 licenseName SGI_B_1_1 = "SGI Free Software License B v1.1"
 licenseName SGI_B_2_0 = "SGI Free Software License B v2.0"
 licenseName SGI_OpenGL = "SGI OpenGL License"
+licenseName SGMLUG_PM = "SGMLUG Parser Materials License"
 licenseName SGP4 = "SGP4 Permission Notice"
 licenseName SHL_0_51 = "Solderpad Hardware License, Version 0.51"
 licenseName SHL_0_5 = "Solderpad Hardware License v0.5"
@@ -2057,6 +2137,7 @@ licenseName SSH_short = "SSH short notice"
 licenseName SSLeay_standalone = "SSLeay License - standalone"
 licenseName SSPL_1_0 = "Server Side Public License, v 1"
 licenseName SugarCRM_1_1_3 = "SugarCRM Public License v1.1.3"
+licenseName SUL_1_0 = "Sustainable Use License v1.0"
 licenseName Sun_PPP_2000 = "Sun PPP License (2000)"
 licenseName Sun_PPP = "Sun PPP License"
 licenseName SunPro = "SunPro License"
@@ -2066,6 +2147,7 @@ licenseName Symlinks = "Symlinks License"
 licenseName TAPR_OHL_1_0 = "TAPR Open Hardware License v1.0"
 licenseName TCL = "TCL/TK License"
 licenseName TCP_wrappers = "TCP Wrappers License"
+licenseName TekHVC = "TekHVC License"
 licenseName TermReadKey = "TermReadKey License"
 licenseName TGPPL_1_0 = "Transitive Grace Period Public Licence 1.0"
 licenseName ThirdEye = "ThirdEye License"
@@ -2093,9 +2175,11 @@ licenseName UnixCrypt = "UnixCrypt License"
 licenseName Unlicense_libtelnet = "Unlicense - libtelnet variant"
 licenseName Unlicense_libwhirlpool = "Unlicense - libwhirlpool variant"
 licenseName Unlicense = "The Unlicense"
+licenseName UnRAR = "UnRAR License"
 licenseName UPL_1_0 = "Universal Permissive License v1.0"
 licenseName URT_RLE = "Utah Raster Toolkit Run Length Encoded License"
 licenseName Vim = "Vim License"
+licenseName Vixie_Cron = "Vixie Cron License"
 licenseName VOSTROM = "VOSTROM Public License for Open Source"
 licenseName VSL_1_0 = "Vovida Software License v1.0"
 licenseName W3C_19980720 = "W3C Software Notice and License (1998-07-20)"
@@ -2104,10 +2188,13 @@ licenseName W3C = "W3C Software Notice and License (2002-12-31)"
 licenseName W3m = "w3m License"
 licenseName Watcom_1_0 = "Sybase Open Watcom Public License 1.0"
 licenseName Widget_Workshop = "Widget Workshop License"
+licenseName WordNet = "WordNet License"
 licenseName Wsuipa = "Wsuipa License"
+licenseName WTFNMFPL = "Do What The F*ck You Want To But It's Not My Fault Public License"
 licenseName WTFPL = "Do What The F*ck You Want To Public License"
 licenseName Wwl = "WWL License"
 licenseName X11_distribute_modifications_variant = "X11 License Distribution Modification Variant"
+licenseName X11_no_permit_persons = "X11 no permit persons clause"
 licenseName X11_swapped = "X11 swapped final paragraphs"
 licenseName X11 = "X11 License"
 licenseName Xdebug_1_03 = "Xdebug License v 1.03"
@@ -2147,6 +2234,7 @@ licenseIsOsiApproved AFL_2_1 = True
 licenseIsOsiApproved AFL_3_0 = True
 licenseIsOsiApproved AGPL_3_0_only = True
 licenseIsOsiApproved AGPL_3_0_or_later = True
+licenseIsOsiApproved ALGLIB_Documentation = True
 licenseIsOsiApproved Apache_1_1 = True
 licenseIsOsiApproved Apache_2_0 = True
 licenseIsOsiApproved APL_1_0 = True
@@ -2163,6 +2251,7 @@ licenseIsOsiApproved BSD_1_Clause = True
 licenseIsOsiApproved BSD_2_Clause_Patent = True
 licenseIsOsiApproved BSD_2_Clause = True
 licenseIsOsiApproved BSD_3_Clause_LBNL = True
+licenseIsOsiApproved BSD_3_Clause_Open_MPI = True
 licenseIsOsiApproved BSD_3_Clause = True
 licenseIsOsiApproved BSL_1_0 = True
 licenseIsOsiApproved CAL_1_0_Combined_Work_Exception = True
@@ -2239,6 +2328,7 @@ licenseIsOsiApproved OFL_1_1 = True
 licenseIsOsiApproved OGTSL = True
 licenseIsOsiApproved OLDAP_2_8 = True
 licenseIsOsiApproved OLFL_1_3 = True
+licenseIsOsiApproved OSC_1_0 = True
 licenseIsOsiApproved OSET_PL_2_1 = True
 licenseIsOsiApproved OSL_1_0 = True
 licenseIsOsiApproved OSL_2_0 = True
@@ -2266,6 +2356,7 @@ licenseIsOsiApproved VSL_1_0 = True
 licenseIsOsiApproved W3C_20150513 = True
 licenseIsOsiApproved W3C = True
 licenseIsOsiApproved Watcom_1_0 = True
+licenseIsOsiApproved WordNet = True
 licenseIsOsiApproved Xnet = True
 licenseIsOsiApproved Zlib = True
 licenseIsOsiApproved ZPL_2_0 = True
@@ -3613,6 +3704,367 @@ licenseIdList LicenseListVersion_3_26 =
     , Zeeff
     ]
     ++ bulkOfLicenses
+licenseIdList LicenseListVersion_3_28 =
+    [ N_3D_Slicer_1_0
+    , AdaCore_doc
+    , Adobe_Display_PostScript
+    , Adobe_Utopia
+    , Advanced_Cryptics_Dictionary
+    , AGPL_1_0_only
+    , AGPL_1_0_or_later
+    , ALGLIB_Documentation
+    , AMD_newlib
+    , AML_glslang
+    , ANTLR_PD_fallback
+    , Any_OSI_perl_modules
+    , Any_OSI
+    , App_s2p
+    , Arphic_1999
+    , Artistic_dist
+    , Aspell_RU
+    , ASWF_Digital_Assets_1_0
+    , ASWF_Digital_Assets_1_1
+    , Baekmuk
+    , Bcrypt_Solar_Designer
+    , Bitstream_Charter
+    , Bitstream_Vera
+    , Blessing
+    , BlueOak_1_0_0
+    , Boehm_GC_without_fee
+    , Boehm_GC
+    , BOLA_1_1
+    , Brian_Gladman_2_Clause
+    , Brian_Gladman_3_Clause
+    , BSD_2_Clause_Darwin
+    , BSD_2_Clause_first_lines
+    , BSD_2_Clause_pkgconf_disclaimer
+    , BSD_2_Clause_Views
+    , BSD_3_Clause_acpica
+    , BSD_3_Clause_flex
+    , BSD_3_Clause_HP
+    , BSD_3_Clause_Modification
+    , BSD_3_Clause_No_Military_License
+    , BSD_3_Clause_Open_MPI
+    , BSD_3_Clause_Sun
+    , BSD_3_Clause_Tso
+    , BSD_4_Clause_Shortened
+    , BSD_4_3RENO
+    , BSD_4_3TAHOE
+    , BSD_Advertising_Acknowledgement
+    , BSD_Attribution_HPND_disclaimer
+    , BSD_Inferno_Nettverk
+    , BSD_Mark_Modifications
+    , BSD_Source_beginning_file
+    , BSD_Systemics_W3Works
+    , BSD_Systemics
+    , Buddy
+    , BUSL_1_1
+    , C_UDA_1_0
+    , CAL_1_0_Combined_Work_Exception
+    , CAL_1_0
+    , Caldera_no_preamble
+    , CAPEC_tou
+    , Catharon
+    , CC_BY_2_5_AU
+    , CC_BY_3_0_AT
+    , CC_BY_3_0_AU
+    , CC_BY_3_0_DE
+    , CC_BY_3_0_IGO
+    , CC_BY_3_0_NL
+    , CC_BY_3_0_US
+    , CC_BY_NC_3_0_DE
+    , CC_BY_NC_ND_3_0_DE
+    , CC_BY_NC_ND_3_0_IGO
+    , CC_BY_NC_SA_2_0_DE
+    , CC_BY_NC_SA_2_0_FR
+    , CC_BY_NC_SA_2_0_UK
+    , CC_BY_NC_SA_3_0_DE
+    , CC_BY_NC_SA_3_0_IGO
+    , CC_BY_ND_3_0_DE
+    , CC_BY_SA_2_0_UK
+    , CC_BY_SA_2_1_JP
+    , CC_BY_SA_3_0_AT
+    , CC_BY_SA_3_0_DE
+    , CC_BY_SA_3_0_IGO
+    , CC_PDDC
+    , CC_PDM_1_0
+    , CC_SA_1_0
+    , CDL_1_0
+    , CDLA_Permissive_2_0
+    , CERN_OHL_1_1
+    , CERN_OHL_1_2
+    , CERN_OHL_P_2_0
+    , CERN_OHL_S_2_0
+    , CERN_OHL_W_2_0
+    , CFITSIO
+    , Check_cvs
+    , Checkmk
+    , Clips
+    , CMU_Mach_nodoc
+    , CMU_Mach
+    , COIL_1_0
+    , Community_Spec_1_0
+    , Copyleft_next_0_3_0
+    , Copyleft_next_0_3_1
+    , Cornell_Lossless_JPEG
+    , Cronyx
+    , CryptoSwift
+    , Cve_tou
+    , DEC_3_Clause
+    , DL_DE_BY_2_0
+    , DL_DE_ZERO_2_0
+    , DocBook_DTD
+    , DocBook_Schema
+    , DocBook_Stylesheet
+    , DocBook_XML
+    , DRL_1_0
+    , DRL_1_1
+    , Dtoa
+    , Elastic_2_0
+    , EPICS
+    , ESA_PL_permissive_2_4
+    , ESA_PL_strong_copyleft_2_4
+    , ESA_PL_weak_copyleft_2_4
+    , Etalab_2_0
+    , FBM
+    , FDK_AAC
+    , Ferguson_Twofish
+    , FreeBSD_DOC
+    , FSFAP_no_warranty_disclaimer
+    , FSFULLRSD
+    , FSFULLRWD
+    , FSL_1_1_ALv2
+    , FSL_1_1_MIT
+    , Furuseth
+    , Fwlw
+    , Game_Programming_Gems
+    , GCR_docs
+    , GD
+    , Generic_xts
+    , GFDL_1_1_invariants_only
+    , GFDL_1_1_invariants_or_later
+    , GFDL_1_1_no_invariants_only
+    , GFDL_1_1_no_invariants_or_later
+    , GFDL_1_2_invariants_only
+    , GFDL_1_2_invariants_or_later
+    , GFDL_1_2_no_invariants_only
+    , GFDL_1_2_no_invariants_or_later
+    , GFDL_1_3_invariants_only
+    , GFDL_1_3_invariants_or_later
+    , GFDL_1_3_no_invariants_only
+    , GFDL_1_3_no_invariants_or_later
+    , GLWTPL
+    , Graphics_Gems
+    , Gtkbook
+    , Gutmann
+    , HDF5
+    , Hdparm
+    , HIDAPI
+    , Hippocratic_2_1
+    , HP_1986
+    , HP_1989
+    , HPND_DEC
+    , HPND_doc_sell
+    , HPND_doc
+    , HPND_export_US_acknowledgement
+    , HPND_export_US_modify
+    , HPND_export_US
+    , HPND_export2_US
+    , HPND_Fenneberg_Livingston
+    , HPND_INRIA_IMAG
+    , HPND_Intel
+    , HPND_Kevlin_Henney
+    , HPND_Markus_Kuhn
+    , HPND_merchantability_variant
+    , HPND_MIT_disclaimer
+    , HPND_Netrek
+    , HPND_Pbmplus
+    , HPND_sell_MIT_disclaimer_xserver
+    , HPND_sell_regexpr
+    , HPND_sell_variant_critical_systems
+    , HPND_sell_variant_MIT_disclaimer_rev
+    , HPND_sell_variant_MIT_disclaimer
+    , HPND_sell_variant
+    , HPND_SMC
+    , HPND_UC_export_US
+    , HPND_UC
+    , HTMLTIDY
+    , Hyphen_bulgarian
+    , IEC_Code_Components_EULA
+    , IJG_short
+    , Inner_Net_2_0
+    , InnoSetup
+    , ISC_Veillard
+    , ISO_permission
+    , Jam
+    , Jove
+    , JPL_image
+    , JPNIC
+    , Kastrup
+    , Kazlib
+    , Knuth_CTAN
+    , Latex2e_translated_notice
+    , Libpng_1_6_35
+    , Libpng_2_0
+    , Libselinux_1_0
+    , Libutil_David_Nugent
+    , Linux_man_pages_1_para
+    , Linux_man_pages_copyleft_2_para
+    , Linux_man_pages_copyleft_var
+    , Linux_man_pages_copyleft
+    , Linux_OpenIB
+    , LOOP
+    , LPD_document
+    , Lsof
+    , Lucida_Bitmap_Fonts
+    , LZMA_SDK_9_11_to_9_20
+    , LZMA_SDK_9_22
+    , Mackerras_3_Clause_acknowledgment
+    , Mackerras_3_Clause
+    , Magaz
+    , Mailprio
+    , Man2html
+    , Martin_Birgmeier
+    , McPhee_slideshow
+    , Metamail
+    , Minpack
+    , MIPS
+    , MIT_0
+    , MIT_Click
+    , MIT_Festival
+    , MIT_Khronos_old
+    , MIT_Modern_Variant
+    , MIT_open_group
+    , MIT_STK
+    , MIT_testregex
+    , MIT_Wu
+    , MMIXware
+    , MMPL_1_0_1
+    , MPEG_SSG
+    , Mpi_permissive
+    , Mplus
+    , MS_LPL
+    , MulanPSL_1_0
+    , MulanPSL_2_0
+    , NAIST_2003
+    , NCBI_PD
+    , NCGL_UK_2_0
+    , NCL
+    , Ngrep
+    , NICTA_1_0
+    , NIST_PD_fallback
+    , NIST_PD_TNT
+    , NIST_PD
+    , NIST_Software
+    , NLOD_2_0
+    , NTIA_PD
+    , NTP_0
+    , O_UDA_1_0
+    , OAR
+    , ODC_By_1_0
+    , OFFIS
+    , OFL_1_0_no_RFN
+    , OFL_1_0_RFN
+    , OFL_1_1_no_RFN
+    , OFL_1_1_RFN
+    , OGC_1_0
+    , OGDL_Taiwan_1_0
+    , OGL_Canada_2_0
+    , OGL_UK_1_0
+    , OGL_UK_2_0
+    , OGL_UK_3_0
+    , OLFL_1_3
+    , OpenMDW_1_0
+    , OpenPBS_2_3
+    , OpenSSL_standalone
+    , OpenVision
+    , OPL_UK_3_0
+    , OPUBL_1_0
+    , OSC_1_0
+    , OSSP
+    , PADL
+    , ParaType_Free_Font_1_3
+    , Parity_6_0_0
+    , Parity_7_0_0
+    , Pixar
+    , Pkgconf
+    , Pnmstitch
+    , PolyForm_Noncommercial_1_0_0
+    , PolyForm_Small_Business_1_0_0
+    , PPL
+    , PSF_2_0
+    , Python_2_0_1
+    , Python_ldap
+    , QPL_1_0_INRIA_2004
+    , Radvd
+    , Ruby_pty
+    , SAX_PD_2_0
+    , SchemeReport
+    , Sendmail_8_23
+    , Sendmail_Open_Source_1_1
+    , SGI_OpenGL
+    , SGMLUG_PM
+    , SGP4
+    , SHL_0_51
+    , SHL_0_5
+    , SL
+    , SMAIL_GPL
+    , Snprintf
+    , SOFA
+    , SoftSurfer
+    , Soundex
+    , Ssh_keyscan
+    , SSH_OpenSSH
+    , SSH_short
+    , SSLeay_standalone
+    , SSPL_1_0
+    , SUL_1_0
+    , Sun_PPP_2000
+    , Sun_PPP
+    , SunPro
+    , Swrule
+    , Symlinks
+    , TAPR_OHL_1_0
+    , TekHVC
+    , TermReadKey
+    , TGPPL_1_0
+    , ThirdEye
+    , Threeparttable
+    , TPDL
+    , TPL_1_0
+    , TrustedQSL
+    , TTWL
+    , TTYP0
+    , TU_Berlin_1_0
+    , TU_Berlin_2_0
+    , Ubuntu_font_1_0
+    , UCAR
+    , UCL_1_0
+    , Ulem
+    , UMich_Merit
+    , Unicode_3_0
+    , UnixCrypt
+    , Unlicense_libtelnet
+    , Unlicense_libwhirlpool
+    , UnRAR
+    , URT_RLE
+    , Vixie_Cron
+    , W3m
+    , Widget_Workshop
+    , WordNet
+    , WTFNMFPL
+    , Wwl
+    , X11_distribute_modifications_variant
+    , X11_no_permit_persons
+    , X11_swapped
+    , Xdebug_1_03
+    , Xfig
+    , Xkeyboard_config_Zinoviev
+    , Xlock
+    , Xzoom
+    , Zeeff
+    ]
+    ++ bulkOfLicenses
 
 -- | Create a 'LicenseId' from a 'String'.
 mkLicenseId :: LicenseListVersion -> String -> Maybe LicenseId
@@ -3625,6 +4077,7 @@ mkLicenseId LicenseListVersion_3_16 s = Map.lookup s stringLookup_3_16
 mkLicenseId LicenseListVersion_3_23 s = Map.lookup s stringLookup_3_23
 mkLicenseId LicenseListVersion_3_25 s = Map.lookup s stringLookup_3_25
 mkLicenseId LicenseListVersion_3_26 s = Map.lookup s stringLookup_3_26
+mkLicenseId LicenseListVersion_3_28 s = Map.lookup s stringLookup_3_28
 
 stringLookup_3_0 :: Map String LicenseId
 stringLookup_3_0 = Map.fromList $ map (\i -> (licenseId i, i)) $
@@ -3661,6 +4114,10 @@ stringLookup_3_25 = Map.fromList $ map (\i -> (licenseId i, i)) $
 stringLookup_3_26 :: Map String LicenseId
 stringLookup_3_26 = Map.fromList $ map (\i -> (licenseId i, i)) $
     licenseIdList LicenseListVersion_3_26
+
+stringLookup_3_28 :: Map String LicenseId
+stringLookup_3_28 = Map.fromList $ map (\i -> (licenseId i, i)) $
+    licenseIdList LicenseListVersion_3_28
 
 --  | Licenses in all SPDX License lists
 bulkOfLicenses :: [LicenseId]

--- a/Cabal-syntax/src/Distribution/SPDX/LicenseListVersion.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseListVersion.hs
@@ -25,9 +25,12 @@ data LicenseListVersion
     LicenseListVersion_3_25
   | -- | @since 3.16.0.0
     LicenseListVersion_3_26
+  | -- | @since 3.18.0.0
+    LicenseListVersion_3_28
   deriving (Eq, Ord, Show, Enum, Bounded)
 
 cabalSpecVersionToSPDXListVersion :: CabalSpecVersion -> LicenseListVersion
+cabalSpecVersionToSPDXListVersion CabalSpecV3_18 = LicenseListVersion_3_28
 cabalSpecVersionToSPDXListVersion CabalSpecV3_16 = LicenseListVersion_3_26
 cabalSpecVersionToSPDXListVersion CabalSpecV3_14 = LicenseListVersion_3_25
 cabalSpecVersionToSPDXListVersion CabalSpecV3_12 = LicenseListVersion_3_23

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -18,7 +18,7 @@ tests = testGroup "Distribution.Utils.Structured"
     [ testCase "VersionRange" $
       md5Check (Proxy :: Proxy VersionRange) 0x39396fc4f2d751aaa1f94e6d843f03bd
     , testCase "SPDX.License" $
-      md5Check (Proxy :: Proxy License) 0xf90ab6c2e4ffbc71b2e8c12531e50356
+      md5Check (Proxy :: Proxy License) 0x2804cd5d2137508059c16ac2449741d2
     -- The difference is in encoding of newtypes
     , testCase "GenericPackageDescription" $ md5CheckGenericPackageDescription (Proxy :: Proxy GenericPackageDescription)
     , testCase "LocalBuildInfo" $ md5CheckLocalBuildInfo (Proxy :: Proxy LocalBuildInfo)
@@ -29,8 +29,8 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
-    0xfd3ceefd3ccba5b23fa3688aefb363a9
+    0xfbca1c1f2a700fb3a174ec5346e86cbb
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x1bc2c98e507f9818275835dcf4dd2f12
+    0x3bf7bf1420847ce5fdaf6e36e33aecb2

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ SPDX_EXCEPTION_HS:=Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs
 .PHONY: spdx
 spdx : $(SPDX_LICENSE_HS) $(SPDX_EXCEPTION_HS)
 
-SPDX_LICENSE_VERSIONS:=3.0 3.2 3.6 3.9 3.10 3.16 3.23 3.25 3.26
+SPDX_LICENSE_VERSIONS:=3.0 3.2 3.6 3.9 3.10 3.16 3.23 3.25 3.26 3.28
 
 $(SPDX_LICENSE_HS) : templates/SPDX.LicenseId.template.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDX.hs license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json
 	cabal run --builddir=dist-newstyle-meta --project-file=cabal.meta.project gen-spdx -- templates/SPDX.LicenseId.template.hs $(SPDX_LICENSE_VERSIONS:%=license-list-data/licenses-%.json) $(SPDX_LICENSE_HS)

--- a/cabal-dev-scripts/src/GenSPDX.hs
+++ b/cabal-dev-scripts/src/GenSPDX.hs
@@ -38,6 +38,7 @@ main = generate =<< O.execParser opts where
         <*> licenses "3.23"
         <*> licenses "3.25"
         <*> licenses "3.26"
+        <*> licenses "3.28"
 
     template = O.strArgument $ mconcat
         [ O.metavar "SPDX.LicenseId.template.hs"

--- a/cabal-dev-scripts/src/GenSPDXExc.hs
+++ b/cabal-dev-scripts/src/GenSPDXExc.hs
@@ -38,6 +38,7 @@ main = generate =<< O.execParser opts where
         <*> licenses "3.23"
         <*> licenses "3.25"
         <*> licenses "3.26"
+        <*> licenses "3.28"
 
     template = O.strArgument $ mconcat
         [ O.metavar "SPDX.LicenseExceptionId.template.hs"

--- a/cabal-dev-scripts/src/GenUtils.hs
+++ b/cabal-dev-scripts/src/GenUtils.hs
@@ -33,12 +33,14 @@ data SPDXLicenseListVersion
     | SPDXLicenseListVersion_3_23
     | SPDXLicenseListVersion_3_25
     | SPDXLicenseListVersion_3_26
+    | SPDXLicenseListVersion_3_28
   deriving (Eq, Ord, Show, Enum, Bounded)
 
 allVers :: Set.Set SPDXLicenseListVersion
 allVers =  Set.fromList [minBound .. maxBound]
 
 prettyVer :: SPDXLicenseListVersion -> Text
+prettyVer SPDXLicenseListVersion_3_28 = "SPDX License List 3.28"
 prettyVer SPDXLicenseListVersion_3_26 = "SPDX License List 3.26"
 prettyVer SPDXLicenseListVersion_3_25 = "SPDX License List 3.25"
 prettyVer SPDXLicenseListVersion_3_23 = "SPDX License List 3.23"
@@ -50,6 +52,7 @@ prettyVer SPDXLicenseListVersion_3_2  = "SPDX License List 3.2"
 prettyVer SPDXLicenseListVersion_3_0  = "SPDX License List 3.0"
 
 suffixVer :: SPDXLicenseListVersion -> String
+suffixVer SPDXLicenseListVersion_3_28 = "_3_28"
 suffixVer SPDXLicenseListVersion_3_26 = "_3_26"
 suffixVer SPDXLicenseListVersion_3_25 = "_3_25"
 suffixVer SPDXLicenseListVersion_3_23 = "_3_23"
@@ -64,7 +67,7 @@ suffixVer SPDXLicenseListVersion_3_0  = "_3_0"
 -- Per version
 -------------------------------------------------------------------------------
 
-data PerV a = PerV a a a a a a a a a
+data PerV a = PerV a a a a a a a a a a
   deriving (Show, Functor, Foldable, Traversable)
 
 class Functor f => Representable i f | f -> i where
@@ -72,15 +75,16 @@ class Functor f => Representable i f | f -> i where
     tabulate :: (i -> a) -> f a
 
 instance Representable SPDXLicenseListVersion PerV where
-    index SPDXLicenseListVersion_3_0  (PerV x _ _ _ _ _ _ _ _) = x
-    index SPDXLicenseListVersion_3_2  (PerV _ x _ _ _ _ _ _ _) = x
-    index SPDXLicenseListVersion_3_6  (PerV _ _ x _ _ _ _ _ _) = x
-    index SPDXLicenseListVersion_3_9  (PerV _ _ _ x _ _ _ _ _) = x
-    index SPDXLicenseListVersion_3_10 (PerV _ _ _ _ x _ _ _ _) = x
-    index SPDXLicenseListVersion_3_16 (PerV _ _ _ _ _ x _ _ _) = x
-    index SPDXLicenseListVersion_3_23 (PerV _ _ _ _ _ _ x _ _) = x
-    index SPDXLicenseListVersion_3_25 (PerV _ _ _ _ _ _ _ x _) = x
-    index SPDXLicenseListVersion_3_26 (PerV _ _ _ _ _ _ _ _ x) = x
+    index SPDXLicenseListVersion_3_0  (PerV x _ _ _ _ _ _ _ _ _) = x
+    index SPDXLicenseListVersion_3_2  (PerV _ x _ _ _ _ _ _ _ _) = x
+    index SPDXLicenseListVersion_3_6  (PerV _ _ x _ _ _ _ _ _ _) = x
+    index SPDXLicenseListVersion_3_9  (PerV _ _ _ x _ _ _ _ _ _) = x
+    index SPDXLicenseListVersion_3_10 (PerV _ _ _ _ x _ _ _ _ _) = x
+    index SPDXLicenseListVersion_3_16 (PerV _ _ _ _ _ x _ _ _ _) = x
+    index SPDXLicenseListVersion_3_23 (PerV _ _ _ _ _ _ x _ _ _) = x
+    index SPDXLicenseListVersion_3_25 (PerV _ _ _ _ _ _ _ x _ _) = x
+    index SPDXLicenseListVersion_3_26 (PerV _ _ _ _ _ _ _ _ x _) = x
+    index SPDXLicenseListVersion_3_28 (PerV _ _ _ _ _ _ _ _ _ x) = x
 
     tabulate f = PerV
         (f SPDXLicenseListVersion_3_0)
@@ -92,6 +96,7 @@ instance Representable SPDXLicenseListVersion PerV where
         (f SPDXLicenseListVersion_3_23)
         (f SPDXLicenseListVersion_3_25)
         (f SPDXLicenseListVersion_3_26)
+        (f SPDXLicenseListVersion_3_28)
 
 -------------------------------------------------------------------------------
 -- Sorting

--- a/changelog.d/pr-11978
+++ b/changelog.d/pr-11978
@@ -1,0 +1,9 @@
+synopsis: add SPDX license data version 3.28
+packages: Cabal
+prs: #11978
+
+description: {
+
+- Update SPDX license list to version 3.28.0 2026-02-20
+
+}

--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -19,6 +19,12 @@ relative to the respective preceding *published* version.
     versions of the ``Cabal`` library denote unreleased development
     branches which have no stability guarantee.
 
+``cabal-version: 3.18``
+-----------------------
+
+* License fields use identifiers from SPDX License List version
+  ``3.28 2026-02-20``.
+
 ``cabal-version: 3.14``
 -----------------------
 

--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -25,6 +25,12 @@ relative to the respective preceding *published* version.
 * License fields use identifiers from SPDX License List version
   ``3.28 2026-02-20``.
 
+``cabal-version: 3.16``
+-----------------------
+
+* License fields use identifiers from SPDX License List version
+  ``3.26 2025-06-10``.
+
 ``cabal-version: 3.14``
 -----------------------
 

--- a/license-list-data/exceptions-3.28.json
+++ b/license-list-data/exceptions-3.28.json
@@ -1,0 +1,971 @@
+{
+  "licenseListVersion": "3.28.0",
+  "exceptions": [
+    {
+      "reference": "https://spdx.org/licenses/389-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/389-exception.json",
+      "referenceNumber": 49,
+      "name": "389 Directory Server Exception",
+      "licenseExceptionId": "389-exception",
+      "seeAlso": [
+        "http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text",
+        "https://web.archive.org/web/20080828121337/http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Asterisk-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Asterisk-exception.json",
+      "referenceNumber": 3,
+      "name": "Asterisk exception",
+      "licenseExceptionId": "Asterisk-exception",
+      "seeAlso": [
+        "https://github.com/asterisk/libpri/blob/7f91151e6bd10957c746c031c1f4a030e8146e9a/pri.c#L22",
+        "https://github.com/asterisk/libss7/blob/03e81bcd0d28ff25d4c77c78351ddadc82ff5c3f/ss7.c#L24"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Asterisk-linking-protocols-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Asterisk-linking-protocols-exception.json",
+      "referenceNumber": 4,
+      "name": "Asterisk linking protocols exception",
+      "licenseExceptionId": "Asterisk-linking-protocols-exception",
+      "seeAlso": [
+        "https://github.com/asterisk/asterisk/blob/115d7c01e32ccf4566a99e9d74e2b88830985a0b/LICENSE#L27"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Autoconf-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-2.0.json",
+      "referenceNumber": 30,
+      "name": "Autoconf exception 2.0",
+      "licenseExceptionId": "Autoconf-exception-2.0",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html",
+        "http://ftp.gnu.org/gnu/autoconf/autoconf-2.59.tar.gz"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Autoconf-exception-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-3.0.json",
+      "referenceNumber": 51,
+      "name": "Autoconf exception 3.0",
+      "licenseExceptionId": "Autoconf-exception-3.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Autoconf-exception-generic.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-generic.json",
+      "referenceNumber": 28,
+      "name": "Autoconf generic exception",
+      "licenseExceptionId": "Autoconf-exception-generic",
+      "seeAlso": [
+        "https://launchpad.net/ubuntu/precise/+source/xmltooling/+copyright",
+        "https://tracker.debian.org/media/packages/s/sipwitch/copyright-1.9.15-3",
+        "https://opensource.apple.com/source/launchd/launchd-258.1/launchd/compile.auto.html",
+        "https://git.savannah.gnu.org/gitweb/?p\u003dgnulib.git;a\u003dblob;f\u003dgnulib-tool;h\u003d029a8cf377ad8d8f2d9e54061bf2f20496ad2eef;hb\u003d73c74ba0197e6566da6882c87b1adee63e24d75c#l407"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Autoconf-exception-generic-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-generic-3.0.json",
+      "referenceNumber": 37,
+      "name": "Autoconf generic exception for GPL-3.0",
+      "licenseExceptionId": "Autoconf-exception-generic-3.0",
+      "seeAlso": [
+        "https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/config.guess"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Autoconf-exception-macro.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-macro.json",
+      "referenceNumber": 27,
+      "name": "Autoconf macro exception",
+      "licenseExceptionId": "Autoconf-exception-macro",
+      "seeAlso": [
+        "https://github.com/freedesktop/xorg-macros/blob/39f07f7db58ebbf3dcb64a2bf9098ed5cf3d1223/xorg-macros.m4.in",
+        "https://www.gnu.org/software/autoconf-archive/ax_pthread.html",
+        "https://launchpad.net/ubuntu/precise/+source/xmltooling/+copyright"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bison-exception-1.24.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bison-exception-1.24.json",
+      "referenceNumber": 15,
+      "name": "Bison exception 1.24",
+      "licenseExceptionId": "Bison-exception-1.24",
+      "seeAlso": [
+        "https://github.com/arineng/rwhoisd/blob/master/rwhoisd/mkdb/y.tab.c#L180"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bison-exception-2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bison-exception-2.2.json",
+      "referenceNumber": 74,
+      "name": "Bison exception 2.2",
+      "licenseExceptionId": "Bison-exception-2.2",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bootloader-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bootloader-exception.json",
+      "referenceNumber": 29,
+      "name": "Bootloader Distribution Exception",
+      "licenseExceptionId": "Bootloader-exception",
+      "seeAlso": [
+        "https://github.com/pyinstaller/pyinstaller/blob/develop/COPYING.txt"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/CGAL-linking-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CGAL-linking-exception.json",
+      "referenceNumber": 62,
+      "name": "CGAL Linking Exception",
+      "licenseExceptionId": "CGAL-linking-exception",
+      "seeAlso": [
+        "https://github.com/openscad/openscad/blob/openscad-2021.01/COPYING#L3",
+        "https://github.com/floriankirsch/OpenCSG/blob/opencsg-1-4-2-release/license.txt#L3"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Classpath-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Classpath-exception-2.0.json",
+      "referenceNumber": 2,
+      "name": "Classpath exception 2.0",
+      "licenseExceptionId": "Classpath-exception-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/software/classpath/license.html",
+        "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Classpath-exception-2.0-short.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Classpath-exception-2.0-short.json",
+      "referenceNumber": 52,
+      "name": "Classpath exception 2.0 - short",
+      "licenseExceptionId": "Classpath-exception-2.0-short",
+      "seeAlso": [
+        "https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%204.2/lazarus-4.2-0.tar.gz/download"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/CLISP-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CLISP-exception-2.0.json",
+      "referenceNumber": 21,
+      "name": "CLISP exception 2.0",
+      "licenseExceptionId": "CLISP-exception-2.0",
+      "seeAlso": [
+        "http://sourceforge.net/p/clisp/clisp/ci/default/tree/COPYRIGHT"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/cryptsetup-OpenSSL-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/cryptsetup-OpenSSL-exception.json",
+      "referenceNumber": 1,
+      "name": "cryptsetup OpenSSL exception",
+      "licenseExceptionId": "cryptsetup-OpenSSL-exception",
+      "seeAlso": [
+        "https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/COPYING",
+        "https://gitlab.nic.cz/datovka/datovka/-/blob/develop/COPYING",
+        "https://github.com/nbs-system/naxsi/blob/951123ad456bdf5ac94e8d8819342fe3d49bc002/naxsi_src/naxsi_raw.c",
+        "http://web.mit.edu/jgross/arch/amd64_deb60/bin/mosh",
+        "https://sourceforge.net/p/linux-ima/ima-evm-utils/ci/master/tree/src/evmctl.c#l30",
+        "https://github.com/ocaml-omake/omake/blob/master/LICENSE.OMake#L20"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Digia-Qt-LGPL-exception-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Digia-Qt-LGPL-exception-1.1.json",
+      "referenceNumber": 5,
+      "name": "Digia Qt LGPL Exception version 1.1",
+      "licenseExceptionId": "Digia-Qt-LGPL-exception-1.1",
+      "seeAlso": [
+        "https://src.fedoraproject.org/rpms/qtlockedfile/blob/rawhide/f/LGPL_EXCEPTION"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/DigiRule-FOSS-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DigiRule-FOSS-exception.json",
+      "referenceNumber": 80,
+      "name": "DigiRule FOSS License Exception",
+      "licenseExceptionId": "DigiRule-FOSS-exception",
+      "seeAlso": [
+        "http://www.digirulesolutions.com/drupal/foss"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/eCos-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/eCos-exception-2.0.json",
+      "referenceNumber": 36,
+      "name": "eCos exception 2.0",
+      "licenseExceptionId": "eCos-exception-2.0",
+      "seeAlso": [
+        "http://ecos.sourceware.org/license-overview.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/erlang-otp-linking-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/erlang-otp-linking-exception.json",
+      "referenceNumber": 26,
+      "name": "Erlang/OTP Linking Exception",
+      "licenseExceptionId": "erlang-otp-linking-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs",
+        "https://erlang.org/pipermail/erlang-questions/2012-May/066355.html",
+        "https://gitea.osmocom.org/erlang/osmo_ss7/src/commit/2286c1b8738d715950026650bf53f19a69d6ed0e/src/ss7_links.erl#L20"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Fawkes-Runtime-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Fawkes-Runtime-exception.json",
+      "referenceNumber": 25,
+      "name": "Fawkes Runtime Exception",
+      "licenseExceptionId": "Fawkes-Runtime-exception",
+      "seeAlso": [
+        "http://www.fawkesrobotics.org/about/license/"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/FLTK-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FLTK-exception.json",
+      "referenceNumber": 32,
+      "name": "FLTK exception",
+      "licenseExceptionId": "FLTK-exception",
+      "seeAlso": [
+        "http://www.fltk.org/COPYING.php"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/fmt-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/fmt-exception.json",
+      "referenceNumber": 72,
+      "name": "fmt exception",
+      "licenseExceptionId": "fmt-exception",
+      "seeAlso": [
+        "https://github.com/fmtlib/fmt/blob/master/LICENSE",
+        "https://github.com/fmtlib/fmt/blob/2eb363297b24cd71a68ccfb20ff755430f17e60f/LICENSE#L22C1-L27C62"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Font-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Font-exception-2.0.json",
+      "referenceNumber": 39,
+      "name": "Font exception 2.0",
+      "licenseExceptionId": "Font-exception-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/freertos-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/freertos-exception-2.0.json",
+      "referenceNumber": 38,
+      "name": "FreeRTOS Exception 2.0",
+      "licenseExceptionId": "freertos-exception-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20060809182744/http://www.freertos.org/a00114.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GCC-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GCC-exception-2.0.json",
+      "referenceNumber": 78,
+      "name": "GCC Runtime Library exception 2.0",
+      "licenseExceptionId": "GCC-exception-2.0",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10",
+        "https://sourceware.org/git/?p\u003dglibc.git;a\u003dblob;f\u003dcsu/abi-note.c;h\u003dc2ec208e94fbe91f63d3c375bd254b884695d190;hb\u003dHEAD"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GCC-exception-2.0-note.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GCC-exception-2.0-note.json",
+      "referenceNumber": 53,
+      "name": "GCC    Runtime Library exception 2.0 - note variant",
+      "licenseExceptionId": "GCC-exception-2.0-note",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dglibc.git;a\u003dblob;f\u003dsysdeps/x86_64/start.S"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GCC-exception-3.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GCC-exception-3.1.json",
+      "referenceNumber": 48,
+      "name": "GCC Runtime Library exception 3.1",
+      "licenseExceptionId": "GCC-exception-3.1",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Gmsh-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Gmsh-exception.json",
+      "referenceNumber": 22,
+      "name": "Gmsh exception",
+      "licenseExceptionId": "Gmsh-exception",
+      "seeAlso": [
+        "https://gitlab.onelab.info/gmsh/gmsh/-/raw/master/LICENSE.txt"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GNAT-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GNAT-exception.json",
+      "referenceNumber": 20,
+      "name": "GNAT exception",
+      "licenseExceptionId": "GNAT-exception",
+      "seeAlso": [
+        "https://github.com/AdaCore/florist/blob/master/libsrc/posix-configurable_file_limits.adb"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GNOME-examples-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GNOME-examples-exception.json",
+      "referenceNumber": 35,
+      "name": "GNOME examples exception",
+      "licenseExceptionId": "GNOME-examples-exception",
+      "seeAlso": [
+        "https://gitlab.gnome.org/Archive/gnome-devel-docs/-/blob/master/platform-demos/C/legal.xml?ref_type\u003dheads",
+        "http://meldmerge.org/help/"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GNU-compiler-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GNU-compiler-exception.json",
+      "referenceNumber": 19,
+      "name": "GNU Compiler Exception",
+      "licenseExceptionId": "GNU-compiler-exception",
+      "seeAlso": [
+        "https://sourceware.org/git?p\u003dbinutils-gdb.git;a\u003dblob;f\u003dlibiberty/unlink-if-ordinary.c;h\u003de49f2f2f67bfdb10d6b2bd579b0e01cad0fd708e;hb\u003dHEAD#l19",
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/powerpc/lib/crtsavres.S?h\u003dv6.16-rc6#n34"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/gnu-javamail-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/gnu-javamail-exception.json",
+      "referenceNumber": 71,
+      "name": "GNU JavaMail exception",
+      "licenseExceptionId": "gnu-javamail-exception",
+      "seeAlso": [
+        "http://www.gnu.org/software/classpathx/javamail/javamail.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-389-ds-base-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-389-ds-base-exception.json",
+      "referenceNumber": 13,
+      "name": "GPL-3.0 389 DS Base Exception",
+      "licenseExceptionId": "GPL-3.0-389-ds-base-exception",
+      "seeAlso": []
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-interface-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-interface-exception.json",
+      "referenceNumber": 11,
+      "name": "GPL-3.0 Interface Exception",
+      "licenseExceptionId": "GPL-3.0-interface-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.en.html#LinkingOverControlledInterface"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-linking-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-linking-exception.json",
+      "referenceNumber": 59,
+      "name": "GPL-3.0 Linking Exception",
+      "licenseExceptionId": "GPL-3.0-linking-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-linking-source-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-linking-source-exception.json",
+      "referenceNumber": 69,
+      "name": "GPL-3.0 Linking Exception (with Corresponding Source)",
+      "licenseExceptionId": "GPL-3.0-linking-source-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs",
+        "https://github.com/mirror/wget/blob/master/src/http.c#L20"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-CC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-CC-1.0.json",
+      "referenceNumber": 40,
+      "name": "GPL Cooperation Commitment 1.0",
+      "licenseExceptionId": "GPL-CC-1.0",
+      "seeAlso": [
+        "https://github.com/gplcc/gplcc/blob/master/Project/COMMITMENT",
+        "https://gplcc.github.io/gplcc/Project/README-PROJECT.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GStreamer-exception-2005.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GStreamer-exception-2005.json",
+      "referenceNumber": 16,
+      "name": "GStreamer Exception (2005)",
+      "licenseExceptionId": "GStreamer-exception-2005",
+      "seeAlso": [
+        "https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html?gi-language\u003dc#licensing-of-applications-using-gstreamer"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/GStreamer-exception-2008.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GStreamer-exception-2008.json",
+      "referenceNumber": 41,
+      "name": "GStreamer Exception (2008)",
+      "licenseExceptionId": "GStreamer-exception-2008",
+      "seeAlso": [
+        "https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html?gi-language\u003dc#licensing-of-applications-using-gstreamer"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/harbour-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/harbour-exception.json",
+      "referenceNumber": 60,
+      "name": "harbour exception",
+      "licenseExceptionId": "harbour-exception",
+      "seeAlso": [
+        "https://github.com/harbour/core/blob/master/LICENSE.txt#L44-L66"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/i2p-gpl-java-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/i2p-gpl-java-exception.json",
+      "referenceNumber": 58,
+      "name": "i2p GPL+Java Exception",
+      "licenseExceptionId": "i2p-gpl-java-exception",
+      "seeAlso": [
+        "http://geti2p.net/en/get-involved/develop/licenses#java_exception"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Independent-modules-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Independent-modules-exception.json",
+      "referenceNumber": 9,
+      "name": "Independent Module Linking exception",
+      "licenseExceptionId": "Independent-modules-exception",
+      "seeAlso": [
+        "https://gitlab.com/freepascal.org/fpc/source/-/blob/release_3_2_2/rtl/COPYING.FPC"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/KiCad-libraries-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/KiCad-libraries-exception.json",
+      "referenceNumber": 46,
+      "name": "KiCad Libraries Exception",
+      "licenseExceptionId": "KiCad-libraries-exception",
+      "seeAlso": [
+        "https://www.kicad.org/libraries/license/"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/kvirc-openssl-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/kvirc-openssl-exception.json",
+      "referenceNumber": 34,
+      "name": "kvirc OpenSSL Exception",
+      "licenseExceptionId": "kvirc-openssl-exception",
+      "seeAlso": [
+        "https://github.com/kvirc/KVIrc/blob/ba18690abb4f5ce77bb10164ee0835cc150f4a2a/doc/ABOUT-LICENSE#L34"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-linking-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-linking-exception.json",
+      "referenceNumber": 56,
+      "name": "LGPL-3.0 Linking Exception",
+      "licenseExceptionId": "LGPL-3.0-linking-exception",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/go-xmlpath/xmlpath/v2/LICENSE",
+        "https://github.com/goamz/goamz/blob/master/LICENSE",
+        "https://github.com/juju/errors/blob/master/LICENSE"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/libpri-OpenH323-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libpri-OpenH323-exception.json",
+      "referenceNumber": 81,
+      "name": "libpri OpenH323 exception",
+      "licenseExceptionId": "libpri-OpenH323-exception",
+      "seeAlso": [
+        "https://github.com/asterisk/libpri/blob/1.6.0/README#L19-L22"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Libtool-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Libtool-exception.json",
+      "referenceNumber": 14,
+      "name": "Libtool Exception",
+      "licenseExceptionId": "Libtool-exception",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/libtool.git/tree/m4/libtool.m4",
+        "https://git.savannah.gnu.org/cgit/libtool.git/tree/libltdl/lt__alloc.c#n15"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-syscall-note.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-syscall-note.json",
+      "referenceNumber": 44,
+      "name": "Linux Syscall Note",
+      "licenseExceptionId": "Linux-syscall-note",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/COPYING"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/LLGPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LLGPL.json",
+      "referenceNumber": 47,
+      "name": "LLGPL Preamble",
+      "licenseExceptionId": "LLGPL",
+      "seeAlso": [
+        "http://opensource.franz.com/preamble.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/LLVM-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LLVM-exception.json",
+      "referenceNumber": 82,
+      "name": "LLVM Exception",
+      "licenseExceptionId": "LLVM-exception",
+      "seeAlso": [
+        "http://llvm.org/foundation/relicensing/LICENSE.txt",
+        "https://web.archive.org/web/20240423023852/https://foundation.llvm.org/relicensing/LICENSE.txt"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/LZMA-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LZMA-exception.json",
+      "referenceNumber": 83,
+      "name": "LZMA exception",
+      "licenseExceptionId": "LZMA-exception",
+      "seeAlso": [
+        "http://nsis.sourceforge.net/Docs/AppendixI.html#I.6"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/mif-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mif-exception.json",
+      "referenceNumber": 43,
+      "name": "Macros and Inline Functions Exception",
+      "licenseExceptionId": "mif-exception",
+      "seeAlso": [
+        "http://www.scs.stanford.edu/histar/src/lib/cppsup/exception",
+        "http://dev.bertos.org/doxygen/",
+        "https://www.threadingbuildingblocks.org/licensing"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/mxml-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mxml-exception.json",
+      "referenceNumber": 61,
+      "name": "mxml Exception",
+      "licenseExceptionId": "mxml-exception",
+      "seeAlso": [
+        "https://github.com/michaelrsweet/mxml/blob/master/NOTICE",
+        "https://github.com/michaelrsweet/mxml/blob/master/LICENSE"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nokia-Qt-exception-1.1.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/Nokia-Qt-exception-1.1.json",
+      "referenceNumber": 7,
+      "name": "Nokia Qt LGPL exception 1.1",
+      "licenseExceptionId": "Nokia-Qt-exception-1.1",
+      "seeAlso": [
+        "https://www.keepassx.org/dev/projects/keepassx/repository/revisions/b8dfb9cc4d5133e0f09cd7533d15a4f1c19a40f2/entry/LICENSE.NOKIA-LGPL-EXCEPTION"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/OCaml-LGPL-linking-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OCaml-LGPL-linking-exception.json",
+      "referenceNumber": 54,
+      "name": "OCaml LGPL Linking Exception",
+      "licenseExceptionId": "OCaml-LGPL-linking-exception",
+      "seeAlso": [
+        "https://caml.inria.fr/ocaml/license.en.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/OCCT-exception-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OCCT-exception-1.0.json",
+      "referenceNumber": 67,
+      "name": "Open CASCADE Exception 1.0",
+      "licenseExceptionId": "OCCT-exception-1.0",
+      "seeAlso": [
+        "http://www.opencascade.com/content/licensing"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.json",
+      "referenceNumber": 23,
+      "name": "OpenJDK Assembly exception 1.0",
+      "licenseExceptionId": "OpenJDK-assembly-exception-1.0",
+      "seeAlso": [
+        "http://openjdk.java.net/legal/assembly-exception.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/openvpn-openssl-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/openvpn-openssl-exception.json",
+      "referenceNumber": 18,
+      "name": "OpenVPN OpenSSL Exception",
+      "licenseExceptionId": "openvpn-openssl-exception",
+      "seeAlso": [
+        "http://openvpn.net/index.php/license.html",
+        "https://github.com/psycopg/psycopg2/blob/2_9_3/LICENSE#L14"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/PCRE2-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PCRE2-exception.json",
+      "referenceNumber": 55,
+      "name": "PCRE2 exception",
+      "licenseExceptionId": "PCRE2-exception",
+      "seeAlso": [
+        "https://www.pcre.org/licence.txt"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/polyparse-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/polyparse-exception.json",
+      "referenceNumber": 6,
+      "name": "Polyparse Exception",
+      "licenseExceptionId": "polyparse-exception",
+      "seeAlso": [
+        "https://hackage.haskell.org/package/polyparse-1.13/src/COPYRIGHT"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/PS-or-PDF-font-exception-20170817.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PS-or-PDF-font-exception-20170817.json",
+      "referenceNumber": 66,
+      "name": "PS/PDF font exception (2017-08-17)",
+      "licenseExceptionId": "PS-or-PDF-font-exception-20170817",
+      "seeAlso": [
+        "https://github.com/ArtifexSoftware/urw-base35-fonts/blob/65962e27febc3883a17e651cdb23e783668c996f/LICENSE"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004-exception.json",
+      "referenceNumber": 10,
+      "name": "INRIA QPL 1.0 2004 variant exception",
+      "licenseExceptionId": "QPL-1.0-INRIA-2004-exception",
+      "seeAlso": [
+        "https://git.frama-c.com/pub/frama-c/-/blob/master/licenses/Q_MODIFIED_LICENSE",
+        "https://github.com/maranget/hevea/blob/master/LICENSE"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Qt-GPL-exception-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Qt-GPL-exception-1.0.json",
+      "referenceNumber": 64,
+      "name": "Qt GPL exception 1.0",
+      "licenseExceptionId": "Qt-GPL-exception-1.0",
+      "seeAlso": [
+        "http://code.qt.io/cgit/qt/qtbase.git/tree/LICENSE.GPL3-EXCEPT"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Qt-LGPL-exception-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Qt-LGPL-exception-1.1.json",
+      "referenceNumber": 79,
+      "name": "Qt LGPL exception 1.1",
+      "licenseExceptionId": "Qt-LGPL-exception-1.1",
+      "seeAlso": [
+        "http://code.qt.io/cgit/qt/qtbase.git/tree/LGPL_EXCEPTION.txt"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Qwt-exception-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Qwt-exception-1.0.json",
+      "referenceNumber": 75,
+      "name": "Qwt exception 1.0",
+      "licenseExceptionId": "Qwt-exception-1.0",
+      "seeAlso": [
+        "http://qwt.sourceforge.net/qwtlicense.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/romic-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/romic-exception.json",
+      "referenceNumber": 76,
+      "name": "Romic Exception",
+      "licenseExceptionId": "romic-exception",
+      "seeAlso": [
+        "https://web.archive.org/web/20210124015834/http://mo.morsi.org/blog/2009/08/13/lesser_affero_gplv3/",
+        "https://sourceforge.net/p/romic/code/ci/3ab2856180cf0d8b007609af53154cf092efc58f/tree/COPYING",
+        "https://github.com/moll/node-mitm/blob/bbf24b8bd7596dc6e091e625363161ce91984fc7/LICENSE#L8-L11",
+        "https://github.com/zenbones/SmallMind/blob/3c62b5995fe7f27c453f140ff9b60560a0893f2a/COPYRIGHT#L25-L30",
+        "https://github.com/CubeArtisan/cubeartisan/blob/2c6ab53455237b88a3ea07be02a838a135c4ab79/LICENSE.LESSER#L10-L15",
+        "https://github.com/savearray2/py.js/blob/b781273c08c8afa89f4954de4ecf42ec01429bae/README.md#license"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/RRDtool-FLOSS-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RRDtool-FLOSS-exception-2.0.json",
+      "referenceNumber": 70,
+      "name": "RRDtool FLOSS exception 2.0",
+      "licenseExceptionId": "RRDtool-FLOSS-exception-2.0",
+      "seeAlso": [
+        "https://github.com/oetiker/rrdtool-1.x/blob/master/COPYRIGHT#L25-L90",
+        "https://oss.oetiker.ch/rrdtool/license.en.html"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/rsync-linking-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/rsync-linking-exception.json",
+      "referenceNumber": 33,
+      "name": "rsync Linking Exception",
+      "licenseExceptionId": "rsync-linking-exception",
+      "seeAlso": [
+        "https://github.com/RsyncProject/rsync/blob/master/COPYING"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/SANE-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SANE-exception.json",
+      "referenceNumber": 63,
+      "name": "SANE Exception",
+      "licenseExceptionId": "SANE-exception",
+      "seeAlso": [
+        "https://github.com/alexpevzner/sane-airscan/blob/master/LICENSE",
+        "https://gitlab.com/sane-project/backends/-/blob/master/sanei/sanei_pp.c?ref_type\u003dheads",
+        "https://gitlab.com/sane-project/frontends/-/blob/master/sanei/sanei_codec_ascii.c?ref_type\u003dheads"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-2.0.json",
+      "referenceNumber": 24,
+      "name": "Solderpad Hardware License v2.0",
+      "licenseExceptionId": "SHL-2.0",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-2.0/"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-2.1.json",
+      "referenceNumber": 45,
+      "name": "Solderpad Hardware License v2.1",
+      "licenseExceptionId": "SHL-2.1",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-2.1/"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Simple-Library-Usage-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Simple-Library-Usage-exception.json",
+      "referenceNumber": 8,
+      "name": "Simple Library Usage Exception",
+      "licenseExceptionId": "Simple-Library-Usage-exception",
+      "seeAlso": [
+        "https://sourceforge.net/p/teem/code/HEAD/tree/teem/trunk/LICENSE.txt"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/sqlitestudio-OpenSSL-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/sqlitestudio-OpenSSL-exception.json",
+      "referenceNumber": 12,
+      "name": "sqlitestudio OpenSSL exception",
+      "licenseExceptionId": "sqlitestudio-OpenSSL-exception",
+      "seeAlso": [
+        "https://github.com/pawelsalawa/sqlitestudio/blob/master/LICENSE"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/stunnel-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/stunnel-exception.json",
+      "referenceNumber": 68,
+      "name": "stunnel Exception",
+      "licenseExceptionId": "stunnel-exception",
+      "seeAlso": [
+        "https://github.com/mtrojnar/stunnel/blob/master/COPYING.md"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/SWI-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SWI-exception.json",
+      "referenceNumber": 77,
+      "name": "SWI exception",
+      "licenseExceptionId": "SWI-exception",
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/packages-clpqr/blob/bfa80b9270274f0800120d5b8e6fef42ac2dc6a5/clpqr/class.pl"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Swift-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Swift-exception.json",
+      "referenceNumber": 57,
+      "name": "Swift Exception",
+      "licenseExceptionId": "Swift-exception",
+      "seeAlso": [
+        "https://swift.org/LICENSE.txt",
+        "https://github.com/apple/swift-package-manager/blob/7ab2275f447a5eb37497ed63a9340f8a6d1e488b/LICENSE.txt#L205"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Texinfo-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Texinfo-exception.json",
+      "referenceNumber": 73,
+      "name": "Texinfo exception",
+      "licenseExceptionId": "Texinfo-exception",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/automake.git/tree/lib/texinfo.tex?h\u003dv1.16.5#n23"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/u-boot-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/u-boot-exception-2.0.json",
+      "referenceNumber": 84,
+      "name": "U-Boot exception 2.0",
+      "licenseExceptionId": "u-boot-exception-2.0",
+      "seeAlso": [
+        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003dLicenses/Exceptions"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/UBDL-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UBDL-exception.json",
+      "referenceNumber": 31,
+      "name": "Unmodified Binary Distribution exception",
+      "licenseExceptionId": "UBDL-exception",
+      "seeAlso": [
+        "https://github.com/ipxe/ipxe/blob/master/COPYING.UBDL"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Universal-FOSS-exception-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Universal-FOSS-exception-1.0.json",
+      "referenceNumber": 50,
+      "name": "Universal FOSS Exception, Version 1.0",
+      "licenseExceptionId": "Universal-FOSS-exception-1.0",
+      "seeAlso": [
+        "https://oss.oracle.com/licenses/universal-foss-exception/"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/vsftpd-openssl-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/vsftpd-openssl-exception.json",
+      "referenceNumber": 65,
+      "name": "vsftpd OpenSSL exception",
+      "licenseExceptionId": "vsftpd-openssl-exception",
+      "seeAlso": [
+        "https://git.stg.centos.org/source-git/vsftpd/blob/f727873674d9c9cd7afcae6677aa782eb54c8362/f/LICENSE",
+        "https://launchpad.net/debian/squeeze/+source/vsftpd/+copyright",
+        "https://github.com/richardcochran/vsftpd/blob/master/COPYING"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/WxWindows-exception-3.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/WxWindows-exception-3.1.json",
+      "referenceNumber": 17,
+      "name": "WxWindows Library Exception 3.1",
+      "licenseExceptionId": "WxWindows-exception-3.1",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/WXwindows"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/x11vnc-openssl-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/x11vnc-openssl-exception.json",
+      "referenceNumber": 42,
+      "name": "x11vnc OpenSSL Exception",
+      "licenseExceptionId": "x11vnc-openssl-exception",
+      "seeAlso": [
+        "https://github.com/LibVNC/x11vnc/blob/master/src/8to24.c#L22"
+      ]
+    }
+  ],
+  "releaseDate": "2026-02-20T00:00:00Z"
+}

--- a/license-list-data/licenses-3.28.json
+++ b/license-list-data/licenses-3.28.json
@@ -1,0 +1,9119 @@
+{
+  "licenseListVersion": "3.28.0",
+  "licenses": [
+    {
+      "reference": "https://spdx.org/licenses/0BSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/0BSD.json",
+      "referenceNumber": 422,
+      "name": "BSD Zero Clause License",
+      "licenseId": "0BSD",
+      "seeAlso": [
+        "http://landley.net/toybox/license.html",
+        "https://opensource.org/licenses/0BSD"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/3D-Slicer-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/3D-Slicer-1.0.json",
+      "referenceNumber": 134,
+      "name": "3D Slicer License v1.0",
+      "licenseId": "3D-Slicer-1.0",
+      "seeAlso": [
+        "https://slicer.org/LICENSE",
+        "https://github.com/Slicer/Slicer/blob/main/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AAL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AAL.json",
+      "referenceNumber": 94,
+      "name": "Attribution Assurance License",
+      "licenseId": "AAL",
+      "seeAlso": [
+        "https://opensource.org/licenses/attribution"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Abstyles.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
+      "referenceNumber": 16,
+      "name": "Abstyles License",
+      "licenseId": "Abstyles",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Abstyles"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AdaCore-doc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AdaCore-doc.json",
+      "referenceNumber": 291,
+      "name": "AdaCore Doc License",
+      "licenseId": "AdaCore-doc",
+      "seeAlso": [
+        "https://github.com/AdaCore/xmlada/blob/master/docs/index.rst",
+        "https://github.com/AdaCore/gnatcoll-core/blob/master/docs/index.rst",
+        "https://github.com/AdaCore/gnatcoll-db/blob/master/docs/index.rst"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Adobe-2006.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
+      "referenceNumber": 373,
+      "name": "Adobe Systems Incorporated Source Code License Agreement",
+      "licenseId": "Adobe-2006",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Adobe-Display-PostScript.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Adobe-Display-PostScript.json",
+      "referenceNumber": 136,
+      "name": "Adobe Display PostScript License",
+      "licenseId": "Adobe-Display-PostScript",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type\u003dheads#L752"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
+      "referenceNumber": 345,
+      "name": "Adobe Glyph List License",
+      "licenseId": "Adobe-Glyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Adobe-Utopia.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Adobe-Utopia.json",
+      "referenceNumber": 121,
+      "name": "Adobe Utopia Font License",
+      "licenseId": "Adobe-Utopia",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/font/adobe-utopia-100dpi/-/blob/master/COPYING?ref_type\u003dheads"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ADSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ADSL.json",
+      "referenceNumber": 242,
+      "name": "Amazon Digital Services License",
+      "licenseId": "ADSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Advanced-Cryptics-Dictionary.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Advanced-Cryptics-Dictionary.json",
+      "referenceNumber": 511,
+      "name": "Advanced Cryptics Dictionary License",
+      "licenseId": "Advanced-Cryptics-Dictionary",
+      "seeAlso": [
+        "https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2020.12.07-0.tar.bz2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
+      "referenceNumber": 122,
+      "name": "Academic Free License v1.1",
+      "licenseId": "AFL-1.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
+        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
+      "referenceNumber": 495,
+      "name": "Academic Free License v1.2",
+      "licenseId": "AFL-1.2",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
+        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
+      "referenceNumber": 496,
+      "name": "Academic Free License v2.0",
+      "licenseId": "AFL-2.0",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
+      "referenceNumber": 460,
+      "name": "Academic Free License v2.1",
+      "licenseId": "AFL-2.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
+      "referenceNumber": 478,
+      "name": "Academic Free License v3.0",
+      "licenseId": "AFL-3.0",
+      "seeAlso": [
+        "http://www.rosenlaw.com/AFL3.0.htm",
+        "https://opensource.org/licenses/afl-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Afmparse.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
+      "referenceNumber": 560,
+      "name": "Afmparse License",
+      "licenseId": "Afmparse",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Afmparse"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
+      "referenceNumber": 635,
+      "name": "Affero General Public License v1.0",
+      "licenseId": "AGPL-1.0",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
+      "referenceNumber": 660,
+      "name": "Affero General Public License v1.0 only",
+      "licenseId": "AGPL-1.0-only",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
+      "referenceNumber": 13,
+      "name": "Affero General Public License v1.0 or later",
+      "licenseId": "AGPL-1.0-or-later",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
+      "referenceNumber": 90,
+      "name": "GNU Affero General Public License v3.0",
+      "licenseId": "AGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
+      "referenceNumber": 687,
+      "name": "GNU Affero General Public License v3.0 only",
+      "licenseId": "AGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
+      "referenceNumber": 380,
+      "name": "GNU Affero General Public License v3.0 or later",
+      "licenseId": "AGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Aladdin.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
+      "referenceNumber": 700,
+      "name": "Aladdin Free Public License",
+      "licenseId": "Aladdin",
+      "seeAlso": [
+        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ALGLIB-Documentation.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ALGLIB-Documentation.json",
+      "referenceNumber": 91,
+      "name": "ALGLIB Documentation License",
+      "licenseId": "ALGLIB-Documentation",
+      "seeAlso": [],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AMD-newlib.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AMD-newlib.json",
+      "referenceNumber": 439,
+      "name": "AMD newlib License",
+      "licenseId": "AMD-newlib",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/sys/a29khif/_close.S;h\u003d04f52ae00de1dafbd9055ad8d73c5c697a3aae7f;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AMDPLPA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
+      "referenceNumber": 645,
+      "name": "AMD\u0027s plpa_map.c License",
+      "licenseId": "AMDPLPA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AML.json",
+      "referenceNumber": 615,
+      "name": "Apple MIT License",
+      "licenseId": "AML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AML-glslang.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AML-glslang.json",
+      "referenceNumber": 95,
+      "name": "AML glslang variant License",
+      "licenseId": "AML-glslang",
+      "seeAlso": [
+        "https://github.com/KhronosGroup/glslang/blob/main/LICENSE.txt#L949",
+        "https://docs.omniverse.nvidia.com/install-guide/latest/common/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AMPAS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
+      "referenceNumber": 260,
+      "name": "Academy of Motion Picture Arts and Sciences BSD",
+      "licenseId": "AMPAS",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ANTLR-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
+      "referenceNumber": 375,
+      "name": "ANTLR Software Rights Notice",
+      "licenseId": "ANTLR-PD",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
+      "referenceNumber": 73,
+      "name": "ANTLR Software Rights Notice with license fallback",
+      "licenseId": "ANTLR-PD-fallback",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/any-OSI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/any-OSI.json",
+      "referenceNumber": 347,
+      "name": "Any OSI License",
+      "licenseId": "any-OSI",
+      "seeAlso": [
+        "https://metacpan.org/pod/Exporter::Tidy#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/any-OSI-perl-modules.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/any-OSI-perl-modules.json",
+      "referenceNumber": 401,
+      "name": "Any OSI License - Perl Modules",
+      "licenseId": "any-OSI-perl-modules",
+      "seeAlso": [
+        "https://metacpan.org/release/JUERD/Exporter-Tidy-0.09/view/Tidy.pm#LICENSE",
+        "https://metacpan.org/pod/Qmail::Deliverable::Client#LICENSE",
+        "https://metacpan.org/pod/Net::MQTT::Simple#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Apache-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
+      "referenceNumber": 683,
+      "name": "Apache License 1.0",
+      "licenseId": "Apache-1.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-1.0"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Apache-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
+      "referenceNumber": 217,
+      "name": "Apache License 1.1",
+      "licenseId": "Apache-1.1",
+      "seeAlso": [
+        "http://apache.org/licenses/LICENSE-1.1",
+        "https://opensource.org/licenses/Apache-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Apache-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
+      "referenceNumber": 102,
+      "name": "Apache License 2.0",
+      "licenseId": "Apache-2.0",
+      "seeAlso": [
+        "https://www.apache.org/licenses/LICENSE-2.0",
+        "https://opensource.org/licenses/Apache-2.0",
+        "https://opensource.org/license/apache-2-0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APAFML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APAFML.json",
+      "referenceNumber": 127,
+      "name": "Adobe Postscript AFM License",
+      "licenseId": "APAFML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
+      "referenceNumber": 155,
+      "name": "Adaptive Public License 1.0",
+      "licenseId": "APL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/APL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/App-s2p.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
+      "referenceNumber": 414,
+      "name": "App::s2p License",
+      "licenseId": "App-s2p",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/App-s2p"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
+      "referenceNumber": 694,
+      "name": "Apple Public Source License 1.0",
+      "licenseId": "APSL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
+      "referenceNumber": 590,
+      "name": "Apple Public Source License 1.1",
+      "licenseId": "APSL-1.1",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
+      "referenceNumber": 581,
+      "name": "Apple Public Source License 1.2",
+      "licenseId": "APSL-1.2",
+      "seeAlso": [
+        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
+      "referenceNumber": 357,
+      "name": "Apple Public Source License 2.0",
+      "licenseId": "APSL-2.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/license/apsl/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Arphic-1999.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
+      "referenceNumber": 272,
+      "name": "Arphic Public License",
+      "licenseId": "Arphic-1999",
+      "seeAlso": [
+        "http://ftp.gnu.org/gnu/non-gnu/chinese-fonts-truetype/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
+      "referenceNumber": 377,
+      "name": "Artistic License 1.0",
+      "licenseId": "Artistic-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
+      "referenceNumber": 477,
+      "name": "Artistic License 1.0 w/clause 8",
+      "licenseId": "Artistic-1.0-cl8",
+      "seeAlso": [
+        "https://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
+      "referenceNumber": 409,
+      "name": "Artistic License 1.0 (Perl)",
+      "licenseId": "Artistic-1.0-Perl",
+      "seeAlso": [
+        "http://dev.perl.org/licenses/artistic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
+      "referenceNumber": 631,
+      "name": "Artistic License 2.0",
+      "licenseId": "Artistic-2.0",
+      "seeAlso": [
+        "http://www.perlfoundation.org/artistic_license_2_0",
+        "https://www.perlfoundation.org/artistic-license-20.html",
+        "https://opensource.org/licenses/artistic-license-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-dist.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-dist.json",
+      "referenceNumber": 605,
+      "name": "Artistic License 1.0 (dist)",
+      "licenseId": "Artistic-dist",
+      "seeAlso": [
+        "https://github.com/pexip/os-perl/blob/833cf4c86cc465ccfc627ff16db67e783156a248/debian/copyright#L2720-L2845"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Aspell-RU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Aspell-RU.json",
+      "referenceNumber": 350,
+      "name": "Aspell Russian License",
+      "licenseId": "Aspell-RU",
+      "seeAlso": [
+        "https://ftp.gnu.org/gnu/aspell/dict/ru/aspell6-ru-0.99f7-1.tar.bz2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.json",
+      "referenceNumber": 190,
+      "name": "ASWF Digital Assets License version 1.0",
+      "licenseId": "ASWF-Digital-Assets-1.0",
+      "seeAlso": [
+        "https://github.com/AcademySoftwareFoundation/foundation/blob/main/digital_assets/aswf_digital_assets_license_v1.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.json",
+      "referenceNumber": 610,
+      "name": "ASWF Digital Assets License 1.1",
+      "licenseId": "ASWF-Digital-Assets-1.1",
+      "seeAlso": [
+        "https://github.com/AcademySoftwareFoundation/foundation/blob/main/digital_assets/aswf_digital_assets_license_v1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Baekmuk.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
+      "referenceNumber": 564,
+      "name": "Baekmuk License",
+      "licenseId": "Baekmuk",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:Baekmuk?rd\u003dLicensing/Baekmuk"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bahyph.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
+      "referenceNumber": 525,
+      "name": "Bahyph License",
+      "licenseId": "Bahyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Bahyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Barr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Barr.json",
+      "referenceNumber": 543,
+      "name": "Barr License",
+      "licenseId": "Barr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Barr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/bcrypt-Solar-Designer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/bcrypt-Solar-Designer.json",
+      "referenceNumber": 494,
+      "name": "bcrypt Solar Designer License",
+      "licenseId": "bcrypt-Solar-Designer",
+      "seeAlso": [
+        "https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/ext/mri/crypt_blowfish.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Beerware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Beerware.json",
+      "referenceNumber": 429,
+      "name": "Beerware License",
+      "licenseId": "Beerware",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Beerware",
+        "https://people.freebsd.org/~phk/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bitstream-Charter.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bitstream-Charter.json",
+      "referenceNumber": 216,
+      "name": "Bitstream Charter Font License",
+      "licenseId": "Bitstream-Charter",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Charter#License_Text",
+        "https://raw.githubusercontent.com/blackhole89/notekit/master/data/fonts/Charter%20license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
+      "referenceNumber": 680,
+      "name": "Bitstream Vera Font License",
+      "licenseId": "Bitstream-Vera",
+      "seeAlso": [
+        "https://web.archive.org/web/20080207013128/http://www.gnome.org/fonts/",
+        "https://docubrain.com/sites/default/files/licenses/bitstream-vera.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
+      "referenceNumber": 224,
+      "name": "BitTorrent Open Source License v1.0",
+      "licenseId": "BitTorrent-1.0",
+      "seeAlso": [
+        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1\u003d1.1\u0026r2\u003d1.1.1.1\u0026diff_format\u003ds"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
+      "referenceNumber": 352,
+      "name": "BitTorrent Open Source License v1.1",
+      "licenseId": "BitTorrent-1.1",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/blessing.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/blessing.json",
+      "referenceNumber": 617,
+      "name": "SQLite Blessing",
+      "licenseId": "blessing",
+      "seeAlso": [
+        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln\u003d4-9",
+        "https://sqlite.org/src/artifact/df5091916dbb40e6"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
+      "referenceNumber": 515,
+      "name": "Blue Oak Model License 1.0.0",
+      "licenseId": "BlueOak-1.0.0",
+      "seeAlso": [
+        "https://blueoakcouncil.org/license/1.0.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Boehm-GC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Boehm-GC.json",
+      "referenceNumber": 251,
+      "name": "Boehm-Demers-Weiser GC License",
+      "licenseId": "Boehm-GC",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT#Another_Minimal_variant_(found_in_libatomic_ops)",
+        "https://github.com/uim/libgcroots/blob/master/COPYING",
+        "https://github.com/ivmai/libatomic_ops/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Boehm-GC-without-fee.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Boehm-GC-without-fee.json",
+      "referenceNumber": 580,
+      "name": "Boehm-Demers-Weiser GC License (without fee)",
+      "licenseId": "Boehm-GC-without-fee",
+      "seeAlso": [
+        "https://github.com/MariaDB/server/blob/11.6/libmysqld/lib_sql.cc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BOLA-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BOLA-1.1.json",
+      "referenceNumber": 606,
+      "name": "Buena Onda License Agreement v1.1",
+      "licenseId": "BOLA-1.1",
+      "seeAlso": [
+        "https://blitiri.com.ar/p/bola/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Borceux.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Borceux.json",
+      "referenceNumber": 81,
+      "name": "Borceux license",
+      "licenseId": "Borceux",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Borceux"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Brian-Gladman-2-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-2-Clause.json",
+      "referenceNumber": 522,
+      "name": "Brian Gladman 2-Clause License",
+      "licenseId": "Brian-Gladman-2-Clause",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L140-L156",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause.json",
+      "referenceNumber": 476,
+      "name": "Brian Gladman 3-Clause License",
+      "licenseId": "Brian-Gladman-3-Clause",
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/packages-clib/blob/master/sha1/brg_endian.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
+      "referenceNumber": 718,
+      "name": "BSD 1-Clause License",
+      "licenseId": "BSD-1-Clause",
+      "seeAlso": [
+        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
+      "referenceNumber": 431,
+      "name": "BSD 2-Clause \"Simplified\" License",
+      "licenseId": "BSD-2-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-2-Clause"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Darwin.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Darwin.json",
+      "referenceNumber": 244,
+      "name": "BSD 2-Clause - Ian Darwin variant",
+      "licenseId": "BSD-2-Clause-Darwin",
+      "seeAlso": [
+        "https://github.com/file/file/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-first-lines.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-first-lines.json",
+      "referenceNumber": 524,
+      "name": "BSD 2-Clause - first lines requirement",
+      "licenseId": "BSD-2-Clause-first-lines",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L664-L690",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
+      "referenceNumber": 537,
+      "name": "BSD 2-Clause FreeBSD License",
+      "licenseId": "BSD-2-Clause-FreeBSD",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
+      "referenceNumber": 707,
+      "name": "BSD 2-Clause NetBSD License",
+      "licenseId": "BSD-2-Clause-NetBSD",
+      "seeAlso": [
+        "http://www.netbsd.org/about/redistribution.html#default"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
+      "referenceNumber": 305,
+      "name": "BSD-2-Clause Plus Patent License",
+      "licenseId": "BSD-2-Clause-Patent",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSDplusPatent"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.json",
+      "referenceNumber": 29,
+      "name": "BSD 2-Clause pkgconf disclaimer variant",
+      "licenseId": "BSD-2-Clause-pkgconf-disclaimer",
+      "seeAlso": [
+        "https://github.com/audacious-media-player/audacious/blob/master/src/audacious/main.cc",
+        "https://github.com/audacious-media-player/audacious/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
+      "referenceNumber": 316,
+      "name": "BSD 2-Clause with views sentence",
+      "licenseId": "BSD-2-Clause-Views",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html",
+        "https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh",
+        "https://github.com/protegeproject/protege/blob/master/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
+      "referenceNumber": 290,
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-3-Clause",
+        "https://www.eclipse.org/org/documents/edl-v10.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-acpica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-acpica.json",
+      "referenceNumber": 5,
+      "name": "BSD 3-Clause acpica variant",
+      "licenseId": "BSD-3-Clause-acpica",
+      "seeAlso": [
+        "https://github.com/acpica/acpica/blob/master/source/common/acfileio.c#L119"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
+      "referenceNumber": 575,
+      "name": "BSD with attribution",
+      "licenseId": "BSD-3-Clause-Attribution",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
+      "referenceNumber": 579,
+      "name": "BSD 3-Clause Clear License",
+      "licenseId": "BSD-3-Clause-Clear",
+      "seeAlso": [
+        "http://labs.metacarta.com/license-explanation.html#license"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-flex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-flex.json",
+      "referenceNumber": 318,
+      "name": "BSD 3-Clause Flex variant",
+      "licenseId": "BSD-3-Clause-flex",
+      "seeAlso": [
+        "https://github.com/westes/flex/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-HP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-HP.json",
+      "referenceNumber": 317,
+      "name": "Hewlett-Packard BSD variant license",
+      "licenseId": "BSD-3-Clause-HP",
+      "seeAlso": [
+        "https://github.com/zdohnal/hplip/blob/master/COPYING#L939"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
+      "referenceNumber": 54,
+      "name": "Lawrence Berkeley National Labs BSD variant license",
+      "licenseId": "BSD-3-Clause-LBNL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
+      "referenceNumber": 408,
+      "name": "BSD 3-Clause Modification",
+      "licenseId": "BSD-3-Clause-Modification",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:BSD#Modification_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
+      "referenceNumber": 199,
+      "name": "BSD 3-Clause No Military License",
+      "licenseId": "BSD-3-Clause-No-Military-License",
+      "seeAlso": [
+        "https://gitlab.syncad.com/hive/dhive/-/blob/master/LICENSE",
+        "https://github.com/greymass/swift-eosio/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
+      "referenceNumber": 398,
+      "name": "BSD 3-Clause No Nuclear License",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License",
+      "seeAlso": [
+        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
+      "referenceNumber": 459,
+      "name": "BSD 3-Clause No Nuclear License 2014",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+      "seeAlso": [
+        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
+      "referenceNumber": 601,
+      "name": "BSD 3-Clause No Nuclear Warranty",
+      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
+      "seeAlso": [
+        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
+      "referenceNumber": 489,
+      "name": "BSD 3-Clause Open MPI variant",
+      "licenseId": "BSD-3-Clause-Open-MPI",
+      "seeAlso": [
+        "https://www.open-mpi.org/community/license.php",
+        "http://www.netlib.org/lapack/LICENSE.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Sun.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Sun.json",
+      "referenceNumber": 337,
+      "name": "BSD 3-Clause Sun Microsystems",
+      "licenseId": "BSD-3-Clause-Sun",
+      "seeAlso": [
+        "https://github.com/xmlark/msv/blob/b9316e2f2270bc1606952ea4939ec87fbba157f3/xsdlib/src/main/java/com/sun/msv/datatype/regexp/InternalImpl.java"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Tso.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Tso.json",
+      "referenceNumber": 650,
+      "name": "BSD 3-Clause Tso variant",
+      "licenseId": "BSD-3-Clause-Tso",
+      "seeAlso": [
+        "https://www.x.org/archive/current/doc/xorg-docs/License.html#Theodore_Tso"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
+      "referenceNumber": 294,
+      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
+      "licenseId": "BSD-4-Clause",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BSD_4Clause",
+        "https://github.com/jsommers/pytricia/blob/master/patricia.c#L33-L67"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
+      "referenceNumber": 214,
+      "name": "BSD 4 Clause Shortened",
+      "licenseId": "BSD-4-Clause-Shortened",
+      "seeAlso": [
+        "https://metadata.ftp-master.debian.org/changelogs//main/a/arpwatch/arpwatch_2.1a15-7_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
+      "referenceNumber": 343,
+      "name": "BSD-4-Clause (University of California-Specific)",
+      "licenseId": "BSD-4-Clause-UC",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4.3RENO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4.3RENO.json",
+      "referenceNumber": 229,
+      "name": "BSD 4.3 RENO License",
+      "licenseId": "BSD-4.3RENO",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dbinutils-gdb.git;a\u003dblob;f\u003dlibiberty/strcasecmp.c;h\u003d131d81c2ce7881fa48c363dc5bf5fb302c61ce0b;hb\u003dHEAD",
+        "https://git.openldap.org/openldap/openldap/-/blob/master/COPYRIGHT#L55-63"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4.3TAHOE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4.3TAHOE.json",
+      "referenceNumber": 497,
+      "name": "BSD 4.3 TAHOE License",
+      "licenseId": "BSD-4.3TAHOE",
+      "seeAlso": [
+        "https://github.com/389ds/389-ds-base/blob/main/ldap/include/sysexits-compat.h#L15",
+        "https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id\u003da74c6b4ee49397cf330b333da1042bffa60ed14f#n1788"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.json",
+      "referenceNumber": 150,
+      "name": "BSD Advertising Acknowledgement License",
+      "licenseId": "BSD-Advertising-Acknowledgement",
+      "seeAlso": [
+        "https://github.com/python-excel/xlrd/blob/master/LICENSE#L33"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.json",
+      "referenceNumber": 534,
+      "name": "BSD with Attribution and HPND disclaimer",
+      "licenseId": "BSD-Attribution-HPND-disclaimer",
+      "seeAlso": [
+        "https://github.com/cyrusimap/cyrus-sasl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Inferno-Nettverk.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Inferno-Nettverk.json",
+      "referenceNumber": 583,
+      "name": "BSD-Inferno-Nettverk",
+      "licenseId": "BSD-Inferno-Nettverk",
+      "seeAlso": [
+        "https://www.inet.no/dante/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Mark-Modifications.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Mark-Modifications.json",
+      "referenceNumber": 128,
+      "name": "BSD Mark Modifications License",
+      "licenseId": "BSD-Mark-Modifications",
+      "seeAlso": [
+        "https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2020.12.07-0.tar.bz2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Protection.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
+      "referenceNumber": 339,
+      "name": "BSD Protection License",
+      "licenseId": "BSD-Protection",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Source-beginning-file.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Source-beginning-file.json",
+      "referenceNumber": 722,
+      "name": "BSD Source Code Attribution - beginning of file variant",
+      "licenseId": "BSD-Source-beginning-file",
+      "seeAlso": [
+        "https://github.com/lattera/freebsd/blob/master/sys/cam/cam.c#L4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
+      "referenceNumber": 86,
+      "name": "BSD Source Code Attribution",
+      "licenseId": "BSD-Source-Code",
+      "seeAlso": [
+        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Systemics.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Systemics.json",
+      "referenceNumber": 448,
+      "name": "Systemics BSD variant license",
+      "licenseId": "BSD-Systemics",
+      "seeAlso": [
+        "https://metacpan.org/release/DPARIS/Crypt-DES-2.07/source/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Systemics-W3Works.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Systemics-W3Works.json",
+      "referenceNumber": 445,
+      "name": "Systemics W3Works BSD variant license",
+      "licenseId": "BSD-Systemics-W3Works",
+      "seeAlso": [
+        "https://metacpan.org/release/DPARIS/Crypt-Blowfish-2.14/source/COPYRIGHT#L7"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
+      "referenceNumber": 591,
+      "name": "Boost Software License 1.0",
+      "licenseId": "BSL-1.0",
+      "seeAlso": [
+        "http://www.boost.org/LICENSE_1_0.txt",
+        "https://opensource.org/licenses/BSL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Buddy.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Buddy.json",
+      "referenceNumber": 355,
+      "name": "Buddy License",
+      "licenseId": "Buddy",
+      "seeAlso": [
+        "https://sourceforge.net/p/buddy/gitcode/ci/master/tree/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BUSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
+      "referenceNumber": 333,
+      "name": "Business Source License 1.1",
+      "licenseId": "BUSL-1.1",
+      "seeAlso": [
+        "https://mariadb.com/bsl11/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
+      "referenceNumber": 598,
+      "name": "bzip2 and libbzip2 License v1.0.5",
+      "licenseId": "bzip2-1.0.5",
+      "seeAlso": [
+        "https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
+      "referenceNumber": 599,
+      "name": "bzip2 and libbzip2 License v1.0.6",
+      "licenseId": "bzip2-1.0.6",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dbzip2.git;a\u003dblob;f\u003dLICENSE;hb\u003dbzip2-1.0.6",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html",
+        "https://sourceware.org/cgit/valgrind/tree/mpi/libmpiwrap.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
+      "referenceNumber": 383,
+      "name": "Computational Use of Data Agreement v1.0",
+      "licenseId": "C-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Computational-Use-of-Data-Agreement/blob/master/C-UDA-1.0.md",
+        "https://cdla.dev/computational-use-of-data-agreement-v1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
+      "referenceNumber": 22,
+      "name": "Cryptographic Autonomy License 1.0",
+      "licenseId": "CAL-1.0",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
+      "referenceNumber": 363,
+      "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
+      "licenseId": "CAL-1.0-Combined-Work-Exception",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Caldera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Caldera.json",
+      "referenceNumber": 202,
+      "name": "Caldera License",
+      "licenseId": "Caldera",
+      "seeAlso": [
+        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Caldera-no-preamble.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Caldera-no-preamble.json",
+      "referenceNumber": 430,
+      "name": "Caldera License (without preamble)",
+      "licenseId": "Caldera-no-preamble",
+      "seeAlso": [
+        "https://github.com/apache/apr/blob/trunk/LICENSE#L298C6-L298C29"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CAPEC-tou.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CAPEC-tou.json",
+      "referenceNumber": 621,
+      "name": "Common Attack    Pattern Enumeration and Classification License",
+      "licenseId": "CAPEC-tou",
+      "seeAlso": [
+        "https://capec.mitre.org/about/termsofuse.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Catharon.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Catharon.json",
+      "referenceNumber": 14,
+      "name": "Catharon License",
+      "licenseId": "Catharon",
+      "seeAlso": [
+        "https://github.com/scummvm/scummvm/blob/v2.8.0/LICENSES/CatharonLicense.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
+      "referenceNumber": 76,
+      "name": "Computer Associates Trusted Open Source License 1.1",
+      "licenseId": "CATOSL-1.1",
+      "seeAlso": [
+        "https://opensource.org/licenses/CATOSL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
+      "referenceNumber": 387,
+      "name": "Creative Commons Attribution 1.0 Generic",
+      "licenseId": "CC-BY-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
+      "referenceNumber": 697,
+      "name": "Creative Commons Attribution 2.0 Generic",
+      "licenseId": "CC-BY-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
+      "referenceNumber": 12,
+      "name": "Creative Commons Attribution 2.5 Generic",
+      "licenseId": "CC-BY-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
+      "referenceNumber": 237,
+      "name": "Creative Commons Attribution 2.5 Australia",
+      "licenseId": "CC-BY-2.5-AU",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.5/au/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
+      "referenceNumber": 32,
+      "name": "Creative Commons Attribution 3.0 Unported",
+      "licenseId": "CC-BY-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
+      "referenceNumber": 535,
+      "name": "Creative Commons Attribution 3.0 Austria",
+      "licenseId": "CC-BY-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-AU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AU.json",
+      "referenceNumber": 416,
+      "name": "Creative Commons Attribution 3.0 Australia",
+      "licenseId": "CC-BY-3.0-AU",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/au/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
+      "referenceNumber": 4,
+      "name": "Creative Commons Attribution 3.0 Germany",
+      "licenseId": "CC-BY-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
+      "referenceNumber": 46,
+      "name": "Creative Commons Attribution 3.0 IGO",
+      "licenseId": "CC-BY-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
+      "referenceNumber": 161,
+      "name": "Creative Commons Attribution 3.0 Netherlands",
+      "licenseId": "CC-BY-3.0-NL",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/nl/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
+      "referenceNumber": 709,
+      "name": "Creative Commons Attribution 3.0 United States",
+      "licenseId": "CC-BY-3.0-US",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/us/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
+      "referenceNumber": 640,
+      "name": "Creative Commons Attribution 4.0 International",
+      "licenseId": "CC-BY-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
+      "referenceNumber": 701,
+      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
+      "licenseId": "CC-BY-NC-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
+      "referenceNumber": 157,
+      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
+      "licenseId": "CC-BY-NC-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
+      "referenceNumber": 321,
+      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
+      "licenseId": "CC-BY-NC-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
+      "referenceNumber": 587,
+      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
+      "licenseId": "CC-BY-NC-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
+      "referenceNumber": 492,
+      "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
+      "licenseId": "CC-BY-NC-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
+      "referenceNumber": 417,
+      "name": "Creative Commons Attribution Non Commercial 4.0 International",
+      "licenseId": "CC-BY-NC-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
+      "referenceNumber": 507,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
+      "licenseId": "CC-BY-NC-ND-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
+      "referenceNumber": 638,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-NC-ND-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
+      "referenceNumber": 475,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-NC-ND-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
+      "referenceNumber": 600,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-NC-ND-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
+      "referenceNumber": 528,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
+      "licenseId": "CC-BY-NC-ND-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
+      "referenceNumber": 400,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
+      "licenseId": "CC-BY-NC-ND-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
+      "referenceNumber": 551,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
+      "licenseId": "CC-BY-NC-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
+      "referenceNumber": 171,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-NC-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
+      "referenceNumber": 545,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-NC-SA-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.json",
+      "referenceNumber": 206,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
+      "licenseId": "CC-BY-NC-SA-2.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
+      "referenceNumber": 246,
+      "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
+      "licenseId": "CC-BY-NC-SA-2.0-FR",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/fr/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
+      "referenceNumber": 205,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-NC-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/uk/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
+      "referenceNumber": 124,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-NC-SA-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
+      "referenceNumber": 255,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-NC-SA-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
+      "referenceNumber": 212,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
+      "licenseId": "CC-BY-NC-SA-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
+      "referenceNumber": 234,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
+      "licenseId": "CC-BY-NC-SA-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
+      "referenceNumber": 284,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+      "licenseId": "CC-BY-NC-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
+      "referenceNumber": 117,
+      "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
+      "licenseId": "CC-BY-ND-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/1.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
+      "referenceNumber": 20,
+      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-ND-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
+      "referenceNumber": 249,
+      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-ND-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
+      "referenceNumber": 243,
+      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-ND-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
+      "referenceNumber": 570,
+      "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
+      "licenseId": "CC-BY-ND-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
+      "referenceNumber": 487,
+      "name": "Creative Commons Attribution No Derivatives 4.0 International",
+      "licenseId": "CC-BY-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
+      "referenceNumber": 558,
+      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
+      "referenceNumber": 620,
+      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-SA-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
+      "referenceNumber": 35,
+      "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
+      "referenceNumber": 221,
+      "name": "Creative Commons Attribution Share Alike 2.1 Japan",
+      "licenseId": "CC-BY-SA-2.1-JP",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.1/jp/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
+      "referenceNumber": 100,
+      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-SA-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
+      "referenceNumber": 457,
+      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-SA-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
+      "referenceNumber": 92,
+      "name": "Creative Commons Attribution Share Alike 3.0 Austria",
+      "licenseId": "CC-BY-SA-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
+      "referenceNumber": 177,
+      "name": "Creative Commons Attribution Share Alike 3.0 Germany",
+      "licenseId": "CC-BY-SA-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.json",
+      "referenceNumber": 358,
+      "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
+      "licenseId": "CC-BY-SA-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
+      "referenceNumber": 89,
+      "name": "Creative Commons Attribution Share Alike 4.0 International",
+      "licenseId": "CC-BY-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-PDDC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
+      "referenceNumber": 574,
+      "name": "Creative Commons Public Domain Dedication and Certification",
+      "licenseId": "CC-PDDC",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/publicdomain/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-PDM-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-PDM-1.0.json",
+      "referenceNumber": 25,
+      "name": "Creative    Commons Public Domain Mark 1.0 Universal",
+      "licenseId": "CC-PDM-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/mark/1.0/",
+        "https://creativecommons.org/share-your-work/cclicenses/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-SA-1.0.json",
+      "referenceNumber": 681,
+      "name": "Creative Commons Share Alike 1.0 Generic",
+      "licenseId": "CC-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC0-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
+      "referenceNumber": 195,
+      "name": "Creative Commons Zero v1.0 Universal",
+      "licenseId": "CC0-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
+      "referenceNumber": 67,
+      "name": "Common Development and Distribution License 1.0",
+      "licenseId": "CDDL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/cddl1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDDL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
+      "referenceNumber": 662,
+      "name": "Common Development and Distribution License 1.1",
+      "licenseId": "CDDL-1.1",
+      "seeAlso": [
+        "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
+        "https://javaee.github.io/glassfish/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
+      "referenceNumber": 87,
+      "name": "Common Documentation License 1.0",
+      "licenseId": "CDL-1.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/cdl/",
+        "https://fedoraproject.org/wiki/Licensing/Common_Documentation_License",
+        "https://www.gnu.org/licenses/license-list.html#ACDL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
+      "referenceNumber": 28,
+      "name": "Community Data License Agreement Permissive 1.0",
+      "licenseId": "CDLA-Permissive-1.0",
+      "seeAlso": [
+        "https://cdla.io/permissive-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
+      "referenceNumber": 340,
+      "name": "Community Data License Agreement Permissive 2.0",
+      "licenseId": "CDLA-Permissive-2.0",
+      "seeAlso": [
+        "https://cdla.dev/permissive-2-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
+      "referenceNumber": 567,
+      "name": "Community Data License Agreement Sharing 1.0",
+      "licenseId": "CDLA-Sharing-1.0",
+      "seeAlso": [
+        "https://cdla.io/sharing-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
+      "referenceNumber": 208,
+      "name": "CeCILL Free Software License Agreement v1.0",
+      "licenseId": "CECILL-1.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
+      "referenceNumber": 248,
+      "name": "CeCILL Free Software License Agreement v1.1",
+      "licenseId": "CECILL-1.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
+      "referenceNumber": 713,
+      "name": "CeCILL Free Software License Agreement v2.0",
+      "licenseId": "CECILL-2.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
+      "referenceNumber": 144,
+      "name": "CeCILL Free Software License Agreement v2.1",
+      "licenseId": "CECILL-2.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-B.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
+      "referenceNumber": 188,
+      "name": "CeCILL-B Free Software License Agreement",
+      "licenseId": "CECILL-B",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-C.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
+      "referenceNumber": 186,
+      "name": "CeCILL-C Free Software License Agreement",
+      "licenseId": "CECILL-C",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
+      "referenceNumber": 167,
+      "name": "CERN Open Hardware Licence v1.1",
+      "licenseId": "CERN-OHL-1.1",
+      "seeAlso": [
+        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
+      "referenceNumber": 450,
+      "name": "CERN Open Hardware Licence v1.2",
+      "licenseId": "CERN-OHL-1.2",
+      "seeAlso": [
+        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
+      "referenceNumber": 646,
+      "name": "CERN Open Hardware Licence Version 2 - Permissive",
+      "licenseId": "CERN-OHL-P-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
+      "referenceNumber": 619,
+      "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+      "licenseId": "CERN-OHL-S-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
+      "referenceNumber": 544,
+      "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
+      "licenseId": "CERN-OHL-W-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CFITSIO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CFITSIO.json",
+      "referenceNumber": 693,
+      "name": "CFITSIO License",
+      "licenseId": "CFITSIO",
+      "seeAlso": [
+        "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/f_user/node9.html",
+        "https://heasarc.gsfc.nasa.gov/docs/software/ftools/fv/doc/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/check-cvs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/check-cvs.json",
+      "referenceNumber": 63,
+      "name": "check-cvs License",
+      "licenseId": "check-cvs",
+      "seeAlso": [
+        "http://cvs.savannah.gnu.org/viewvc/cvs/ccvs/contrib/check_cvs.in?revision\u003d1.1.4.3\u0026view\u003dmarkup\u0026pathrev\u003dcvs1-11-23#l2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/checkmk.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/checkmk.json",
+      "referenceNumber": 415,
+      "name": "Checkmk License",
+      "licenseId": "checkmk",
+      "seeAlso": [
+        "https://github.com/libcheck/check/blob/master/checkmk/checkmk.in"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ClArtistic.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
+      "referenceNumber": 502,
+      "name": "Clarified Artistic License",
+      "licenseId": "ClArtistic",
+      "seeAlso": [
+        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
+        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Clips.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Clips.json",
+      "referenceNumber": 210,
+      "name": "Clips License",
+      "licenseId": "Clips",
+      "seeAlso": [
+        "https://github.com/DrItanium/maya/blob/master/LICENSE.CLIPS"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CMU-Mach.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CMU-Mach.json",
+      "referenceNumber": 41,
+      "name": "CMU Mach License",
+      "licenseId": "CMU-Mach",
+      "seeAlso": [
+        "https://www.cs.cmu.edu/~410/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CMU-Mach-nodoc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CMU-Mach-nodoc.json",
+      "referenceNumber": 26,
+      "name": "CMU    Mach - no notices-in-documentation variant",
+      "licenseId": "CMU-Mach-nodoc",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L718-L728",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CNRI-Jython.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
+      "referenceNumber": 396,
+      "name": "CNRI Jython License",
+      "licenseId": "CNRI-Jython",
+      "seeAlso": [
+        "http://www.jython.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CNRI-Python.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
+      "referenceNumber": 236,
+      "name": "CNRI Python License",
+      "licenseId": "CNRI-Python",
+      "seeAlso": [
+        "https://opensource.org/licenses/CNRI-Python"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
+      "referenceNumber": 69,
+      "name": "CNRI Python Open Source GPL Compatible License Agreement",
+      "licenseId": "CNRI-Python-GPL-Compatible",
+      "seeAlso": [
+        "http://www.python.org/download/releases/1.6.1/download_win/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/COIL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
+      "referenceNumber": 378,
+      "name": "Copyfree Open Innovation License",
+      "licenseId": "COIL-1.0",
+      "seeAlso": [
+        "https://coil.apotheon.org/plaintext/01.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
+      "referenceNumber": 397,
+      "name": "Community Specification License 1.0",
+      "licenseId": "Community-Spec-1.0",
+      "seeAlso": [
+        "https://github.com/CommunitySpecification/1.0/blob/master/1._Community_Specification_License-v1.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Condor-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
+      "referenceNumber": 566,
+      "name": "Condor Public License v1.1",
+      "licenseId": "Condor-1.1",
+      "seeAlso": [
+        "http://research.cs.wisc.edu/condor/license.html#condor",
+        "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
+      "referenceNumber": 468,
+      "name": "copyleft-next 0.3.0",
+      "licenseId": "copyleft-next-0.3.0",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
+      "referenceNumber": 2,
+      "name": "copyleft-next 0.3.1",
+      "licenseId": "copyleft-next-0.3.1",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Cornell-Lossless-JPEG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Cornell-Lossless-JPEG.json",
+      "referenceNumber": 385,
+      "name": "Cornell Lossless JPEG License",
+      "licenseId": "Cornell-Lossless-JPEG",
+      "seeAlso": [
+        "https://android.googlesource.com/platform/external/dng_sdk/+/refs/heads/master/source/dng_lossless_jpeg.cpp#16",
+        "https://www.mssl.ucl.ac.uk/~mcrw/src/20050920/proto.h",
+        "https://gitlab.freedesktop.org/libopenraw/libopenraw/blob/master/lib/ljpegdecompressor.cpp#L32"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
+      "referenceNumber": 356,
+      "name": "Common Public Attribution License 1.0",
+      "licenseId": "CPAL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPAL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
+      "referenceNumber": 585,
+      "name": "Common Public License 1.0",
+      "licenseId": "CPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPOL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
+      "referenceNumber": 596,
+      "name": "Code Project Open License 1.02",
+      "licenseId": "CPOL-1.02",
+      "seeAlso": [
+        "http://www.codeproject.com/info/cpol10.aspx"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Cronyx.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Cronyx.json",
+      "referenceNumber": 156,
+      "name": "Cronyx License",
+      "licenseId": "Cronyx",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/font/alias/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/font/cronyx-cyrillic/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/font/misc-cyrillic/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/font/screen-cyrillic/-/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Crossword.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Crossword.json",
+      "referenceNumber": 720,
+      "name": "Crossword License",
+      "licenseId": "Crossword",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Crossword"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CryptoSwift.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CryptoSwift.json",
+      "referenceNumber": 704,
+      "name": "CryptoSwift License",
+      "licenseId": "CryptoSwift",
+      "seeAlso": [
+        "https://github.com/krzyzanowskim/CryptoSwift/blob/main/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CrystalStacker.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
+      "referenceNumber": 461,
+      "name": "CrystalStacker License",
+      "licenseId": "CrystalStacker",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd\u003dLicensing/CrystalStacker"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
+      "referenceNumber": 622,
+      "name": "CUA Office Public License v1.0",
+      "licenseId": "CUA-OPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CUA-OPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Cube.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Cube.json",
+      "referenceNumber": 366,
+      "name": "Cube License",
+      "licenseId": "Cube",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Cube"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/curl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/curl.json",
+      "referenceNumber": 215,
+      "name": "curl License",
+      "licenseId": "curl",
+      "seeAlso": [
+        "https://github.com/bagder/curl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/cve-tou.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/cve-tou.json",
+      "referenceNumber": 614,
+      "name": "Common Vulnerability Enumeration ToU License",
+      "licenseId": "cve-tou",
+      "seeAlso": [
+        "https://www.cve.org/Legal/TermsOfUse"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
+      "referenceNumber": 168,
+      "name": "Deutsche Freie Software Lizenz",
+      "licenseId": "D-FSL-1.0",
+      "seeAlso": [
+        "http://www.dipp.nrw.de/d-fsl/lizenzen/",
+        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/de/D-FSL-1_0_de.txt",
+        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/en/D-FSL-1_0_en.txt",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/deutsche-freie-software-lizenz",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/german-free-software-license",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_de.txt/at_download/file",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_en.txt/at_download/file"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DEC-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DEC-3-Clause.json",
+      "referenceNumber": 140,
+      "name": "DEC 3-Clause License",
+      "licenseId": "DEC-3-Clause",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type\u003dheads#L239"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/diffmark.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/diffmark.json",
+      "referenceNumber": 463,
+      "name": "diffmark license",
+      "licenseId": "diffmark",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/diffmark"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
+      "referenceNumber": 261,
+      "name": "Data licence Germany – attribution – version 2.0",
+      "licenseId": "DL-DE-BY-2.0",
+      "seeAlso": [
+        "https://www.govdata.de/dl-de/by-2-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DL-DE-ZERO-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DL-DE-ZERO-2.0.json",
+      "referenceNumber": 43,
+      "name": "Data licence Germany – zero – version 2.0",
+      "licenseId": "DL-DE-ZERO-2.0",
+      "seeAlso": [
+        "https://www.govdata.de/dl-de/zero-2-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DOC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DOC.json",
+      "referenceNumber": 562,
+      "name": "DOC License",
+      "licenseId": "DOC",
+      "seeAlso": [
+        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html",
+        "https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-DTD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-DTD.json",
+      "referenceNumber": 74,
+      "name": "DocBook DTD License",
+      "licenseId": "DocBook-DTD",
+      "seeAlso": [
+        "http://www.docbook.org/xml/simple/1.1/docbook-simple-1.1.zip"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-Schema.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-Schema.json",
+      "referenceNumber": 702,
+      "name": "DocBook Schema License",
+      "licenseId": "DocBook-Schema",
+      "seeAlso": [
+        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/assembly/schema/docbook51b7.rnc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-Stylesheet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-Stylesheet.json",
+      "referenceNumber": 643,
+      "name": "DocBook Stylesheet License",
+      "licenseId": "DocBook-Stylesheet",
+      "seeAlso": [
+        "http://www.docbook.org/xml/5.0/docbook-5.0.zip"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-XML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-XML.json",
+      "referenceNumber": 572,
+      "name": "DocBook XML License",
+      "licenseId": "DocBook-XML",
+      "seeAlso": [
+        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/COPYING#L27"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Dotseqn.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
+      "referenceNumber": 584,
+      "name": "Dotseqn License",
+      "licenseId": "Dotseqn",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DRL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
+      "referenceNumber": 577,
+      "name": "Detection Rule License 1.0",
+      "licenseId": "DRL-1.0",
+      "seeAlso": [
+        "https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DRL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DRL-1.1.json",
+      "referenceNumber": 711,
+      "name": "Detection Rule License 1.1",
+      "licenseId": "DRL-1.1",
+      "seeAlso": [
+        "https://github.com/SigmaHQ/Detection-Rule-License/blob/6ec7fbde6101d101b5b5d1fcb8f9b69fbc76c04a/LICENSE.Detection.Rules.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DSDP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DSDP.json",
+      "referenceNumber": 509,
+      "name": "DSDP License",
+      "licenseId": "DSDP",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/DSDP"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/dtoa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/dtoa.json",
+      "referenceNumber": 484,
+      "name": "David M. Gay dtoa License",
+      "licenseId": "dtoa",
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/swipl-devel/blob/master/src/os/dtoa.c",
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/stdlib/mprec.h;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/dvipdfm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
+      "referenceNumber": 553,
+      "name": "dvipdfm License",
+      "licenseId": "dvipdfm",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ECL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
+      "referenceNumber": 129,
+      "name": "Educational Community License v1.0",
+      "licenseId": "ECL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/ECL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ECL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
+      "referenceNumber": 118,
+      "name": "Educational Community License v2.0",
+      "licenseId": "ECL-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/ECL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/eCos-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
+      "referenceNumber": 165,
+      "name": "eCos license version 2.0",
+      "licenseId": "eCos-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/ecos-license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EFL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
+      "referenceNumber": 51,
+      "name": "Eiffel Forum License v1.0",
+      "licenseId": "EFL-1.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/forum.txt",
+        "https://opensource.org/licenses/EFL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EFL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
+      "referenceNumber": 265,
+      "name": "Eiffel Forum License v2.0",
+      "licenseId": "EFL-2.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
+        "https://opensource.org/licenses/EFL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/eGenix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/eGenix.json",
+      "referenceNumber": 688,
+      "name": "eGenix.com Public License 1.1.0",
+      "licenseId": "eGenix",
+      "seeAlso": [
+        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
+        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Elastic-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
+      "referenceNumber": 160,
+      "name": "Elastic License 2.0",
+      "licenseId": "Elastic-2.0",
+      "seeAlso": [
+        "https://www.elastic.co/licensing/elastic-license",
+        "https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Entessa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Entessa.json",
+      "referenceNumber": 116,
+      "name": "Entessa Public License v1.0",
+      "licenseId": "Entessa",
+      "seeAlso": [
+        "https://opensource.org/licenses/Entessa"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EPICS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EPICS.json",
+      "referenceNumber": 315,
+      "name": "EPICS Open License",
+      "licenseId": "EPICS",
+      "seeAlso": [
+        "https://epics.anl.gov/license/open.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
+      "referenceNumber": 103,
+      "name": "Eclipse Public License 1.0",
+      "licenseId": "EPL-1.0",
+      "seeAlso": [
+        "http://www.eclipse.org/legal/epl-v10.html",
+        "https://opensource.org/licenses/EPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
+      "referenceNumber": 520,
+      "name": "Eclipse Public License 2.0",
+      "licenseId": "EPL-2.0",
+      "seeAlso": [
+        "https://www.eclipse.org/legal/epl-2.0",
+        "https://www.opensource.org/licenses/EPL-2.0",
+        "https://www.eclipse.org/legal/epl-v20.html",
+        "https://projects.eclipse.org/license/epl-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
+      "referenceNumber": 692,
+      "name": "Erlang Public License v1.1",
+      "licenseId": "ErlPL-1.1",
+      "seeAlso": [
+        "http://www.erlang.org/EPLICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ESA-PL-permissive-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ESA-PL-permissive-2.4.json",
+      "referenceNumber": 435,
+      "name": "European Space Agency Public License – v2.4 – Permissive (Type 3)",
+      "licenseId": "ESA-PL-permissive-2.4",
+      "seeAlso": [
+        "https://essr.esa.int/license/european-space-agency-public-license-v2-4-permissive-type-3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ESA-PL-strong-copyleft-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ESA-PL-strong-copyleft-2.4.json",
+      "referenceNumber": 493,
+      "name": "European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1)",
+      "licenseId": "ESA-PL-strong-copyleft-2.4",
+      "seeAlso": [
+        "https://essr.esa.int/license/european-space-agency-public-license-v2-4-strong-copyleft-type-1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ESA-PL-weak-copyleft-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ESA-PL-weak-copyleft-2.4.json",
+      "referenceNumber": 309,
+      "name": "European Space Agency Public License – v2.4 – Weak Copyleft (Type 2)",
+      "licenseId": "ESA-PL-weak-copyleft-2.4",
+      "seeAlso": [
+        "https://essr.esa.int/license/european-space-agency-public-license-v2-4-weak-copyleft-type-2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/etalab-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
+      "referenceNumber": 211,
+      "name": "Etalab Open License 2.0",
+      "licenseId": "etalab-2.0",
+      "seeAlso": [
+        "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
+        "https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EUDatagrid.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
+      "referenceNumber": 565,
+      "name": "EU DataGrid Software License",
+      "licenseId": "EUDatagrid",
+      "seeAlso": [
+        "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
+        "https://opensource.org/licenses/EUDatagrid"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EUPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
+      "referenceNumber": 288,
+      "name": "European Union Public License 1.0",
+      "licenseId": "EUPL-1.0",
+      "seeAlso": [
+        "http://ec.europa.eu/idabc/en/document/7330.html",
+        "http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id\u003d31096"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EUPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
+      "referenceNumber": 618,
+      "name": "European Union Public License 1.1",
+      "licenseId": "EUPL-1.1",
+      "seeAlso": [
+        "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
+        "https://opensource.org/licenses/EUPL-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EUPL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
+      "referenceNumber": 151,
+      "name": "European Union Public License 1.2",
+      "licenseId": "EUPL-1.2",
+      "seeAlso": [
+        "https://joinup.ec.europa.eu/page/eupl-text-11-12",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt",
+        "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
+        "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
+        "https://opensource.org/licenses/EUPL-1.2"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Eurosym.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
+      "referenceNumber": 72,
+      "name": "Eurosym License",
+      "licenseId": "Eurosym",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Eurosym"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Fair.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Fair.json",
+      "referenceNumber": 7,
+      "name": "Fair License",
+      "licenseId": "Fair",
+      "seeAlso": [
+        "https://web.archive.org/web/20150926120323/http://fairlicense.org/",
+        "https://opensource.org/licenses/Fair"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/FBM.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FBM.json",
+      "referenceNumber": 424,
+      "name": "Fuzzy Bitmap License",
+      "licenseId": "FBM",
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/packages-xpce/blob/161a40cd82004f731ba48024f9d30af388a7edf5/src/img/gifwrite.c#L21-L26"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FDK-AAC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
+      "referenceNumber": 595,
+      "name": "Fraunhofer FDK AAC Codec Library",
+      "licenseId": "FDK-AAC",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FDK-AAC",
+        "https://directory.fsf.org/wiki/License:Fdk"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Ferguson-Twofish.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ferguson-Twofish.json",
+      "referenceNumber": 512,
+      "name": "Ferguson Twofish License",
+      "licenseId": "Ferguson-Twofish",
+      "seeAlso": [
+        "https://github.com/wernerd/ZRTPCPP/blob/6b3cd8e6783642292bad0c21e3e5e5ce45ff3e03/cryptcommon/twofish.c#L113C3-L127"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
+      "referenceNumber": 395,
+      "name": "Frameworx Open License 1.0",
+      "licenseId": "Frameworx-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Frameworx-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
+      "referenceNumber": 370,
+      "name": "FreeBSD Documentation License",
+      "licenseId": "FreeBSD-DOC",
+      "seeAlso": [
+        "https://www.freebsd.org/copyright/freebsd-doc-license/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FreeImage.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
+      "referenceNumber": 299,
+      "name": "FreeImage Public License v1.0",
+      "licenseId": "FreeImage",
+      "seeAlso": [
+        "http://freeimage.sourceforge.net/freeimage-license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFAP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
+      "referenceNumber": 96,
+      "name": "FSF All Permissive License",
+      "licenseId": "FSFAP",
+      "seeAlso": [
+        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.json",
+      "referenceNumber": 223,
+      "name": "FSF All Permissive License (without Warranty)",
+      "licenseId": "FSFAP-no-warranty-disclaimer",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/wget.git/tree/util/trunc.c?h\u003dv1.21.3\u0026id\u003d40747a11e44ced5a8ac628a41f879ced3e2ebce9#n6"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFUL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
+      "referenceNumber": 133,
+      "name": "FSF Unlimited License",
+      "licenseId": "FSFUL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFULLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
+      "referenceNumber": 203,
+      "name": "FSF Unlimited License (with License Retention)",
+      "licenseId": "FSFULLR",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFULLRSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLRSD.json",
+      "referenceNumber": 308,
+      "name": "FSF Unlimited License (with License Retention and Short Disclaimer)",
+      "licenseId": "FSFULLRSD",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/gnulib.git/tree/modules/COPYING?id\u003d7b08932179d0d6b017f7df01a2ddf6e096b038e3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFULLRWD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLRWD.json",
+      "referenceNumber": 326,
+      "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
+      "licenseId": "FSFULLRWD",
+      "seeAlso": [
+        "https://lists.gnu.org/archive/html/autoconf/2012-04/msg00061.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSL-1.1-ALv2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSL-1.1-ALv2.json",
+      "referenceNumber": 433,
+      "name": "Functional Source License, Version 1.1, ALv2 Future License",
+      "licenseId": "FSL-1.1-ALv2",
+      "seeAlso": [
+        "https://fsl.software/FSL-1.1-ALv2.template.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSL-1.1-MIT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSL-1.1-MIT.json",
+      "referenceNumber": 0,
+      "name": "Functional Source License, Version 1.1, MIT Future License",
+      "licenseId": "FSL-1.1-MIT",
+      "seeAlso": [
+        "https://fsl.software/FSL-1.1-MIT.template.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FTL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FTL.json",
+      "referenceNumber": 351,
+      "name": "Freetype Project License",
+      "licenseId": "FTL",
+      "seeAlso": [
+        "http://freetype.fis.uniroma2.it/FTL.TXT",
+        "http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT",
+        "http://gitlab.freedesktop.org/freetype/freetype/-/raw/master/docs/FTL.TXT"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Furuseth.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Furuseth.json",
+      "referenceNumber": 690,
+      "name": "Furuseth License",
+      "licenseId": "Furuseth",
+      "seeAlso": [
+        "https://git.openldap.org/openldap/openldap/-/blob/master/COPYRIGHT?ref_type\u003dheads#L39-51"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/fwlw.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/fwlw.json",
+      "referenceNumber": 226,
+      "name": "fwlw License",
+      "licenseId": "fwlw",
+      "seeAlso": [
+        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/fwlw/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Game-Programming-Gems.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Game-Programming-Gems.json",
+      "referenceNumber": 282,
+      "name": "Game Programming Gems License",
+      "licenseId": "Game-Programming-Gems",
+      "seeAlso": [
+        "https://github.com/OGRECave/ogre/blob/master/OgreMain/include/OgreSingleton.h#L28C3-L35C46"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GCR-docs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GCR-docs.json",
+      "referenceNumber": 207,
+      "name": "Gnome GCR Documentation License",
+      "licenseId": "GCR-docs",
+      "seeAlso": [
+        "https://github.com/GNOME/gcr/blob/master/docs/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GD.json",
+      "referenceNumber": 549,
+      "name": "GD License",
+      "licenseId": "GD",
+      "seeAlso": [
+        "https://libgd.github.io/manuals/2.3.0/files/license-txt.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/generic-xts.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/generic-xts.json",
+      "referenceNumber": 131,
+      "name": "Generic XTS License",
+      "licenseId": "generic-xts",
+      "seeAlso": [
+        "https://github.com/mhogomchungu/zuluCrypt/blob/master/external_libraries/tcplay/generic_xts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
+      "referenceNumber": 486,
+      "name": "GNU Free Documentation License v1.1",
+      "licenseId": "GFDL-1.1",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
+      "referenceNumber": 588,
+      "name": "GNU Free Documentation License v1.1 only - invariants",
+      "licenseId": "GFDL-1.1-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
+      "referenceNumber": 381,
+      "name": "GNU Free Documentation License v1.1 or later - invariants",
+      "licenseId": "GFDL-1.1-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
+      "referenceNumber": 557,
+      "name": "GNU Free Documentation License v1.1 only - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
+      "referenceNumber": 653,
+      "name": "GNU Free Documentation License v1.1 or later - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
+      "referenceNumber": 327,
+      "name": "GNU Free Documentation License v1.1 only",
+      "licenseId": "GFDL-1.1-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
+      "referenceNumber": 434,
+      "name": "GNU Free Documentation License v1.1 or later",
+      "licenseId": "GFDL-1.1-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
+      "referenceNumber": 30,
+      "name": "GNU Free Documentation License v1.2",
+      "licenseId": "GFDL-1.2",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
+      "referenceNumber": 23,
+      "name": "GNU Free Documentation License v1.2 only - invariants",
+      "licenseId": "GFDL-1.2-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
+      "referenceNumber": 451,
+      "name": "GNU Free Documentation License v1.2 or later - invariants",
+      "licenseId": "GFDL-1.2-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
+      "referenceNumber": 62,
+      "name": "GNU Free Documentation License v1.2 only - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
+      "referenceNumber": 82,
+      "name": "GNU Free Documentation License v1.2 or later - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
+      "referenceNumber": 159,
+      "name": "GNU Free Documentation License v1.2 only",
+      "licenseId": "GFDL-1.2-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
+      "referenceNumber": 671,
+      "name": "GNU Free Documentation License v1.2 or later",
+      "licenseId": "GFDL-1.2-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
+      "referenceNumber": 499,
+      "name": "GNU Free Documentation License v1.3",
+      "licenseId": "GFDL-1.3",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
+      "referenceNumber": 233,
+      "name": "GNU Free Documentation License v1.3 only - invariants",
+      "licenseId": "GFDL-1.3-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
+      "referenceNumber": 231,
+      "name": "GNU Free Documentation License v1.3 or later - invariants",
+      "licenseId": "GFDL-1.3-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
+      "referenceNumber": 647,
+      "name": "GNU Free Documentation License v1.3 only - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
+      "referenceNumber": 386,
+      "name": "GNU Free Documentation License v1.3 or later - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
+      "referenceNumber": 184,
+      "name": "GNU Free Documentation License v1.3 only",
+      "licenseId": "GFDL-1.3-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
+      "referenceNumber": 58,
+      "name": "GNU Free Documentation License v1.3 or later",
+      "licenseId": "GFDL-1.3-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Giftware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Giftware.json",
+      "referenceNumber": 428,
+      "name": "Giftware License",
+      "licenseId": "Giftware",
+      "seeAlso": [
+        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GL2PS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
+      "referenceNumber": 276,
+      "name": "GL2PS License",
+      "licenseId": "GL2PS",
+      "seeAlso": [
+        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Glide.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Glide.json",
+      "referenceNumber": 716,
+      "name": "3dfx Glide License",
+      "licenseId": "Glide",
+      "seeAlso": [
+        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Glulxe.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
+      "referenceNumber": 40,
+      "name": "Glulxe License",
+      "licenseId": "Glulxe",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Glulxe"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GLWTPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
+      "referenceNumber": 573,
+      "name": "Good Luck With That Public License",
+      "licenseId": "GLWTPL",
+      "seeAlso": [
+        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/gnuplot.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
+      "referenceNumber": 281,
+      "name": "gnuplot License",
+      "licenseId": "gnuplot",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
+      "referenceNumber": 712,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
+      "referenceNumber": 412,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
+      "referenceNumber": 349,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
+      "referenceNumber": 526,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
+      "referenceNumber": 319,
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
+      "referenceNumber": 21,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
+      "referenceNumber": 323,
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt",
+        "https://opensource.org/licenses/GPL-2.0",
+        "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
+      "referenceNumber": 491,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0",
+        "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
+      "referenceNumber": 706,
+      "name": "GNU General Public License v2.0 w/Autoconf exception",
+      "licenseId": "GPL-2.0-with-autoconf-exception",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
+      "referenceNumber": 24,
+      "name": "GNU General Public License v2.0 w/Bison exception",
+      "licenseId": "GPL-2.0-with-bison-exception",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
+      "referenceNumber": 332,
+      "name": "GNU General Public License v2.0 w/Classpath exception",
+      "licenseId": "GPL-2.0-with-classpath-exception",
+      "seeAlso": [
+        "https://www.gnu.org/software/classpath/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
+      "referenceNumber": 322,
+      "name": "GNU General Public License v2.0 w/Font exception",
+      "licenseId": "GPL-2.0-with-font-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
+      "referenceNumber": 250,
+      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-2.0-with-GCC-exception",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
+      "referenceNumber": 164,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
+      "referenceNumber": 84,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": 410,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
+      "referenceNumber": 173,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
+      "referenceNumber": 666,
+      "name": "GNU General Public License v3.0 w/Autoconf exception",
+      "licenseId": "GPL-3.0-with-autoconf-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
+      "referenceNumber": 554,
+      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-3.0-with-GCC-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Graphics-Gems.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Graphics-Gems.json",
+      "referenceNumber": 672,
+      "name": "Graphics Gems License",
+      "licenseId": "Graphics-Gems",
+      "seeAlso": [
+        "https://github.com/erich666/GraphicsGems/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
+      "referenceNumber": 517,
+      "name": "gSOAP Public License v1.3b",
+      "licenseId": "gSOAP-1.3b",
+      "seeAlso": [
+        "http://www.cs.fsu.edu/~engelen/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/gtkbook.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/gtkbook.json",
+      "referenceNumber": 99,
+      "name": "gtkbook License",
+      "licenseId": "gtkbook",
+      "seeAlso": [
+        "https://github.com/slogan621/gtkbook",
+        "https://github.com/oetiker/rrdtool-1.x/blob/master/src/plbasename.c#L8-L11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Gutmann.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Gutmann.json",
+      "referenceNumber": 637,
+      "name": "Gutmann License",
+      "licenseId": "Gutmann",
+      "seeAlso": [
+        "https://www.cs.auckland.ac.nz/~pgut001/dumpasn1.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HaskellReport.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
+      "referenceNumber": 561,
+      "name": "Haskell Language Report License",
+      "licenseId": "HaskellReport",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HDF5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HDF5.json",
+      "referenceNumber": 64,
+      "name": "HDF5 License",
+      "licenseId": "HDF5",
+      "seeAlso": [
+        "https://github.com/HDFGroup/hdf5/?tab\u003dLicense-1-ov-file#readme"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/hdparm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/hdparm.json",
+      "referenceNumber": 252,
+      "name": "hdparm License",
+      "licenseId": "hdparm",
+      "seeAlso": [
+        "https://github.com/Distrotech/hdparm/blob/4517550db29a91420fb2b020349523b1b4512df2/LICENSE.TXT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HIDAPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HIDAPI.json",
+      "referenceNumber": 180,
+      "name": "HIDAPI License",
+      "licenseId": "HIDAPI",
+      "seeAlso": [
+        "https://github.com/signal11/hidapi/blob/master/LICENSE-orig.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
+      "referenceNumber": 239,
+      "name": "Hippocratic License 2.1",
+      "licenseId": "Hippocratic-2.1",
+      "seeAlso": [
+        "https://firstdonoharm.dev/version/2/1/license.html",
+        "https://github.com/EthicalSource/hippocratic-license/blob/58c0e646d64ff6fbee275bfe2b9492f914e3ab2a/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HP-1986.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HP-1986.json",
+      "referenceNumber": 586,
+      "name": "Hewlett-Packard 1986 License",
+      "licenseId": "HP-1986",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/machine/hppa/memchr.S;h\u003d1cca3e5e8867aa4bffef1f75a5c1bba25c0c441e;hb\u003dHEAD#l2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HP-1989.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HP-1989.json",
+      "referenceNumber": 384,
+      "name": "Hewlett-Packard 1989 License",
+      "licenseId": "HP-1989",
+      "seeAlso": [
+        "https://github.com/bleargh45/Data-UUID/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND.json",
+      "referenceNumber": 298,
+      "name": "Historical Permission Notice and Disclaimer",
+      "licenseId": "HPND",
+      "seeAlso": [
+        "https://opensource.org/licenses/HPND",
+        "http://lists.opensource.org/pipermail/license-discuss_lists.opensource.org/2002-November/006304.html"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-DEC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-DEC.json",
+      "referenceNumber": 198,
+      "name": "Historical Permission Notice and Disclaimer - DEC variant",
+      "licenseId": "HPND-DEC",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/app/xkbcomp/-/blob/master/COPYING?ref_type\u003dheads#L69"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-doc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-doc.json",
+      "referenceNumber": 235,
+      "name": "Historical Permission Notice and Disclaimer - documentation variant",
+      "licenseId": "HPND-doc",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/lib/libxext/-/blob/master/COPYING?ref_type\u003dheads#L185-197",
+        "https://gitlab.freedesktop.org/xorg/lib/libxtst/-/blob/master/COPYING?ref_type\u003dheads#L70-77"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-doc-sell.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-doc-sell.json",
+      "referenceNumber": 142,
+      "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
+      "licenseId": "HPND-doc-sell",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/lib/libxtst/-/blob/master/COPYING?ref_type\u003dheads#L108-117",
+        "https://gitlab.freedesktop.org/xorg/lib/libxext/-/blob/master/COPYING?ref_type\u003dheads#L153-162"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export-US.json",
+      "referenceNumber": 710,
+      "name": "HPND with US Government export control warning",
+      "licenseId": "HPND-export-US",
+      "seeAlso": [
+        "https://www.kermitproject.org/ck90.html#source"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export-US-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export-US-acknowledgement.json",
+      "referenceNumber": 505,
+      "name": "HPND with US Government export control warning and acknowledgment",
+      "licenseId": "HPND-export-US-acknowledgement",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L831-L852",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export-US-modify.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export-US-modify.json",
+      "referenceNumber": 403,
+      "name": "HPND with US Government export control warning and modification rqmt",
+      "licenseId": "HPND-export-US-modify",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L1157-L1182",
+        "https://github.com/pythongssapi/k5test/blob/v0.10.3/K5TEST-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export2-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export2-US.json",
+      "referenceNumber": 149,
+      "name": "HPND with US Government export control and 2 disclaimers",
+      "licenseId": "HPND-export2-US",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L111-L133",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.json",
+      "referenceNumber": 529,
+      "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
+      "licenseId": "HPND-Fenneberg-Livingston",
+      "seeAlso": [
+        "https://github.com/FreeRADIUS/freeradius-client/blob/master/COPYRIGHT#L32",
+        "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L34"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-INRIA-IMAG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-INRIA-IMAG.json",
+      "referenceNumber": 193,
+      "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
+      "licenseId": "HPND-INRIA-IMAG",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/ipv6cp.c#L75-L83"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Intel.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Intel.json",
+      "referenceNumber": 466,
+      "name": "Historical Permission Notice and Disclaimer - Intel variant",
+      "licenseId": "HPND-Intel",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/machine/i960/memcpy.S;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Kevlin-Henney.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Kevlin-Henney.json",
+      "referenceNumber": 218,
+      "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
+      "licenseId": "HPND-Kevlin-Henney",
+      "seeAlso": [
+        "https://github.com/mruby/mruby/blob/83d12f8d52522cdb7c8cc46fad34821359f453e6/mrbgems/mruby-dir/src/Win/dirent.c#L127-L140"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Markus-Kuhn.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Markus-Kuhn.json",
+      "referenceNumber": 372,
+      "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
+      "licenseId": "HPND-Markus-Kuhn",
+      "seeAlso": [
+        "https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c",
+        "https://sourceware.org/git/?p\u003dbinutils-gdb.git;a\u003dblob;f\u003dreadline/readline/support/wcwidth.c;h\u003d0f5ec995796f4813abbcf4972aec0378ab74722a;hb\u003dHEAD#l55"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-merchantability-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-merchantability-variant.json",
+      "referenceNumber": 715,
+      "name": "Historical Permission Notice and Disclaimer - merchantability variant",
+      "licenseId": "HPND-merchantability-variant",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/misc/fini.c;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-MIT-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-MIT-disclaimer.json",
+      "referenceNumber": 253,
+      "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
+      "licenseId": "HPND-MIT-disclaimer",
+      "seeAlso": [
+        "https://metacpan.org/release/NLNETLABS/Net-DNS-SEC-1.22/source/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Netrek.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Netrek.json",
+      "referenceNumber": 111,
+      "name": "Historical Permission Notice and Disclaimer - Netrek variant",
+      "licenseId": "HPND-Netrek",
+      "seeAlso": [],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Pbmplus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Pbmplus.json",
+      "referenceNumber": 654,
+      "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
+      "licenseId": "HPND-Pbmplus",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/netpbm.c#l8"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.json",
+      "referenceNumber": 301,
+      "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
+      "licenseId": "HPND-sell-MIT-disclaimer-xserver",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type\u003dheads#L1781"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-regexpr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-regexpr.json",
+      "referenceNumber": 668,
+      "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
+      "licenseId": "HPND-sell-regexpr",
+      "seeAlso": [
+        "https://gitlab.com/bacula-org/bacula/-/blob/Branch-11.0/bacula/LICENSE-FOSS?ref_type\u003dheads#L245"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
+      "referenceNumber": 209,
+      "name": "Historical Permission Notice and Disclaimer - sell variant",
+      "licenseId": "HPND-sell-variant",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19",
+        "https://github.com/kfish/xsel/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant-critical-systems.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-critical-systems.json",
+      "referenceNumber": 685,
+      "name": "HPND - sell variant with safety critical systems clause",
+      "licenseId": "HPND-sell-variant-critical-systems",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/driver/xf86-video-voodoo/-/blob/68a5b6d98ae34749cca889f4373b4043d00bfe6a/src/voodoo_dga.c#L12-33"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.json",
+      "referenceNumber": 542,
+      "name": "HPND sell variant with MIT disclaimer",
+      "licenseId": "HPND-sell-variant-MIT-disclaimer",
+      "seeAlso": [
+        "https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.json",
+      "referenceNumber": 449,
+      "name": "HPND sell variant with MIT disclaimer - reverse",
+      "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
+      "seeAlso": [
+        "https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/dynlist.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-SMC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-SMC.json",
+      "referenceNumber": 480,
+      "name": "Historical Permission Notice and Disclaimer - SMC variant",
+      "licenseId": "HPND-SMC",
+      "seeAlso": [
+        "https://docs.python.org/3/license.html#execution-tracing"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-UC.json",
+      "referenceNumber": 699,
+      "name": "Historical Permission Notice and Disclaimer - University of California variant",
+      "licenseId": "HPND-UC",
+      "seeAlso": [
+        "https://core.tcl-lang.org/tk/file?name\u003dcompat/unistd.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-UC-export-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-UC-export-US.json",
+      "referenceNumber": 530,
+      "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
+      "licenseId": "HPND-UC-export-US",
+      "seeAlso": [
+        "https://github.com/RTimothyEdwards/magic/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HTMLTIDY.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
+      "referenceNumber": 192,
+      "name": "HTML Tidy License",
+      "licenseId": "HTMLTIDY",
+      "seeAlso": [
+        "https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/hyphen-bulgarian.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/hyphen-bulgarian.json",
+      "referenceNumber": 465,
+      "name": "hyphen-bulgarian License",
+      "licenseId": "hyphen-bulgarian",
+      "seeAlso": [
+        "https://ctan.math.illinois.edu/systems/texlive/tlnet/archive/hyphen-bulgarian.tar.xz",
+        "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/959538769bfad6a73bdf34275d46520ec0f9cbb5/COPYING#L176-185"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/IBM-pibs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
+      "referenceNumber": 61,
+      "name": "IBM PowerPC Initialization and Boot Software",
+      "licenseId": "IBM-pibs",
+      "seeAlso": [
+        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ICU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ICU.json",
+      "referenceNumber": 269,
+      "name": "ICU License",
+      "licenseId": "ICU",
+      "seeAlso": [
+        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/IEC-Code-Components-EULA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IEC-Code-Components-EULA.json",
+      "referenceNumber": 196,
+      "name": "IEC    Code Components End-user licence agreement",
+      "licenseId": "IEC-Code-Components-EULA",
+      "seeAlso": [
+        "https://www.iec.ch/webstore/custserv/pdf/CC-EULA.pdf",
+        "https://www.iec.ch/CCv1",
+        "https://www.iec.ch/copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/IJG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IJG.json",
+      "referenceNumber": 85,
+      "name": "Independent JPEG Group License",
+      "licenseId": "IJG",
+      "seeAlso": [
+        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2",
+        "https://github.com/vstroebel/jpeg-encoder/blob/main/src/fdct.rs#L1-L72",
+        "https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/README.ijg#L117-L161"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/IJG-short.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IJG-short.json",
+      "referenceNumber": 644,
+      "name": "Independent JPEG Group License - short",
+      "licenseId": "IJG-short",
+      "seeAlso": [
+        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/ljpg/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ImageMagick.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
+      "referenceNumber": 335,
+      "name": "ImageMagick License",
+      "licenseId": "ImageMagick",
+      "seeAlso": [
+        "http://www.imagemagick.org/script/license.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/iMatix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/iMatix.json",
+      "referenceNumber": 469,
+      "name": "iMatix Standard Function Library Agreement",
+      "licenseId": "iMatix",
+      "seeAlso": [
+        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Imlib2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
+      "referenceNumber": 655,
+      "name": "Imlib2 License",
+      "licenseId": "Imlib2",
+      "seeAlso": [
+        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
+        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Info-ZIP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
+      "referenceNumber": 328,
+      "name": "Info-ZIP License",
+      "licenseId": "Info-ZIP",
+      "seeAlso": [
+        "http://www.info-zip.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Inner-Net-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Inner-Net-2.0.json",
+      "referenceNumber": 293,
+      "name": "Inner Net License v2.0",
+      "licenseId": "Inner-Net-2.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Inner_Net_License",
+        "https://sourceware.org/git/?p\u003dglibc.git;a\u003dblob;f\u003dLICENSES;h\u003d530893b1dc9ea00755603c68fb36bd4fc38a7be8;hb\u003dHEAD#l207"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/InnoSetup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/InnoSetup.json",
+      "referenceNumber": 11,
+      "name": "Inno Setup License",
+      "licenseId": "InnoSetup",
+      "seeAlso": [
+        "https://github.com/jrsoftware/issrc/blob/HEAD/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Intel.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Intel.json",
+      "referenceNumber": 418,
+      "name": "Intel Open Source License",
+      "licenseId": "Intel",
+      "seeAlso": [
+        "https://opensource.org/licenses/Intel"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Intel-ACPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
+      "referenceNumber": 329,
+      "name": "Intel ACPI Software License Agreement",
+      "licenseId": "Intel-ACPI",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Interbase-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
+      "referenceNumber": 438,
+      "name": "Interbase Public License v1.0",
+      "licenseId": "Interbase-1.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/IPA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IPA.json",
+      "referenceNumber": 508,
+      "name": "IPA Font License",
+      "licenseId": "IPA",
+      "seeAlso": [
+        "https://opensource.org/licenses/IPA"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/IPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
+      "referenceNumber": 338,
+      "name": "IBM Public License v1.0",
+      "licenseId": "IPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/IPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ISC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ISC.json",
+      "referenceNumber": 481,
+      "name": "ISC License",
+      "licenseId": "ISC",
+      "seeAlso": [
+        "https://www.isc.org/licenses/",
+        "https://www.isc.org/downloads/software-support-policy/isc-license/",
+        "https://opensource.org/licenses/ISC"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ISC-Veillard.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ISC-Veillard.json",
+      "referenceNumber": 406,
+      "name": "ISC Veillard variant",
+      "licenseId": "ISC-Veillard",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/GNOME/libxml2/4c2e7c651f6c2f0d1a74f350cbda95f7df3e7017/hash.c",
+        "https://github.com/GNOME/libxml2/blob/master/dict.c",
+        "https://sourceforge.net/p/ctrio/git/ci/master/tree/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ISO-permission.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ISO-permission.json",
+      "referenceNumber": 302,
+      "name": "ISO permission notice",
+      "licenseId": "ISO-permission",
+      "seeAlso": [
+        "https://gitlab.com/agmartin/linuxdoc-tools/-/blob/master/iso-entities/COPYING?ref_type\u003dheads",
+        "https://www.itu.int/ITU-T/formal-language/itu-t/t/t173/1997/ISOMHEG-sir.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Jam.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Jam.json",
+      "referenceNumber": 109,
+      "name": "Jam License",
+      "licenseId": "Jam",
+      "seeAlso": [
+        "https://www.boost.org/doc/libs/1_35_0/doc/html/jam.html",
+        "https://web.archive.org/web/20160330173339/https://swarm.workshop.perforce.com/files/guest/perforce_software/jam/src/README"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/JasPer-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
+      "referenceNumber": 665,
+      "name": "JasPer License",
+      "licenseId": "JasPer-2.0",
+      "seeAlso": [
+        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/jove.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/jove.json",
+      "referenceNumber": 238,
+      "name": "Jove License",
+      "licenseId": "jove",
+      "seeAlso": [
+        "https://github.com/jonmacs/jove/blob/4_17/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/JPL-image.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JPL-image.json",
+      "referenceNumber": 31,
+      "name": "JPL Image Use Policy",
+      "licenseId": "JPL-image",
+      "seeAlso": [
+        "https://www.jpl.nasa.gov/jpl-image-use-policy"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/JPNIC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
+      "referenceNumber": 578,
+      "name": "Japan Network Information Center License",
+      "licenseId": "JPNIC",
+      "seeAlso": [
+        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/JSON.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JSON.json",
+      "referenceNumber": 295,
+      "name": "JSON License",
+      "licenseId": "JSON",
+      "seeAlso": [
+        "http://www.json.org/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Kastrup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Kastrup.json",
+      "referenceNumber": 675,
+      "name": "Kastrup License",
+      "licenseId": "Kastrup",
+      "seeAlso": [
+        "https://ctan.math.utah.edu/ctan/tex-archive/macros/generic/kastrup/binhex.dtx"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Kazlib.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Kazlib.json",
+      "referenceNumber": 185,
+      "name": "Kazlib License",
+      "licenseId": "Kazlib",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/kazlib.git/tree/except.c?id\u003d0062df360c2d17d57f6af19b0e444c51feb99036"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Knuth-CTAN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Knuth-CTAN.json",
+      "referenceNumber": 369,
+      "name": "Knuth CTAN License",
+      "licenseId": "Knuth-CTAN",
+      "seeAlso": [
+        "https://ctan.org/license/knuth"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LAL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
+      "referenceNumber": 247,
+      "name": "Licence Art Libre 1.2",
+      "licenseId": "LAL-1.2",
+      "seeAlso": [
+        "http://artlibre.org/licence/lal/licence-art-libre-12/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LAL-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
+      "referenceNumber": 471,
+      "name": "Licence Art Libre 1.3",
+      "licenseId": "LAL-1.3",
+      "seeAlso": [
+        "https://artlibre.org/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Latex2e.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
+      "referenceNumber": 225,
+      "name": "Latex2e License",
+      "licenseId": "Latex2e",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Latex2e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Latex2e-translated-notice.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Latex2e-translated-notice.json",
+      "referenceNumber": 57,
+      "name": "Latex2e with translated notice permission",
+      "licenseId": "Latex2e-translated-notice",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id\u003da74c6b4ee49397cf330b333da1042bffa60ed14f#n74"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Leptonica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
+      "referenceNumber": 181,
+      "name": "Leptonica License",
+      "licenseId": "Leptonica",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Leptonica"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
+      "referenceNumber": 353,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
+      "referenceNumber": 454,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-only.json",
+      "referenceNumber": 306,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
+      "referenceNumber": 279,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
+      "referenceNumber": 275,
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
+      "referenceNumber": 162,
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
+      "referenceNumber": 482,
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
+      "referenceNumber": 334,
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
+      "referenceNumber": 426,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
+      "referenceNumber": 556,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
+      "referenceNumber": 725,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
+      "referenceNumber": 563,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPLLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
+      "referenceNumber": 34,
+      "name": "Lesser General Public License For Linguistic Resources",
+      "licenseId": "LGPLLR",
+      "seeAlso": [
+        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Libpng.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Libpng.json",
+      "referenceNumber": 280,
+      "name": "libpng License",
+      "licenseId": "Libpng",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libpng-1.6.35.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libpng-1.6.35.json",
+      "referenceNumber": 441,
+      "name": "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)",
+      "licenseId": "libpng-1.6.35",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libpng-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
+      "referenceNumber": 330,
+      "name": "PNG Reference Library version 2",
+      "licenseId": "libpng-2.0",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libselinux-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
+      "referenceNumber": 331,
+      "name": "libselinux public domain notice",
+      "licenseId": "libselinux-1.0",
+      "seeAlso": [
+        "https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libtiff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libtiff.json",
+      "referenceNumber": 213,
+      "name": "libtiff License",
+      "licenseId": "libtiff",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/libtiff"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libutil-David-Nugent.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libutil-David-Nugent.json",
+      "referenceNumber": 399,
+      "name": "libutil David Nugent License",
+      "licenseId": "libutil-David-Nugent",
+      "seeAlso": [
+        "http://web.mit.edu/freebsd/head/lib/libutil/login_ok.3",
+        "https://cgit.freedesktop.org/libbsd/tree/man/setproctitle.3bsd"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
+      "referenceNumber": 201,
+      "name": "Licence Libre du Québec – Permissive version 1.1",
+      "licenseId": "LiLiQ-P-1.1",
+      "seeAlso": [
+        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-P-1.1",
+        "https://forge.gouv.qc.ca/licence/liliq-p/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
+      "referenceNumber": 632,
+      "name": "Licence Libre du Québec – Réciprocité version 1.1",
+      "licenseId": "LiLiQ-R-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-R-1.1",
+        "https://forge.gouv.qc.ca/licence/liliq-p"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
+      "referenceNumber": 510,
+      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+      "licenseId": "LiLiQ-Rplus-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-Rplus-1.1",
+        "https://forge.gouv.qc.ca/licence/liliq-r+/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-man-pages-1-para.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-1-para.json",
+      "referenceNumber": 341,
+      "name": "Linux man-pages - 1 paragraph",
+      "licenseId": "Linux-man-pages-1-para",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/getcpu.2#n4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
+      "referenceNumber": 362,
+      "name": "Linux man-pages Copyleft",
+      "licenseId": "Linux-man-pages-copyleft",
+      "seeAlso": [
+        "https://www.kernel.org/doc/man-pages/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.json",
+      "referenceNumber": 611,
+      "name": "Linux man-pages Copyleft - 2 paragraphs",
+      "licenseId": "Linux-man-pages-copyleft-2-para",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/move_pages.2#n5",
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/migrate_pages.2#n8"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.json",
+      "referenceNumber": 629,
+      "name": "Linux man-pages Copyleft Variant",
+      "licenseId": "Linux-man-pages-copyleft-var",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/set_mempolicy.2#n5"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
+      "referenceNumber": 639,
+      "name": "Linux Kernel Variant of OpenIB.org license",
+      "licenseId": "Linux-OpenIB",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LOOP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LOOP.json",
+      "referenceNumber": 498,
+      "name": "Common Lisp LOOP License",
+      "licenseId": "LOOP",
+      "seeAlso": [
+        "https://gitlab.com/embeddable-common-lisp/ecl/-/blob/develop/src/lsp/loop.lsp",
+        "http://git.savannah.gnu.org/cgit/gcl.git/tree/gcl/lsp/gcl_loop.lsp?h\u003dVersion_2_6_13pre",
+        "https://sourceforge.net/p/sbcl/sbcl/ci/master/tree/src/code/loop.lisp",
+        "https://github.com/cl-adams/adams/blob/master/LICENSE.md",
+        "https://github.com/blakemcbride/eclipse-lisp/blob/master/lisp/loop.lisp",
+        "https://gitlab.common-lisp.net/cmucl/cmucl/-/blob/master/src/code/loop.lisp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPD-document.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPD-document.json",
+      "referenceNumber": 232,
+      "name": "LPD Documentation License",
+      "licenseId": "LPD-document",
+      "seeAlso": [
+        "https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md",
+        "https://www.ietf.org/rfc/rfc1952.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
+      "referenceNumber": 39,
+      "name": "Lucent Public License Version 1.0",
+      "licenseId": "LPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/LPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
+      "referenceNumber": 532,
+      "name": "Lucent Public License v1.02",
+      "licenseId": "LPL-1.02",
+      "seeAlso": [
+        "http://plan9.bell-labs.com/plan9/license.html",
+        "https://opensource.org/licenses/LPL-1.02"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
+      "referenceNumber": 33,
+      "name": "LaTeX Project Public License v1.0",
+      "licenseId": "LPPL-1.0",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
+      "referenceNumber": 367,
+      "name": "LaTeX Project Public License v1.1",
+      "licenseId": "LPPL-1.1",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
+      "referenceNumber": 541,
+      "name": "LaTeX Project Public License v1.2",
+      "licenseId": "LPPL-1.2",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
+      "referenceNumber": 470,
+      "name": "LaTeX Project Public License v1.3a",
+      "licenseId": "LPPL-1.3a",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
+      "referenceNumber": 679,
+      "name": "LaTeX Project Public License v1.3c",
+      "licenseId": "LPPL-1.3c",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
+        "https://opensource.org/licenses/LPPL-1.3c"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/lsof.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/lsof.json",
+      "referenceNumber": 659,
+      "name": "lsof License",
+      "licenseId": "lsof",
+      "seeAlso": [
+        "https://github.com/lsof-org/lsof/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.json",
+      "referenceNumber": 540,
+      "name": "Lucida Bitmap Fonts License",
+      "licenseId": "Lucida-Bitmap-Fonts",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/font/bh-100dpi/-/blob/master/COPYING?ref_type\u003dheads"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
+      "referenceNumber": 230,
+      "name": "LZMA SDK License (versions 9.11 to 9.20)",
+      "licenseId": "LZMA-SDK-9.11-to-9.20",
+      "seeAlso": [
+        "https://www.7-zip.org/sdk.html",
+        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
+      "referenceNumber": 462,
+      "name": "LZMA SDK License (versions 9.22 and beyond)",
+      "licenseId": "LZMA-SDK-9.22",
+      "seeAlso": [
+        "https://www.7-zip.org/sdk.html",
+        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Mackerras-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause.json",
+      "referenceNumber": 9,
+      "name": "Mackerras 3-Clause License",
+      "licenseId": "Mackerras-3-Clause",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/chap_ms.c#L6-L28"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.json",
+      "referenceNumber": 392,
+      "name": "Mackerras 3-Clause - acknowledgment variant",
+      "licenseId": "Mackerras-3-Clause-acknowledgment",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/auth.c#L6-L28"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/magaz.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/magaz.json",
+      "referenceNumber": 163,
+      "name": "magaz License",
+      "licenseId": "magaz",
+      "seeAlso": [
+        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/magaz/magaz.tex",
+        "https://mirrors.ctan.org/macros/latex/contrib/version/version.sty"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mailprio.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mailprio.json",
+      "referenceNumber": 112,
+      "name": "mailprio License",
+      "licenseId": "mailprio",
+      "seeAlso": [
+        "https://fossies.org/linux/sendmail/contrib/mailprio"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MakeIndex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
+      "referenceNumber": 6,
+      "name": "MakeIndex License",
+      "licenseId": "MakeIndex",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/man2html.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/man2html.json",
+      "referenceNumber": 726,
+      "name": "man2html License",
+      "licenseId": "man2html",
+      "seeAlso": [
+        "http://primates.ximian.com/~flucifredi/man/man-1.6g.tar.gz",
+        "https://github.com/hamano/man2html/blob/master/man2html.c",
+        "https://docs.oracle.com/cd/E81115_01/html/E81116/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Martin-Birgmeier.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Martin-Birgmeier.json",
+      "referenceNumber": 453,
+      "name": "Martin Birgmeier License",
+      "licenseId": "Martin-Birgmeier",
+      "seeAlso": [
+        "https://github.com/Perl/perl5/blob/blead/util.c#L6136"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/McPhee-slideshow.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/McPhee-slideshow.json",
+      "referenceNumber": 48,
+      "name": "McPhee Slideshow License",
+      "licenseId": "McPhee-slideshow",
+      "seeAlso": [
+        "https://mirror.las.iastate.edu/tex-archive/graphics/metapost/contrib/macros/slideshow/slideshow.mp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/metamail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/metamail.json",
+      "referenceNumber": 139,
+      "name": "metamail License",
+      "licenseId": "metamail",
+      "seeAlso": [
+        "https://github.com/Dual-Life/mime-base64/blob/master/Base64.xs#L12"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Minpack.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Minpack.json",
+      "referenceNumber": 360,
+      "name": "Minpack License",
+      "licenseId": "Minpack",
+      "seeAlso": [
+        "http://www.netlib.org/minpack/disclaimer",
+        "https://gitlab.com/libeigen/eigen/-/blob/master/COPYING.MINPACK"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIPS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIPS.json",
+      "referenceNumber": 77,
+      "name": "MIPS License",
+      "licenseId": "MIPS",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/sym.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MirOS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MirOS.json",
+      "referenceNumber": 8,
+      "name": "The MirOS Licence",
+      "licenseId": "MirOS",
+      "seeAlso": [
+        "https://opensource.org/licenses/MirOS"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT.json",
+      "referenceNumber": 114,
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "https://opensource.org/license/mit/",
+        "http://opensource.org/licenses/MIT"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
+      "referenceNumber": 264,
+      "name": "MIT No Attribution",
+      "licenseId": "MIT-0",
+      "seeAlso": [
+        "https://github.com/aws/mit-0",
+        "https://romanrm.net/mit-zero",
+        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-advertising.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
+      "referenceNumber": 402,
+      "name": "Enlightenment License (e16)",
+      "licenseId": "MIT-advertising",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Click.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Click.json",
+      "referenceNumber": 444,
+      "name": "MIT Click License",
+      "licenseId": "MIT-Click",
+      "seeAlso": [
+        "https://github.com/kohler/t1utils/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-CMU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
+      "referenceNumber": 359,
+      "name": "CMU License",
+      "licenseId": "MIT-CMU",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style",
+        "https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-enna.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
+      "referenceNumber": 609,
+      "name": "enna License",
+      "licenseId": "MIT-enna",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-feh.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
+      "referenceNumber": 724,
+      "name": "feh License",
+      "licenseId": "MIT-feh",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Festival.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Festival.json",
+      "referenceNumber": 106,
+      "name": "MIT Festival Variant",
+      "licenseId": "MIT-Festival",
+      "seeAlso": [
+        "https://github.com/festvox/flite/blob/master/COPYING",
+        "https://github.com/festvox/speech_tools/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Khronos-old.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Khronos-old.json",
+      "referenceNumber": 597,
+      "name": "MIT Khronos - old variant",
+      "licenseId": "MIT-Khronos-old",
+      "seeAlso": [
+        "https://github.com/KhronosGroup/SPIRV-Cross/blob/main/LICENSES/LicenseRef-KhronosFreeUse.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
+      "referenceNumber": 227,
+      "name": "MIT License Modern Variant",
+      "licenseId": "MIT-Modern-Variant",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT#Modern_Variants",
+        "https://ptolemy.berkeley.edu/copyright.htm",
+        "https://pirlwww.lpl.arizona.edu/resources/guide/software/PerlTk/Tixlic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-open-group.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
+      "referenceNumber": 555,
+      "name": "MIT Open Group variant",
+      "licenseId": "MIT-open-group",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-STK.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-STK.json",
+      "referenceNumber": 296,
+      "name": "MIT-STK License",
+      "licenseId": "MIT-STK",
+      "seeAlso": [
+        "https://github.com/thestk/stk/blob/6aacd357d76250bb7da2b1ddf675651828784bbc/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-testregex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-testregex.json",
+      "referenceNumber": 651,
+      "name": "MIT testregex Variant",
+      "licenseId": "MIT-testregex",
+      "seeAlso": [
+        "https://github.com/dotnet/runtime/blob/55e1ac7c07df62c4108d4acedf78f77574470ce5/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/AttRegexTests.cs#L12-L28"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Wu.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Wu.json",
+      "referenceNumber": 287,
+      "name": "MIT Tom Wu Variant",
+      "licenseId": "MIT-Wu",
+      "seeAlso": [
+        "https://github.com/chromium/octane/blob/master/crypto.js"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MITNFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
+      "referenceNumber": 442,
+      "name": "MIT +no-false-attribs license",
+      "licenseId": "MITNFA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MITNFA"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MMIXware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MMIXware.json",
+      "referenceNumber": 336,
+      "name": "MMIXware License",
+      "licenseId": "MMIXware",
+      "seeAlso": [
+        "https://gitlab.lrz.de/mmix/mmixware/-/blob/master/boilerplate.w"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MMPL-1.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MMPL-1.0.1.json",
+      "referenceNumber": 388,
+      "name": "Minecraft Mod Public License v1.0.1",
+      "licenseId": "MMPL-1.0.1",
+      "seeAlso": [
+        "https://github.com/BuildCraft/BuildCraft/blob/623d323b1868712f29f4a8b0979a02e8d1835131/LICENSE",
+        "https://mod-buildcraft.com/MMPL-1.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Motosoto.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
+      "referenceNumber": 154,
+      "name": "Motosoto License",
+      "licenseId": "Motosoto",
+      "seeAlso": [
+        "https://opensource.org/licenses/Motosoto"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPEG-SSG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPEG-SSG.json",
+      "referenceNumber": 582,
+      "name": "MPEG Software Simulation",
+      "licenseId": "MPEG-SSG",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/ppm/ppmtompeg/jrevdct.c#l1189"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mpi-permissive.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
+      "referenceNumber": 80,
+      "name": "mpi Permissive License",
+      "licenseId": "mpi-permissive",
+      "seeAlso": [
+        "https://sources.debian.org/src/openmpi/4.1.0-10/ompi/debuggers/msgq_interface.h/?hl\u003d19#L19"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mpich2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mpich2.json",
+      "referenceNumber": 104,
+      "name": "mpich2 License",
+      "licenseId": "mpich2",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
+      "referenceNumber": 427,
+      "name": "Mozilla Public License 1.0",
+      "licenseId": "MPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.0.html",
+        "https://opensource.org/licenses/MPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
+      "referenceNumber": 479,
+      "name": "Mozilla Public License 1.1",
+      "licenseId": "MPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.1.html",
+        "https://opensource.org/licenses/MPL-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
+      "referenceNumber": 420,
+      "name": "Mozilla Public License 2.0",
+      "licenseId": "MPL-2.0",
+      "seeAlso": [
+        "https://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
+      "referenceNumber": 521,
+      "name": "Mozilla Public License 2.0 (no copyleft exception)",
+      "licenseId": "MPL-2.0-no-copyleft-exception",
+      "seeAlso": [
+        "https://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/mplus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mplus.json",
+      "referenceNumber": 256,
+      "name": "mplus Font License",
+      "licenseId": "mplus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:Mplus?rd\u003dLicensing/mplus"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-LPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
+      "referenceNumber": 187,
+      "name": "Microsoft Limited Public License",
+      "licenseId": "MS-LPL",
+      "seeAlso": [
+        "https://www.openhub.net/licenses/mslpl",
+        "https://github.com/gabegundy/atlserver/blob/master/License.txt",
+        "https://en.wikipedia.org/wiki/Shared_Source_Initiative#Microsoft_Limited_Public_License_(Ms-LPL)"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
+      "referenceNumber": 66,
+      "name": "Microsoft Public License",
+      "licenseId": "MS-PL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "https://opensource.org/licenses/MS-PL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-RL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
+      "referenceNumber": 17,
+      "name": "Microsoft Reciprocal License",
+      "licenseId": "MS-RL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "https://opensource.org/licenses/MS-RL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MTLL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MTLL.json",
+      "referenceNumber": 374,
+      "name": "Matrix Template Library License",
+      "licenseId": "MTLL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
+      "referenceNumber": 277,
+      "name": "Mulan Permissive Software License, Version 1",
+      "licenseId": "MulanPSL-1.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL/",
+        "https://github.com/yuwenlong/longphp/blob/25dfb70cc2a466dc4bb55ba30901cbce08d164b5/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
+      "referenceNumber": 708,
+      "name": "Mulan Permissive Software License, Version 2",
+      "licenseId": "MulanPSL-2.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Multics.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Multics.json",
+      "referenceNumber": 547,
+      "name": "Multics License",
+      "licenseId": "Multics",
+      "seeAlso": [
+        "https://opensource.org/licenses/Multics"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Mup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Mup.json",
+      "referenceNumber": 723,
+      "name": "Mup License",
+      "licenseId": "Mup",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Mup"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NAIST-2003.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
+      "referenceNumber": 696,
+      "name": "Nara Institute of Science and Technology License (2003)",
+      "licenseId": "NAIST-2003",
+      "seeAlso": [
+        "https://enterprise.dejacode.com/licenses/public/naist-2003/#license-text",
+        "https://github.com/nodejs/node/blob/4a19cc8947b1bba2b2d27816ec3d0edf9b28e503/LICENSE#L343"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NASA-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
+      "referenceNumber": 721,
+      "name": "NASA Open Source Agreement 1.3",
+      "licenseId": "NASA-1.3",
+      "seeAlso": [
+        "http://ti.arc.nasa.gov/opensource/nosa/",
+        "https://opensource.org/licenses/NASA-1.3"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Naumen.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Naumen.json",
+      "referenceNumber": 657,
+      "name": "Naumen Public License",
+      "licenseId": "Naumen",
+      "seeAlso": [
+        "https://opensource.org/licenses/Naumen"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NBPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
+      "referenceNumber": 310,
+      "name": "Net Boolean Public License v1",
+      "licenseId": "NBPL-1.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCBI-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCBI-PD.json",
+      "referenceNumber": 550,
+      "name": "NCBI Public Domain Notice",
+      "licenseId": "NCBI-PD",
+      "seeAlso": [
+        "https://github.com/ncbi/sra-tools/blob/e8e5b6af4edc460156ad9ce5902d0779cffbf685/LICENSE",
+        "https://github.com/ncbi/datasets/blob/0ea4cd16b61e5b799d9cc55aecfa016d6c9bd2bf/LICENSE.md",
+        "https://github.com/ncbi/gprobe/blob/de64d30fee8b4c4013094d7d3139ea89b5dd1ace/LICENSE",
+        "https://github.com/ncbi/egapx/blob/08930b9dec0c69b2d1a05e5153c7b95ef0a3eb0f/LICENSE",
+        "https://github.com/ncbi/datasets/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
+      "referenceNumber": 391,
+      "name": "Non-Commercial Government Licence",
+      "licenseId": "NCGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCL.json",
+      "referenceNumber": 514,
+      "name": "NCL Source Code License",
+      "licenseId": "NCL",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/modules/module-filter-chain/pffft.c?ref_type\u003dheads#L1-52"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCSA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCSA.json",
+      "referenceNumber": 83,
+      "name": "University of Illinois/NCSA Open Source License",
+      "licenseId": "NCSA",
+      "seeAlso": [
+        "http://otm.illinois.edu/uiuc_openSource",
+        "https://opensource.org/licenses/NCSA"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Net-SNMP.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
+      "referenceNumber": 78,
+      "name": "Net-SNMP License",
+      "licenseId": "Net-SNMP",
+      "seeAlso": [
+        "http://net-snmp.sourceforge.net/about/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NetCDF.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
+      "referenceNumber": 682,
+      "name": "NetCDF license",
+      "licenseId": "NetCDF",
+      "seeAlso": [
+        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Newsletr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
+      "referenceNumber": 467,
+      "name": "Newsletr License",
+      "licenseId": "Newsletr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Newsletr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NGPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NGPL.json",
+      "referenceNumber": 421,
+      "name": "Nethack General Public License",
+      "licenseId": "NGPL",
+      "seeAlso": [
+        "https://opensource.org/licenses/NGPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ngrep.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ngrep.json",
+      "referenceNumber": 169,
+      "name": "ngrep License",
+      "licenseId": "ngrep",
+      "seeAlso": [
+        "https://github.com/jpr5/ngrep/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NICTA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
+      "referenceNumber": 394,
+      "name": "NICTA Public Software License, Version 1.0",
+      "licenseId": "NICTA-1.0",
+      "seeAlso": [
+        "https://opensource.apple.com/source/mDNSResponder/mDNSResponder-320.10/mDNSPosix/nss_ReadMe.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
+      "referenceNumber": 446,
+      "name": "NIST Public Domain Notice",
+      "licenseId": "NIST-PD",
+      "seeAlso": [
+        "https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt",
+        "https://github.com/tcheneau/Routing/blob/f09f46fcfe636107f22f2c98348188a65a135d98/README.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
+      "referenceNumber": 200,
+      "name": "NIST Public Domain Notice with license fallback",
+      "licenseId": "NIST-PD-fallback",
+      "seeAlso": [
+        "https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE",
+        "https://github.com/usnistgov/fipy/blob/86aaa5c2ba2c6f1be19593c5986071cf6568cc34/LICENSE.rst"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-PD-TNT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-PD-TNT.json",
+      "referenceNumber": 105,
+      "name": "NIST    Public Domain Notice TNT variant",
+      "licenseId": "NIST-PD-TNT",
+      "seeAlso": [
+        "https://math.nist.gov/tnt/download.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-Software.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-Software.json",
+      "referenceNumber": 18,
+      "name": "NIST Software License",
+      "licenseId": "NIST-Software",
+      "seeAlso": [
+        "https://github.com/open-quantum-safe/liboqs/blob/40b01fdbb270f8614fde30e65d30e9da18c02393/src/common/rand/rand_nist.c#L1-L15"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLOD-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
+      "referenceNumber": 667,
+      "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
+      "licenseId": "NLOD-1.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLOD-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
+      "referenceNumber": 368,
+      "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
+      "licenseId": "NLOD-2.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/2.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLPL.json",
+      "referenceNumber": 447,
+      "name": "No Limit Public License",
+      "licenseId": "NLPL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/NLPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nokia.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Nokia.json",
+      "referenceNumber": 45,
+      "name": "Nokia Open Source License",
+      "licenseId": "Nokia",
+      "seeAlso": [
+        "https://opensource.org/licenses/nokia"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NOSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NOSL.json",
+      "referenceNumber": 257,
+      "name": "Netizen Open Source License",
+      "licenseId": "NOSL",
+      "seeAlso": [
+        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Noweb.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Noweb.json",
+      "referenceNumber": 3,
+      "name": "Noweb License",
+      "licenseId": "Noweb",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Noweb"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
+      "referenceNumber": 115,
+      "name": "Netscape Public License v1.0",
+      "licenseId": "NPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.0/"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
+      "referenceNumber": 636,
+      "name": "Netscape Public License v1.1",
+      "licenseId": "NPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.1/"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
+      "referenceNumber": 303,
+      "name": "Non-Profit Open Software License 3.0",
+      "licenseId": "NPOSL-3.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/NOSL3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NRL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NRL.json",
+      "referenceNumber": 10,
+      "name": "NRL License",
+      "licenseId": "NRL",
+      "seeAlso": [
+        "http://web.mit.edu/network/isakmp/nrllicense.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTIA-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTIA-PD.json",
+      "referenceNumber": 44,
+      "name": "NTIA Public Domain Notice",
+      "licenseId": "NTIA-PD",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/NTIA/itm/refs/heads/master/LICENSE.md",
+        "https://raw.githubusercontent.com/NTIA/scos-sensor/refs/heads/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTP.json",
+      "referenceNumber": 241,
+      "name": "NTP License",
+      "licenseId": "NTP",
+      "seeAlso": [
+        "https://opensource.org/licenses/NTP"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTP-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
+      "referenceNumber": 393,
+      "name": "NTP No Attribution",
+      "licenseId": "NTP-0",
+      "seeAlso": [
+        "https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nunit.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/Nunit.json",
+      "referenceNumber": 698,
+      "name": "Nunit License",
+      "licenseId": "Nunit",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Nunit"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
+      "referenceNumber": 602,
+      "name": "Open Use of Data Agreement v1.0",
+      "licenseId": "O-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md",
+        "https://cdla.dev/open-use-of-data-agreement-v1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OAR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OAR.json",
+      "referenceNumber": 79,
+      "name": "OAR License",
+      "licenseId": "OAR",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/string/strsignal.c;hb\u003dHEAD#l35"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OCCT-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
+      "referenceNumber": 437,
+      "name": "Open CASCADE Technology Public License",
+      "licenseId": "OCCT-PL",
+      "seeAlso": [
+        "http://www.opencascade.com/content/occt-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OCLC-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
+      "referenceNumber": 55,
+      "name": "OCLC Research Public License 2.0",
+      "licenseId": "OCLC-2.0",
+      "seeAlso": [
+        "http://www.oclc.org/research/activities/software/license/v2final.htm",
+        "https://opensource.org/licenses/OCLC-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ODbL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
+      "referenceNumber": 627,
+      "name": "Open Data Commons Open Database License v1.0",
+      "licenseId": "ODbL-1.0",
+      "seeAlso": [
+        "http://www.opendatacommons.org/licenses/odbl/1.0/",
+        "https://opendatacommons.org/licenses/odbl/1-0/"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
+      "referenceNumber": 485,
+      "name": "Open Data Commons Attribution License v1.0",
+      "licenseId": "ODC-By-1.0",
+      "seeAlso": [
+        "https://opendatacommons.org/licenses/by/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFFIS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFFIS.json",
+      "referenceNumber": 263,
+      "name": "OFFIS License",
+      "licenseId": "OFFIS",
+      "seeAlso": [
+        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/dicom/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
+      "referenceNumber": 71,
+      "name": "SIL Open Font License 1.0",
+      "licenseId": "OFL-1.0",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
+      "referenceNumber": 113,
+      "name": "SIL Open Font License 1.0 with no Reserved Font Name",
+      "licenseId": "OFL-1.0-no-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
+      "referenceNumber": 419,
+      "name": "SIL Open Font License 1.0 with Reserved Font Name",
+      "licenseId": "OFL-1.0-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
+      "referenceNumber": 474,
+      "name": "SIL Open Font License 1.1",
+      "licenseId": "OFL-1.1",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
+      "referenceNumber": 126,
+      "name": "SIL Open Font License 1.1 with no Reserved Font Name",
+      "licenseId": "OFL-1.1-no-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
+      "referenceNumber": 324,
+      "name": "SIL Open Font License 1.1 with Reserved Font Name",
+      "licenseId": "OFL-1.1-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
+      "referenceNumber": 56,
+      "name": "OGC Software License, Version 1.0",
+      "licenseId": "OGC-1.0",
+      "seeAlso": [
+        "https://www.ogc.org/ogc/software/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
+      "referenceNumber": 626,
+      "name": "Taiwan Open Government Data License, version 1.0",
+      "licenseId": "OGDL-Taiwan-1.0",
+      "seeAlso": [
+        "https://data.gov.tw/license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
+      "referenceNumber": 311,
+      "name": "Open Government Licence - Canada",
+      "licenseId": "OGL-Canada-2.0",
+      "seeAlso": [
+        "https://open.canada.ca/en/open-government-licence-canada"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
+      "referenceNumber": 220,
+      "name": "Open Government Licence v1.0",
+      "licenseId": "OGL-UK-1.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/1/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
+      "referenceNumber": 107,
+      "name": "Open Government Licence v2.0",
+      "licenseId": "OGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
+      "referenceNumber": 147,
+      "name": "Open Government Licence v3.0",
+      "licenseId": "OGL-UK-3.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGTSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
+      "referenceNumber": 649,
+      "name": "Open Group Test Suite License",
+      "licenseId": "OGTSL",
+      "seeAlso": [
+        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
+        "https://opensource.org/licenses/OGTSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
+      "referenceNumber": 559,
+      "name": "Open LDAP Public License v1.1",
+      "licenseId": "OLDAP-1.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
+      "referenceNumber": 222,
+      "name": "Open LDAP Public License v1.2",
+      "licenseId": "OLDAP-1.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
+      "referenceNumber": 607,
+      "name": "Open LDAP Public License v1.3",
+      "licenseId": "OLDAP-1.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
+      "referenceNumber": 108,
+      "name": "Open LDAP Public License v1.4",
+      "licenseId": "OLDAP-1.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
+      "referenceNumber": 691,
+      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+      "licenseId": "OLDAP-2.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
+      "referenceNumber": 36,
+      "name": "Open LDAP Public License v2.0.1",
+      "licenseId": "OLDAP-2.0.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
+      "referenceNumber": 472,
+      "name": "Open LDAP Public License v2.1",
+      "licenseId": "OLDAP-2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
+      "referenceNumber": 663,
+      "name": "Open LDAP Public License v2.2",
+      "licenseId": "OLDAP-2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
+      "referenceNumber": 278,
+      "name": "Open LDAP Public License v2.2.1",
+      "licenseId": "OLDAP-2.2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d4bc786f34b50aa301be6f5600f58a980070f481e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
+      "referenceNumber": 119,
+      "name": "Open LDAP Public License 2.2.2",
+      "licenseId": "OLDAP-2.2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
+      "referenceNumber": 695,
+      "name": "Open LDAP Public License v2.3",
+      "licenseId": "OLDAP-2.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
+      "referenceNumber": 120,
+      "name": "Open LDAP Public License v2.4",
+      "licenseId": "OLDAP-2.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
+      "referenceNumber": 148,
+      "name": "Open LDAP Public License v2.5",
+      "licenseId": "OLDAP-2.5",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
+      "referenceNumber": 344,
+      "name": "Open LDAP Public License v2.6",
+      "licenseId": "OLDAP-2.6",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
+      "referenceNumber": 178,
+      "name": "Open LDAP Public License v2.7",
+      "licenseId": "OLDAP-2.7",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
+      "referenceNumber": 714,
+      "name": "Open LDAP Public License v2.8",
+      "licenseId": "OLDAP-2.8",
+      "seeAlso": [
+        "http://www.openldap.org/software/release/license.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLFL-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLFL-1.3.json",
+      "referenceNumber": 143,
+      "name": "Open Logistics Foundation License Version 1.3",
+      "licenseId": "OLFL-1.3",
+      "seeAlso": [
+        "https://openlogisticsfoundation.org/licenses/",
+        "https://opensource.org/license/olfl-1-3/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OML.json",
+      "referenceNumber": 379,
+      "name": "Open Market License",
+      "licenseId": "OML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenMDW-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenMDW-1.0.json",
+      "referenceNumber": 689,
+      "name": "OpenMDW License Agreement v1.0",
+      "licenseId": "OpenMDW-1.0",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/OpenMDW/OpenMDW/refs/heads/main/1.0/LICENSE.openmdw",
+        "https://openmdw.ai/license/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenPBS-2.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenPBS-2.3.json",
+      "referenceNumber": 390,
+      "name": "OpenPBS v2.3 Software License",
+      "licenseId": "OpenPBS-2.3",
+      "seeAlso": [
+        "https://github.com/adaptivecomputing/torque/blob/master/PBS_License.txt",
+        "https://www.mcs.anl.gov/research/projects/openpbs/PBS_License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenSSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
+      "referenceNumber": 175,
+      "name": "OpenSSL License",
+      "licenseId": "OpenSSL",
+      "seeAlso": [
+        "http://www.openssl.org/source/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenSSL-standalone.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenSSL-standalone.json",
+      "referenceNumber": 443,
+      "name": "OpenSSL License - standalone",
+      "licenseId": "OpenSSL-standalone",
+      "seeAlso": [
+        "https://library.netapp.com/ecm/ecm_download_file/ECMP1196395",
+        "https://hstechdocs.helpsystems.com/manuals/globalscape/archive/cuteftp6/open_ssl_license_agreement.htm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenVision.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenVision.json",
+      "referenceNumber": 254,
+      "name": "OpenVision License",
+      "licenseId": "OpenVision",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L66-L98",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html",
+        "https://fedoraproject.org/wiki/Licensing:MIT#OpenVision_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
+      "referenceNumber": 348,
+      "name": "Open Public License v1.0",
+      "licenseId": "OPL-1.0",
+      "seeAlso": [
+        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
+        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OPL-UK-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OPL-UK-3.0.json",
+      "referenceNumber": 68,
+      "name": "United    Kingdom Open Parliament Licence v3.0",
+      "licenseId": "OPL-UK-3.0",
+      "seeAlso": [
+        "https://www.parliament.uk/site-information/copyright-parliament/open-parliament-licence/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
+      "referenceNumber": 413,
+      "name": "Open Publication License v1.0",
+      "licenseId": "OPUBL-1.0",
+      "seeAlso": [
+        "http://opencontent.org/openpub/",
+        "https://www.debian.org/opl",
+        "https://www.ctan.org/license/opl"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSC-1.0.json",
+      "referenceNumber": 365,
+      "name": "OSC License 1.0",
+      "licenseId": "OSC-1.0",
+      "seeAlso": [
+        "https://opensource.org/license/osc-license-1-0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
+      "referenceNumber": 423,
+      "name": "OSET Public License version 2.1",
+      "licenseId": "OSET-PL-2.1",
+      "seeAlso": [
+        "http://www.osetfoundation.org/public-license",
+        "https://opensource.org/licenses/OPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
+      "referenceNumber": 673,
+      "name": "Open Software License 1.0",
+      "licenseId": "OSL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/OSL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
+      "referenceNumber": 436,
+      "name": "Open Software License 1.1",
+      "licenseId": "OSL-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
+      "referenceNumber": 676,
+      "name": "Open Software License 2.0",
+      "licenseId": "OSL-2.0",
+      "seeAlso": [
+        "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
+      "referenceNumber": 286,
+      "name": "Open Software License 2.1",
+      "licenseId": "OSL-2.1",
+      "seeAlso": [
+        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
+        "https://opensource.org/licenses/OSL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
+      "referenceNumber": 354,
+      "name": "Open Software License 3.0",
+      "licenseId": "OSL-3.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
+        "https://opensource.org/licenses/OSL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSSP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSSP.json",
+      "referenceNumber": 292,
+      "name": "OSSP License",
+      "licenseId": "OSSP",
+      "seeAlso": [
+        "https://git.sr.ht/~nabijaczleweli/ossp-var"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PADL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PADL.json",
+      "referenceNumber": 594,
+      "name": "PADL License",
+      "licenseId": "PADL",
+      "seeAlso": [
+        "https://git.openldap.org/openldap/openldap/-/blob/master/libraries/libldap/os-local.c?ref_type\u003dheads#L19-23"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ParaType-Free-Font-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ParaType-Free-Font-1.3.json",
+      "referenceNumber": 625,
+      "name": "ParaType Free Font Licensing Agreement v1.3",
+      "licenseId": "ParaType-Free-Font-1.3",
+      "seeAlso": [
+        "https://web.archive.org/web/20161209023955/http://www.paratype.ru/public/pt_openlicense_eng.asp",
+        "https://metadata.ftp-master.debian.org/changelogs//main/f/fonts-paratype/fonts-paratype_20181108-4_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
+      "referenceNumber": 38,
+      "name": "The Parity Public License 6.0.0",
+      "licenseId": "Parity-6.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/6.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
+      "referenceNumber": 633,
+      "name": "The Parity Public License 7.0.0",
+      "licenseId": "Parity-7.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/7.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
+      "referenceNumber": 703,
+      "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
+      "licenseId": "PDDL-1.0",
+      "seeAlso": [
+        "http://opendatacommons.org/licenses/pddl/1.0/",
+        "https://opendatacommons.org/licenses/pddl/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PHP-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
+      "referenceNumber": 504,
+      "name": "PHP License v3.0",
+      "licenseId": "PHP-3.0",
+      "seeAlso": [
+        "http://www.php.net/license/3_0.txt",
+        "https://opensource.org/licenses/PHP-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/PHP-3.01.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
+      "referenceNumber": 283,
+      "name": "PHP License v3.01",
+      "licenseId": "PHP-3.01",
+      "seeAlso": [
+        "http://www.php.net/license/3_01.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Pixar.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Pixar.json",
+      "referenceNumber": 642,
+      "name": "Pixar License",
+      "licenseId": "Pixar",
+      "seeAlso": [
+        "https://github.com/PixarAnimationStudios/OpenSubdiv/raw/v3_5_0/LICENSE.txt",
+        "https://graphics.pixar.com/opensubdiv/docs/license.html",
+        "https://github.com/PixarAnimationStudios/OpenSubdiv/blob/v3_5_0/opensubdiv/version.cpp#L2-L22"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/pkgconf.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/pkgconf.json",
+      "referenceNumber": 219,
+      "name": "pkgconf License",
+      "licenseId": "pkgconf",
+      "seeAlso": [
+        "https://github.com/pkgconf/pkgconf/blob/master/cli/main.c#L8"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Plexus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Plexus.json",
+      "referenceNumber": 152,
+      "name": "Plexus Classworlds License",
+      "licenseId": "Plexus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/pnmstitch.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/pnmstitch.json",
+      "referenceNumber": 204,
+      "name": "pnmstitch License",
+      "licenseId": "pnmstitch",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/editor/pnmstitch.c#l2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
+      "referenceNumber": 623,
+      "name": "PolyForm Noncommercial License 1.0.0",
+      "licenseId": "PolyForm-Noncommercial-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/noncommercial/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
+      "referenceNumber": 503,
+      "name": "PolyForm Small Business License 1.0.0",
+      "licenseId": "PolyForm-Small-Business-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/small-business/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PostgreSQL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
+      "referenceNumber": 717,
+      "name": "PostgreSQL License",
+      "licenseId": "PostgreSQL",
+      "seeAlso": [
+        "http://www.postgresql.org/about/licence",
+        "https://opensource.org/licenses/PostgreSQL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/PPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PPL.json",
+      "referenceNumber": 669,
+      "name": "Peer Production License",
+      "licenseId": "PPL",
+      "seeAlso": [
+        "https://wiki.p2pfoundation.net/Peer_Production_License",
+        "http://www.networkcultures.org/_uploads/%233notebook_telekommunist.pdf"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PSF-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
+      "referenceNumber": 490,
+      "name": "Python Software Foundation License 2.0",
+      "licenseId": "PSF-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Python-2.0",
+        "https://matplotlib.org/stable/project/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/psfrag.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/psfrag.json",
+      "referenceNumber": 166,
+      "name": "psfrag License",
+      "licenseId": "psfrag",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psfrag"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/psutils.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/psutils.json",
+      "referenceNumber": 259,
+      "name": "psutils License",
+      "licenseId": "psutils",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psutils"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Python-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Python-2.0.json",
+      "referenceNumber": 110,
+      "name": "Python License 2.0",
+      "licenseId": "Python-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Python-2.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
+      "referenceNumber": 176,
+      "name": "Python License 2.0.1",
+      "licenseId": "Python-2.0.1",
+      "seeAlso": [
+        "https://www.python.org/download/releases/2.0.1/license/",
+        "https://docs.python.org/3/license.html",
+        "https://github.com/python/cpython/blob/main/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/python-ldap.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/python-ldap.json",
+      "referenceNumber": 273,
+      "name": "Python ldap License",
+      "licenseId": "python-ldap",
+      "seeAlso": [
+        "https://github.com/python-ldap/python-ldap/blob/main/LICENCE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Qhull.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Qhull.json",
+      "referenceNumber": 59,
+      "name": "Qhull License",
+      "licenseId": "Qhull",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Qhull"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/QPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
+      "referenceNumber": 440,
+      "name": "Q Public License 1.0",
+      "licenseId": "QPL-1.0",
+      "seeAlso": [
+        "http://doc.qt.nokia.com/3.3/license.html",
+        "https://opensource.org/licenses/QPL-1.0",
+        "https://doc.qt.io/archives/3.3/license.html"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.json",
+      "referenceNumber": 320,
+      "name": "Q Public License 1.0 - INRIA 2004 variant",
+      "licenseId": "QPL-1.0-INRIA-2004",
+      "seeAlso": [
+        "https://github.com/maranget/hevea/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/radvd.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/radvd.json",
+      "referenceNumber": 613,
+      "name": "radvd License",
+      "licenseId": "radvd",
+      "seeAlso": [
+        "https://github.com/radvd-project/radvd/blob/master/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Rdisc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
+      "referenceNumber": 158,
+      "name": "Rdisc License",
+      "licenseId": "Rdisc",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
+      "referenceNumber": 612,
+      "name": "Red Hat eCos Public License v1.1",
+      "licenseId": "RHeCos-1.1",
+      "seeAlso": [
+        "http://ecos.sourceware.org/old-license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
+      "referenceNumber": 132,
+      "name": "Reciprocal Public License 1.1",
+      "licenseId": "RPL-1.1",
+      "seeAlso": [
+        "https://opensource.org/licenses/RPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/RPL-1.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
+      "referenceNumber": 300,
+      "name": "Reciprocal Public License 1.5",
+      "licenseId": "RPL-1.5",
+      "seeAlso": [
+        "https://opensource.org/licenses/RPL-1.5"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/RPSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
+      "referenceNumber": 27,
+      "name": "RealNetworks Public Source License v1.0",
+      "licenseId": "RPSL-1.0",
+      "seeAlso": [
+        "https://helixcommunity.org/content/rpsl",
+        "https://opensource.org/licenses/RPSL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/RSA-MD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
+      "referenceNumber": 538,
+      "name": "RSA Message-Digest License",
+      "licenseId": "RSA-MD",
+      "seeAlso": [
+        "http://www.faqs.org/rfcs/rfc1321.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RSCPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
+      "referenceNumber": 571,
+      "name": "Ricoh Source Code Public License",
+      "licenseId": "RSCPL",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
+        "https://opensource.org/licenses/RSCPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Ruby.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ruby.json",
+      "referenceNumber": 325,
+      "name": "Ruby License",
+      "licenseId": "Ruby",
+      "seeAlso": [
+        "https://www.ruby-lang.org/en/about/license.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Ruby-pty.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ruby-pty.json",
+      "referenceNumber": 678,
+      "name": "Ruby pty extension license",
+      "licenseId": "Ruby-pty",
+      "seeAlso": [
+        "https://github.com/ruby/ruby/blob/9f6deaa6888a423720b4b127b5314f0ad26cc2e6/ext/pty/pty.c#L775-L786",
+        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-ef5fa30838d6d0cecad9e675cc50b24628cfe2cb277c346053fafcc36c91c204",
+        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-fedf217c1ce44bda01f0a678d3ff8b198bed478754d699c527a698ad933979a0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SAX-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
+      "referenceNumber": 179,
+      "name": "Sax Public Domain Notice",
+      "licenseId": "SAX-PD",
+      "seeAlso": [
+        "http://www.saxproject.org/copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SAX-PD-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SAX-PD-2.0.json",
+      "referenceNumber": 285,
+      "name": "Sax Public Domain Notice 2.0",
+      "licenseId": "SAX-PD-2.0",
+      "seeAlso": [
+        "http://www.saxproject.org/copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Saxpath.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
+      "referenceNumber": 47,
+      "name": "Saxpath License",
+      "licenseId": "Saxpath",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SCEA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SCEA.json",
+      "referenceNumber": 648,
+      "name": "SCEA Shared Source License",
+      "licenseId": "SCEA",
+      "seeAlso": [
+        "http://research.scea.com/scea_shared_source_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SchemeReport.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
+      "referenceNumber": 270,
+      "name": "Scheme Language Report License",
+      "licenseId": "SchemeReport",
+      "seeAlso": [],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sendmail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
+      "referenceNumber": 674,
+      "name": "Sendmail License",
+      "licenseId": "Sendmail",
+      "seeAlso": [
+        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
+        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
+      "referenceNumber": 552,
+      "name": "Sendmail License 8.23",
+      "licenseId": "Sendmail-8.23",
+      "seeAlso": [
+        "https://www.proofpoint.com/sites/default/files/sendmail-license.pdf",
+        "https://web.archive.org/web/20181003101040/https://www.proofpoint.com/sites/default/files/sendmail-license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.json",
+      "referenceNumber": 719,
+      "name": "Sendmail Open Source License v1.1",
+      "licenseId": "Sendmail-Open-Source-1.1",
+      "seeAlso": [
+        "https://github.com/trusteddomainproject/OpenDMARC/blob/master/LICENSE.Sendmail"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
+      "referenceNumber": 546,
+      "name": "SGI Free Software License B v1.0",
+      "licenseId": "SGI-B-1.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
+      "referenceNumber": 670,
+      "name": "SGI Free Software License B v1.1",
+      "licenseId": "SGI-B-1.1",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
+      "referenceNumber": 452,
+      "name": "SGI Free Software License B v2.0",
+      "licenseId": "SGI-B-2.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-OpenGL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-OpenGL.json",
+      "referenceNumber": 500,
+      "name": "SGI OpenGL License",
+      "licenseId": "SGI-OpenGL",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/mesa/glw/-/blob/master/README?ref_type\u003dheads"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGMLUG-PM.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGMLUG-PM.json",
+      "referenceNumber": 641,
+      "name": "SGMLUG Parser Materials License",
+      "licenseId": "SGMLUG-PM",
+      "seeAlso": [
+        "https://gitweb.gentoo.org/repo/gentoo.git/tree/licenses/SGMLUG?id\u003d7d999af4a47bf55e53e54713d98d145f935935c1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGP4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGP4.json",
+      "referenceNumber": 228,
+      "name": "SGP4 Permission Notice",
+      "licenseId": "SGP4",
+      "seeAlso": [
+        "https://celestrak.org/publications/AIAA/2006-6753/faq.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-0.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
+      "referenceNumber": 123,
+      "name": "Solderpad Hardware License v0.5",
+      "licenseId": "SHL-0.5",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.5/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-0.51.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
+      "referenceNumber": 342,
+      "name": "Solderpad Hardware License, Version 0.51",
+      "licenseId": "SHL-0.51",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.51/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SimPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
+      "referenceNumber": 183,
+      "name": "Simple Public License 2.0",
+      "licenseId": "SimPL-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SimPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SISSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SISSL.json",
+      "referenceNumber": 1,
+      "name": "Sun Industry Standards Source License v1.1",
+      "licenseId": "SISSL",
+      "seeAlso": [
+        "http://www.openoffice.org/licenses/sissl_license.html",
+        "https://opensource.org/licenses/SISSL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SISSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
+      "referenceNumber": 506,
+      "name": "Sun Industry Standards Source License v1.2",
+      "licenseId": "SISSL-1.2",
+      "seeAlso": [
+        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SL.json",
+      "referenceNumber": 652,
+      "name": "SL License",
+      "licenseId": "SL",
+      "seeAlso": [
+        "https://github.com/mtoyoda/sl/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sleepycat.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
+      "referenceNumber": 576,
+      "name": "Sleepycat License",
+      "licenseId": "Sleepycat",
+      "seeAlso": [
+        "https://opensource.org/licenses/Sleepycat"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SMAIL-GPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMAIL-GPL.json",
+      "referenceNumber": 101,
+      "name": "SMAIL General Public License",
+      "licenseId": "SMAIL-GPL",
+      "seeAlso": [
+        "https://sources.debian.org/copyright/license/debianutils/4.11.2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SMLNJ.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
+      "referenceNumber": 75,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "SMLNJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SMPPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
+      "referenceNumber": 516,
+      "name": "Secure Messaging Protocol Public License",
+      "licenseId": "SMPPL",
+      "seeAlso": [
+        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SNIA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SNIA.json",
+      "referenceNumber": 389,
+      "name": "SNIA Public License 1.1",
+      "licenseId": "SNIA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/snprintf.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/snprintf.json",
+      "referenceNumber": 49,
+      "name": "snprintf License",
+      "licenseId": "snprintf",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/master/openbsd-compat/bsd-snprintf.c#L2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SOFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SOFA.json",
+      "referenceNumber": 616,
+      "name": "SOFA Software License",
+      "licenseId": "SOFA",
+      "seeAlso": [
+        "http://www.iausofa.org/tandc.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/softSurfer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/softSurfer.json",
+      "referenceNumber": 464,
+      "name": "softSurfer License",
+      "licenseId": "softSurfer",
+      "seeAlso": [
+        "https://github.com/mm2/Little-CMS/blob/master/src/cmssm.c#L207",
+        "https://fedoraproject.org/wiki/Licensing/softSurfer"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Soundex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Soundex.json",
+      "referenceNumber": 523,
+      "name": "Soundex License",
+      "licenseId": "Soundex",
+      "seeAlso": [
+        "https://metacpan.org/release/RJBS/Text-Soundex-3.05/source/Soundex.pm#L3-11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Spencer-86.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
+      "referenceNumber": 130,
+      "name": "Spencer License 86",
+      "licenseId": "Spencer-86",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Spencer-94.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
+      "referenceNumber": 604,
+      "name": "Spencer License 94",
+      "licenseId": "Spencer-94",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License",
+        "https://metacpan.org/release/KNOK/File-MMagic-1.30/source/COPYING#L28"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Spencer-99.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
+      "referenceNumber": 60,
+      "name": "Spencer License 99",
+      "licenseId": "Spencer-99",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
+      "referenceNumber": 628,
+      "name": "Sun Public License v1.0",
+      "licenseId": "SPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ssh-keyscan.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ssh-keyscan.json",
+      "referenceNumber": 297,
+      "name": "ssh-keyscan License",
+      "licenseId": "ssh-keyscan",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/master/LICENCE#L82"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
+      "referenceNumber": 304,
+      "name": "SSH OpenSSH license",
+      "licenseId": "SSH-OpenSSH",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSH-short.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
+      "referenceNumber": 182,
+      "name": "SSH short notice",
+      "licenseId": "SSH-short",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h",
+        "http://web.mit.edu/kolya/.f/root/athena.mit.edu/sipb.mit.edu/project/openssh/OldFiles/src/openssh-2.9.9p2/ssh-add.1",
+        "https://joinup.ec.europa.eu/svn/lesoll/trunk/italc/lib/src/dsa_key.cpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSLeay-standalone.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSLeay-standalone.json",
+      "referenceNumber": 382,
+      "name": "SSLeay License - standalone",
+      "licenseId": "SSLeay-standalone",
+      "seeAlso": [
+        "https://www.tq-group.com/filedownloads/files/software-license-conditions/OriginalSSLeay/OriginalSSLeay.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
+      "referenceNumber": 527,
+      "name": "Server Side Public License, v 1",
+      "licenseId": "SSPL-1.0",
+      "seeAlso": [
+        "https://www.mongodb.com/licensing/server-side-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/StandardML-NJ.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
+      "referenceNumber": 677,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "StandardML-NJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
+      "referenceNumber": 197,
+      "name": "SugarCRM Public License v1.1.3",
+      "licenseId": "SugarCRM-1.1.3",
+      "seeAlso": [
+        "http://www.sugarcrm.com/crm/SPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SUL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SUL-1.0.json",
+      "referenceNumber": 146,
+      "name": "Sustainable Use License v1.0",
+      "licenseId": "SUL-1.0",
+      "seeAlso": [
+        "https://github.com/n8n-io/n8n/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sun-PPP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sun-PPP.json",
+      "referenceNumber": 98,
+      "name": "Sun PPP License",
+      "licenseId": "Sun-PPP",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/eap.c#L7-L16"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sun-PPP-2000.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sun-PPP-2000.json",
+      "referenceNumber": 145,
+      "name": "Sun PPP License (2000)",
+      "licenseId": "Sun-PPP-2000",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/modules/ppp_ahdlc.c#L7-L19"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SunPro.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SunPro.json",
+      "referenceNumber": 267,
+      "name": "SunPro License",
+      "licenseId": "SunPro",
+      "seeAlso": [
+        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_acosh.c",
+        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_lgammal.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SWL.json",
+      "referenceNumber": 174,
+      "name": "Scheme Widget Library (SWL) Software License Agreement",
+      "licenseId": "SWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SWL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/swrule.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/swrule.json",
+      "referenceNumber": 93,
+      "name": "swrule License",
+      "licenseId": "swrule",
+      "seeAlso": [
+        "https://ctan.math.utah.edu/ctan/tex-archive/macros/generic/misc/swrule.sty"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Symlinks.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Symlinks.json",
+      "referenceNumber": 473,
+      "name": "Symlinks License",
+      "licenseId": "Symlinks",
+      "seeAlso": [
+        "https://www.mail-archive.com/debian-bugs-rc@lists.debian.org/msg11494.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
+      "referenceNumber": 153,
+      "name": "TAPR Open Hardware License v1.0",
+      "licenseId": "TAPR-OHL-1.0",
+      "seeAlso": [
+        "https://www.tapr.org/OHL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TCL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TCL.json",
+      "referenceNumber": 53,
+      "name": "TCL/TK License",
+      "licenseId": "TCL",
+      "seeAlso": [
+        "http://www.tcl.tk/software/tcltk/license.html",
+        "https://fedoraproject.org/wiki/Licensing/TCL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TCP-wrappers.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
+      "referenceNumber": 539,
+      "name": "TCP Wrappers License",
+      "licenseId": "TCP-wrappers",
+      "seeAlso": [
+        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TekHVC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TekHVC.json",
+      "referenceNumber": 548,
+      "name": "TekHVC License",
+      "licenseId": "TekHVC",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/master/COPYING?ref_type\u003dheads#L138-171"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TermReadKey.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TermReadKey.json",
+      "referenceNumber": 172,
+      "name": "TermReadKey License",
+      "licenseId": "TermReadKey",
+      "seeAlso": [
+        "https://github.com/jonathanstowe/TermReadKey/blob/master/README#L9-L10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TGPPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TGPPL-1.0.json",
+      "referenceNumber": 245,
+      "name": "Transitive Grace Period Public Licence 1.0",
+      "licenseId": "TGPPL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TGPPL",
+        "https://tahoe-lafs.org/trac/tahoe-lafs/browser/trunk/COPYING.TGPPL.rst"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ThirdEye.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ThirdEye.json",
+      "referenceNumber": 240,
+      "name": "ThirdEye License",
+      "licenseId": "ThirdEye",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/symconst.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/threeparttable.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/threeparttable.json",
+      "referenceNumber": 686,
+      "name": "threeparttable License",
+      "licenseId": "threeparttable",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Threeparttable"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TMate.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TMate.json",
+      "referenceNumber": 313,
+      "name": "TMate Open Source License",
+      "licenseId": "TMate",
+      "seeAlso": [
+        "http://svnkit.com/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
+      "referenceNumber": 371,
+      "name": "TORQUE v2.5+ Software License v1.1",
+      "licenseId": "TORQUE-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TOSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TOSL.json",
+      "referenceNumber": 125,
+      "name": "Trusster Open Source License",
+      "licenseId": "TOSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TOSL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TPDL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TPDL.json",
+      "referenceNumber": 589,
+      "name": "Time::ParseDate License",
+      "licenseId": "TPDL",
+      "seeAlso": [
+        "https://metacpan.org/pod/Time::ParseDate#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TPL-1.0.json",
+      "referenceNumber": 531,
+      "name": "THOR Public License 1.0",
+      "licenseId": "TPL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:ThorPublicLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TrustedQSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TrustedQSL.json",
+      "referenceNumber": 661,
+      "name": "TrustedQSL License",
+      "licenseId": "TrustedQSL",
+      "seeAlso": [
+        "https://sourceforge.net/p/trustedqsl/tqsl/ci/master/tree/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TTWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TTWL.json",
+      "referenceNumber": 432,
+      "name": "Text-Tabs+Wrap License",
+      "licenseId": "TTWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TTWL",
+        "https://github.com/ap/Text-Tabs/blob/master/lib.modern/Text/Tabs.pm#L148"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TTYP0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TTYP0.json",
+      "referenceNumber": 88,
+      "name": "TTYP0 License",
+      "licenseId": "TTYP0",
+      "seeAlso": [
+        "https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
+      "referenceNumber": 411,
+      "name": "Technische Universitaet Berlin License 1.0",
+      "licenseId": "TU-Berlin-1.0",
+      "seeAlso": [
+        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
+      "referenceNumber": 15,
+      "name": "Technische Universitaet Berlin License 2.0",
+      "licenseId": "TU-Berlin-2.0",
+      "seeAlso": [
+        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Ubuntu-font-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ubuntu-font-1.0.json",
+      "referenceNumber": 274,
+      "name": "Ubuntu Font Licence v1.0",
+      "licenseId": "Ubuntu-font-1.0",
+      "seeAlso": [
+        "https://ubuntu.com/legal/font-licence",
+        "https://assets.ubuntu.com/v1/81e5605d-ubuntu-font-licence-1.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UCAR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UCAR.json",
+      "referenceNumber": 656,
+      "name": "UCAR License",
+      "licenseId": "UCAR",
+      "seeAlso": [
+        "https://github.com/Unidata/UDUNITS-2/blob/master/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UCL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
+      "referenceNumber": 70,
+      "name": "Upstream Compatibility License v1.0",
+      "licenseId": "UCL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UCL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ulem.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ulem.json",
+      "referenceNumber": 289,
+      "name": "ulem License",
+      "licenseId": "ulem",
+      "seeAlso": [
+        "https://mirrors.ctan.org/macros/latex/contrib/ulem/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UMich-Merit.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UMich-Merit.json",
+      "referenceNumber": 312,
+      "name": "Michigan/Merit Networks License",
+      "licenseId": "UMich-Merit",
+      "seeAlso": [
+        "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L64"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-3.0.json",
+      "referenceNumber": 37,
+      "name": "Unicode License v3",
+      "licenseId": "Unicode-3.0",
+      "seeAlso": [
+        "https://www.unicode.org/license.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
+      "referenceNumber": 361,
+      "name": "Unicode License Agreement - Data Files and Software (2015)",
+      "licenseId": "Unicode-DFS-2015",
+      "seeAlso": [
+        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
+      "referenceNumber": 501,
+      "name": "Unicode License Agreement - Data Files and Software (2016)",
+      "licenseId": "Unicode-DFS-2016",
+      "seeAlso": [
+        "https://www.unicode.org/license.txt",
+        "http://web.archive.org/web/20160823201924/http://www.unicode.org/copyright.html#License",
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-TOU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
+      "referenceNumber": 658,
+      "name": "Unicode Terms of Use",
+      "licenseId": "Unicode-TOU",
+      "seeAlso": [
+        "http://web.archive.org/web/20140704074106/http://www.unicode.org/copyright.html",
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UnixCrypt.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UnixCrypt.json",
+      "referenceNumber": 425,
+      "name": "UnixCrypt License",
+      "licenseId": "UnixCrypt",
+      "seeAlso": [
+        "https://foss.heptapod.net/python-libs/passlib/-/blob/branch/stable/LICENSE#L70",
+        "https://opensource.apple.com/source/JBoss/JBoss-737/jboss-all/jetty/src/main/org/mortbay/util/UnixCrypt.java.auto.html",
+        "https://archive.eclipse.org/jetty/8.0.1.v20110908/xref/org/eclipse/jetty/http/security/UnixCrypt.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
+      "referenceNumber": 141,
+      "name": "The Unlicense",
+      "licenseId": "Unlicense",
+      "seeAlso": [
+        "https://unlicense.org/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense-libtelnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense-libtelnet.json",
+      "referenceNumber": 271,
+      "name": "Unlicense - libtelnet variant",
+      "licenseId": "Unlicense-libtelnet",
+      "seeAlso": [
+        "https://github.com/seanmiddleditch/libtelnet/blob/develop/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense-libwhirlpool.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense-libwhirlpool.json",
+      "referenceNumber": 19,
+      "name": "Unlicense - libwhirlpool variant",
+      "licenseId": "Unlicense-libwhirlpool",
+      "seeAlso": [
+        "https://github.com/dfateyev/libwhirlpool/blob/master/README#L27"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UnRAR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UnRAR.json",
+      "referenceNumber": 307,
+      "name": "UnRAR License",
+      "licenseId": "UnRAR",
+      "seeAlso": [
+        "https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/LICENSES/unRAR.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
+      "referenceNumber": 138,
+      "name": "Universal Permissive License v1.0",
+      "licenseId": "UPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UPL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/URT-RLE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/URT-RLE.json",
+      "referenceNumber": 135,
+      "name": "Utah Raster Toolkit Run Length Encoded License",
+      "licenseId": "URT-RLE",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/other/pnmtorle.c",
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/other/rletopnm.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Vim.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Vim.json",
+      "referenceNumber": 266,
+      "name": "Vim License",
+      "licenseId": "Vim",
+      "seeAlso": [
+        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Vixie-Cron.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Vixie-Cron.json",
+      "referenceNumber": 518,
+      "name": "Vixie Cron License",
+      "licenseId": "Vixie-Cron",
+      "seeAlso": [
+        "https://github.com/vixie/cron/tree/545b3f5246824a9cda5905eeb7cf019c95e66995"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/VOSTROM.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
+      "referenceNumber": 65,
+      "name": "VOSTROM Public License for Open Source",
+      "licenseId": "VOSTROM",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/VSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
+      "referenceNumber": 97,
+      "name": "Vovida Software License v1.0",
+      "licenseId": "VSL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/VSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/W3C.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/W3C.json",
+      "referenceNumber": 488,
+      "name": "W3C Software Notice and License (2002-12-31)",
+      "licenseId": "W3C",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
+        "https://opensource.org/licenses/W3C"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/W3C-19980720.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
+      "referenceNumber": 50,
+      "name": "W3C Software Notice and License (1998-07-20)",
+      "licenseId": "W3C-19980720",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/W3C-20150513.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
+      "referenceNumber": 513,
+      "name": "W3C Software Notice and Document License (2015-05-13)",
+      "licenseId": "W3C-20150513",
+      "seeAlso": [
+        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
+        "https://www.w3.org/copyright/software-license-2015/",
+        "https://www.w3.org/copyright/software-license-2023/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/w3m.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/w3m.json",
+      "referenceNumber": 170,
+      "name": "w3m License",
+      "licenseId": "w3m",
+      "seeAlso": [
+        "https://github.com/tats/w3m/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Watcom-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
+      "referenceNumber": 684,
+      "name": "Sybase Open Watcom Public License 1.0",
+      "licenseId": "Watcom-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Watcom-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Widget-Workshop.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Widget-Workshop.json",
+      "referenceNumber": 630,
+      "name": "Widget Workshop License",
+      "licenseId": "Widget-Workshop",
+      "seeAlso": [
+        "https://github.com/novnc/noVNC/blob/master/core/crypto/des.js#L24"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/WordNet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/WordNet.json",
+      "referenceNumber": 314,
+      "name": "WordNet License",
+      "licenseId": "WordNet",
+      "seeAlso": [
+        "https://wordnet.princeton.edu/license-and-commercial-use"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Wsuipa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
+      "referenceNumber": 376,
+      "name": "Wsuipa License",
+      "licenseId": "Wsuipa",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/WTFNMFPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/WTFNMFPL.json",
+      "referenceNumber": 568,
+      "name": "Do What The F*ck You Want To But It\u0027s Not My Fault Public License",
+      "licenseId": "WTFNMFPL",
+      "seeAlso": [
+        "https://github.com/adversary-org/wtfnmf/raw/refs/tags/1.0/COPYING.WTFNMFPL",
+        "https://github.com/adversary-org/wtfnmf/raw/3f2cd8235a64350a57a51b9739715edaea63ec1a/COPYING.WTFNMFPL-utf8"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/WTFPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
+      "referenceNumber": 455,
+      "name": "Do What The F*ck You Want To Public License",
+      "licenseId": "WTFPL",
+      "seeAlso": [
+        "http://www.wtfpl.net/about/",
+        "http://sam.zoy.org/wtfpl/COPYING"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/wwl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/wwl.json",
+      "referenceNumber": 191,
+      "name": "WWL License",
+      "licenseId": "wwl",
+      "seeAlso": [
+        "http://www.db.net/downloads/wwl+db-1.3.tgz"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/wxWindows.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
+      "referenceNumber": 346,
+      "name": "wxWindows Library License",
+      "licenseId": "wxWindows",
+      "seeAlso": [
+        "https://opensource.org/licenses/WXwindows"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/X11.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11.json",
+      "referenceNumber": 458,
+      "name": "X11 License",
+      "licenseId": "X11",
+      "seeAlso": [
+        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
+      "referenceNumber": 705,
+      "name": "X11 License Distribution Modification Variant",
+      "licenseId": "X11-distribute-modifications-variant",
+      "seeAlso": [
+        "https://github.com/mirror/ncurses/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/X11-no-permit-persons.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11-no-permit-persons.json",
+      "referenceNumber": 258,
+      "name": "X11 no permit persons clause",
+      "licenseId": "X11-no-permit-persons",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/lib/libxinerama/-/blob/cc22c2f60c3862482562955116d5455263b443dc/COPYING#L44-66"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/X11-swapped.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11-swapped.json",
+      "referenceNumber": 569,
+      "name": "X11 swapped final paragraphs",
+      "licenseId": "X11-swapped",
+      "seeAlso": [
+        "https://github.com/fedeinthemix/chez-srfi/blob/master/srfi/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Xdebug-1.03.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Xdebug-1.03.json",
+      "referenceNumber": 262,
+      "name": "Xdebug License v 1.03",
+      "licenseId": "Xdebug-1.03",
+      "seeAlso": [
+        "https://github.com/xdebug/xdebug/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Xerox.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Xerox.json",
+      "referenceNumber": 533,
+      "name": "Xerox License",
+      "licenseId": "Xerox",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xerox"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Xfig.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Xfig.json",
+      "referenceNumber": 404,
+      "name": "Xfig License",
+      "licenseId": "Xfig",
+      "seeAlso": [
+        "https://github.com/Distrotech/transfig/blob/master/transfig/transfig.c",
+        "https://fedoraproject.org/wiki/Licensing:MIT#Xfig_Variant",
+        "https://sourceforge.net/p/mcj/xfig/ci/master/tree/src/Makefile.am"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/XFree86-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
+      "referenceNumber": 624,
+      "name": "XFree86 License 1.1",
+      "licenseId": "XFree86-1.1",
+      "seeAlso": [
+        "http://www.xfree86.org/current/LICENSE4.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/xinetd.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xinetd.json",
+      "referenceNumber": 634,
+      "name": "xinetd License",
+      "licenseId": "xinetd",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.json",
+      "referenceNumber": 592,
+      "name": "xkeyboard-config Zinoviev License",
+      "licenseId": "xkeyboard-config-Zinoviev",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/master/COPYING?ref_type\u003dheads#L178"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/xlock.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xlock.json",
+      "referenceNumber": 194,
+      "name": "xlock License",
+      "licenseId": "xlock",
+      "seeAlso": [
+        "https://fossies.org/linux/tiff/contrib/ras/ras2tif.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Xnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Xnet.json",
+      "referenceNumber": 364,
+      "name": "X.Net License",
+      "licenseId": "Xnet",
+      "seeAlso": [
+        "https://opensource.org/licenses/Xnet"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/xpp.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xpp.json",
+      "referenceNumber": 52,
+      "name": "XPP License",
+      "licenseId": "xpp",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/xpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/XSkat.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/XSkat.json",
+      "referenceNumber": 593,
+      "name": "XSkat License",
+      "licenseId": "XSkat",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/xzoom.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xzoom.json",
+      "referenceNumber": 268,
+      "name": "xzoom License",
+      "licenseId": "xzoom",
+      "seeAlso": [
+        "https://metadata.ftp-master.debian.org/changelogs//main/x/xzoom/xzoom_0.3-27_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/YPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
+      "referenceNumber": 189,
+      "name": "Yahoo! Public License v1.0",
+      "licenseId": "YPL-1.0",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/YPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
+      "referenceNumber": 407,
+      "name": "Yahoo! Public License v1.1",
+      "licenseId": "YPL-1.1",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zed.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zed.json",
+      "referenceNumber": 608,
+      "name": "Zed License",
+      "licenseId": "Zed",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Zed"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zeeff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zeeff.json",
+      "referenceNumber": 42,
+      "name": "Zeeff License",
+      "licenseId": "Zeeff",
+      "seeAlso": [
+        "ftp://ftp.tin.org/pub/news/utils/newsx/newsx-1.6.tar.gz"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zend-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
+      "referenceNumber": 536,
+      "name": "Zend License v2.0",
+      "licenseId": "Zend-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
+      "referenceNumber": 456,
+      "name": "Zimbra Public License v1.3",
+      "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
+      "referenceNumber": 483,
+      "name": "Zimbra Public License v1.4",
+      "licenseId": "Zimbra-1.4",
+      "seeAlso": [
+        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zlib.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zlib.json",
+      "referenceNumber": 664,
+      "name": "zlib License",
+      "licenseId": "Zlib",
+      "seeAlso": [
+        "http://www.zlib.net/zlib_license.html",
+        "https://opensource.org/licenses/Zlib"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
+      "referenceNumber": 405,
+      "name": "zlib/libpng License with Acknowledgement",
+      "licenseId": "zlib-acknowledgement",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
+      "referenceNumber": 137,
+      "name": "Zope Public License 1.1",
+      "licenseId": "ZPL-1.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
+      "referenceNumber": 519,
+      "name": "Zope Public License 2.0",
+      "licenseId": "ZPL-2.0",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-2.0",
+        "https://opensource.org/licenses/ZPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
+      "referenceNumber": 603,
+      "name": "Zope Public License 2.1",
+      "licenseId": "ZPL-2.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/ZPL/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    }
+  ],
+  "releaseDate": "2026-02-20T00:00:00Z"
+}

--- a/templates/SPDX.LicenseExceptionId.template.hs
+++ b/templates/SPDX.LicenseExceptionId.template.hs
@@ -29,7 +29,7 @@ import qualified Text.PrettyPrint as Disp
 -- LicenseExceptionId
 -------------------------------------------------------------------------------
 
--- | SPDX License Exceptions identifiers list v3.26
+-- | SPDX License Exceptions identifiers list v3.28
 data LicenseExceptionId
 {{ licenseIds }}
   deriving (Eq, Ord, Enum, Bounded, Show, Read, Data, Generic)
@@ -44,7 +44,7 @@ instance Binary LicenseExceptionId where
 
 -- note: remember to bump version each time the definition changes
 instance Structured LicenseExceptionId where
-    structure p = set typeVersion 307 $ nominalStructure p
+    structure p = set typeVersion 308 $ nominalStructure p
 
 instance Pretty LicenseExceptionId where
     pretty = Disp.text . licenseExceptionId
@@ -107,6 +107,9 @@ licenseExceptionIdList LicenseListVersion_3_25 =
 licenseExceptionIdList LicenseListVersion_3_26 =
 {{licenseList_perv.v_3_26}}
     ++ bulkOfLicenses
+licenseExceptionIdList LicenseListVersion_3_28 =
+{{licenseList_perv.v_3_28}}
+    ++ bulkOfLicenses
 
 -- | Create a 'LicenseExceptionId' from a 'String'.
 mkLicenseExceptionId :: LicenseListVersion -> String -> Maybe LicenseExceptionId
@@ -119,6 +122,7 @@ mkLicenseExceptionId LicenseListVersion_3_16 s = Map.lookup s stringLookup_3_16
 mkLicenseExceptionId LicenseListVersion_3_23 s = Map.lookup s stringLookup_3_23
 mkLicenseExceptionId LicenseListVersion_3_25 s = Map.lookup s stringLookup_3_25
 mkLicenseExceptionId LicenseListVersion_3_26 s = Map.lookup s stringLookup_3_26
+mkLicenseExceptionId LicenseListVersion_3_28 s = Map.lookup s stringLookup_3_28
 
 stringLookup_3_0 :: Map String LicenseExceptionId
 stringLookup_3_0 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
@@ -155,6 +159,10 @@ stringLookup_3_25 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
 stringLookup_3_26 :: Map String LicenseExceptionId
 stringLookup_3_26 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
     licenseExceptionIdList LicenseListVersion_3_26
+
+stringLookup_3_28 :: Map String LicenseExceptionId
+stringLookup_3_28 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
+    licenseExceptionIdList LicenseListVersion_3_28
 
 --  | License exceptions in all SPDX License lists
 bulkOfLicenses :: [LicenseExceptionId]

--- a/templates/SPDX.LicenseId.template.hs
+++ b/templates/SPDX.LicenseId.template.hs
@@ -32,7 +32,7 @@ import qualified Text.PrettyPrint as Disp
 -- LicenseId
 -------------------------------------------------------------------------------
 
--- | SPDX License identifiers list v3.26
+-- | SPDX License identifiers list v3.28
 data LicenseId
 {{ licenseIds }}
   deriving (Eq, Ord, Enum, Bounded, Show, Read, Data)
@@ -49,7 +49,7 @@ instance Binary LicenseId where
 
 -- note: remember to bump version each time the definition changes
 instance Structured LicenseId where
-    structure p = set typeVersion 307 $ nominalStructure p
+    structure p = set typeVersion 308 $ nominalStructure p
 
 instance Pretty LicenseId where
     pretty = Disp.text . licenseId
@@ -184,6 +184,9 @@ licenseIdList LicenseListVersion_3_25 =
 licenseIdList LicenseListVersion_3_26 =
 {{licenseList_perv.v_3_26}}
     ++ bulkOfLicenses
+licenseIdList LicenseListVersion_3_28 =
+{{licenseList_perv.v_3_28}}
+    ++ bulkOfLicenses
 
 -- | Create a 'LicenseId' from a 'String'.
 mkLicenseId :: LicenseListVersion -> String -> Maybe LicenseId
@@ -196,6 +199,7 @@ mkLicenseId LicenseListVersion_3_16 s = Map.lookup s stringLookup_3_16
 mkLicenseId LicenseListVersion_3_23 s = Map.lookup s stringLookup_3_23
 mkLicenseId LicenseListVersion_3_25 s = Map.lookup s stringLookup_3_25
 mkLicenseId LicenseListVersion_3_26 s = Map.lookup s stringLookup_3_26
+mkLicenseId LicenseListVersion_3_28 s = Map.lookup s stringLookup_3_28
 
 stringLookup_3_0 :: Map String LicenseId
 stringLookup_3_0 = Map.fromList $ map (\i -> (licenseId i, i)) $
@@ -232,6 +236,10 @@ stringLookup_3_25 = Map.fromList $ map (\i -> (licenseId i, i)) $
 stringLookup_3_26 :: Map String LicenseId
 stringLookup_3_26 = Map.fromList $ map (\i -> (licenseId i, i)) $
     licenseIdList LicenseListVersion_3_26
+
+stringLookup_3_28 :: Map String LicenseId
+stringLookup_3_28 = Map.fromList $ map (\i -> (licenseId i, i)) $
+    licenseIdList LicenseListVersion_3_28
 
 --  | Licenses in all SPDX License lists
 bulkOfLicenses :: [LicenseId]


### PR DESCRIPTION
This PR also adds adds a file format changelog for `3.16`, which we missed.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  ~~* [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.~~
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
~~* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~ N/A

**QA Notes**

```
cabal init -n test
cd test/
# Modify the `license:` field to `Advanced-Cryptics-Dictionary`
cabal check  # it should *not* complain about the license
```