### PR TITLE
Do not shorten names on macOS

### DIFF
--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -52,7 +52,7 @@ import Distribution.Simple.InstallDirs
   )
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import Distribution.System
-  ( OS (OSX, Windows)
+  ( OS (Windows)
   , Platform
   , buildOS
   )
@@ -79,7 +79,6 @@ import qualified Data.Set as Set
 hashedInstalledPackageId :: PackageHashInputs -> InstalledPackageId
 hashedInstalledPackageId
   | buildOS == Windows = hashedInstalledPackageIdShort
-  | buildOS == OSX = hashedInstalledPackageIdVeryShort
   | otherwise = hashedInstalledPackageIdLong
 
 -- | Calculate a 'InstalledPackageId' for a package using our nix-style
@@ -139,41 +138,6 @@ hashedInstalledPackageIdShort pkghashinputs@PackageHashInputs{pkgHashPkgId} =
     truncateStr n s
       | length s <= n = s
       | otherwise = take (n - 1) s ++ "_"
-
--- | On macOS we shorten the name very aggressively.  The mach-o linker on
--- macOS has a limited load command size, to which the name of the library
--- as well as its relative path (\@rpath) entry count.  To circumvent this,
--- on macOS the libraries are not stored as
---  @store/<libraryname>/libHS<libraryname>.dylib@
--- where libraryname contains the libraries name, version and abi hash, but in
---  @store/lib/libHS<very short libraryname>.dylib@
--- where the very short library name drops all vowels from the package name,
--- and truncates the hash to 4 bytes.
---
--- We therefore we only need one \@rpath entry to @store/lib@ instead of one
--- \@rpath entry for each library. And the reduced library name saves some
--- additional space.
---
--- This however has two major drawbacks:
--- 1) Packages can collide more easily due to the shortened hash.
--- 2) The libraries are *not* prefix relocatable anymore as they all end up
---    in the same @store/lib@ folder.
---
--- The ultimate solution would have to include generating proxy dynamic
--- libraries on macOS, such that the proxy libraries and the linked libraries
--- stay under the load command limit, and the recursive linker is still able
--- to link all of them.
-hashedInstalledPackageIdVeryShort :: PackageHashInputs -> InstalledPackageId
-hashedInstalledPackageIdVeryShort pkghashinputs@PackageHashInputs{pkgHashPkgId} =
-  mkComponentId $
-    intercalate
-      "-"
-      [ filter (not . flip elem "aeiou") (prettyShow name)
-      , prettyShow version
-      , showHashValue (truncateHash 4 (hashPackageHashInputs pkghashinputs))
-      ]
-  where
-    PackageIdentifier name version = pkgHashPkgId
 
 -- | All the information that contributes to a package's hash, and thus its
 -- 'InstalledPackageId'.

--- a/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
@@ -11,11 +11,11 @@ main = cabalTest . withRepo "repo" $ do
     -- Documentation is enabled..
     assertFileDoesContain (exeDir </> "cabal-hash.txt") "documentation: True"
     -- But not built
-    shouldDirectoryNotExist (exeDir </> "share" </> "doc" )
+    shouldDirectoryNotExist (exeDir </> "share" </> "doc")
 
     -- Check properties of library
     libDir <- findDependencyInStore "lib"
     -- Documentation is enabled..
     assertFileDoesContain (libDir </> "cabal-hash.txt") "documentation: True"
     -- and has been built
-    shouldDirectoryExist (  libDir </> "share" </> "doc" )
+    shouldDirectoryExist (libDir </> "share" </> "doc")

--- a/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
@@ -1,21 +1,25 @@
 import Test.Cabal.Prelude
 
 
-main = cabalTest . withRepo "repo" $ do
-    cabal "build" ["--enable-documentation"]
+main = cabalTest $ withRepo "repo" $ do
 
-    env <- getTestEnv
+    -- See also discussion in #11510
+    expectBrokenIfOSXAndGhc "<= 8.10.7" 7209 $ do
 
-    -- Check properties of executable component
-    exeDir <- findDependencyInStore "exe"
-    -- Documentation is enabled..
-    assertFileDoesContain (exeDir </> "cabal-hash.txt") "documentation: True"
-    -- But not built
-    shouldDirectoryNotExist (exeDir </> "share" </> "doc")
+        cabal "build" ["--enable-documentation"]
 
-    -- Check properties of library
-    libDir <- findDependencyInStore "lib"
-    -- Documentation is enabled..
-    assertFileDoesContain (libDir </> "cabal-hash.txt") "documentation: True"
-    -- and has been built
-    shouldDirectoryExist (libDir </> "share" </> "doc")
+        env <- getTestEnv
+
+        -- Check properties of executable component
+        exeDir <- findDependencyInStore "exe"
+        -- Documentation is enabled..
+        assertFileDoesContain (exeDir </> "cabal-hash.txt") "documentation: True"
+        -- But not built
+        shouldDirectoryNotExist (exeDir </> "share" </> "doc")
+
+        -- Check properties of library
+        libDir <- findDependencyInStore "lib"
+        -- Documentation is enabled..
+        assertFileDoesContain (libDir </> "cabal-hash.txt") "documentation: True"
+        -- and has been built
+        shouldDirectoryExist (libDir </> "share" </> "doc")

--- a/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
@@ -7,11 +7,11 @@ main = cabalTest . withRepo "repo" $ do
     env <- getTestEnv
 
     -- Check properties of executable component
-    libDir <- findDependencyInStore "exe"
+    exeDir <- findDependencyInStore "exe"
     -- Documentation is enabled..
-    assertFileDoesContain (libDir </> "cabal-hash.txt") "documentation: True"
+    assertFileDoesContain (exeDir </> "cabal-hash.txt") "documentation: True"
     -- But not built
-    shouldDirectoryNotExist (  libDir </> "share" </> "doc" )
+    shouldDirectoryNotExist (exeDir </> "share" </> "doc" )
 
     -- Check properties of library
     libDir <- findDependencyInStore "lib"

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -1409,15 +1409,8 @@ findDependencyInStore pkgName = do
   liftIO $ do
     storeDirForGhcVersion : _ <- listDirectory storeDir
     packageDirs <- listDirectory (storeDir </> storeDirForGhcVersion)
-    -- Ideally, we should call 'hashedInstalledPackageId' from 'Distribution.Client.PackageHash'.
-    -- But 'PackageHashInputs', especially 'PackageHashConfigInputs', is too hard to construct.
-    let pkgName' =
-          if buildOS == OSX
-            then filter (not . flip elem "aeiou") pkgName
-            else -- simulates the way 'hashedInstalledPackageId' uses to compress package name
-              pkgName
-    let libDir = case filter (pkgName' `isPrefixOf`) packageDirs of
-          [] -> error $ "Could not find " <> pkgName' <> " when searching for " <> pkgName' <> " in\n" <> show packageDirs
+    let libDir = case filter (pkgName `isPrefixOf`) packageDirs of
+          [] -> error $ "Could not find " <> pkgName <> " when searching for " <> pkgName <> " in\n" <> show packageDirs
           (dir : _) -> dir
     pure (storeDir </> storeDirForGhcVersion </> libDir)
 

--- a/changelog.d/pr-11979
+++ b/changelog.d/pr-11979
@@ -1,0 +1,8 @@
+---
+synopsis: Do not shorten names on macOS
+packages: [cabal-install]
+prs: 11979
+---
+
+Stop shortening names by removing vowels on macOS.  `cabal-install` user
+will not be impacted by this, but directory names in the store will change.


### PR DESCRIPTION
Closes #7209 #11510
Sadly name shortening is still turned on on Windows, I do not know whether we can that too.

I would _not_ backport this, let nightly users see if they are happy with it.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  ~~* [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.~~ no
* [x] The documentation has been updated, if necessary.
~~* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.~~ n/a
~~* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~ no need for tests, only changes store dir names