### PR TITLE
Add suggested fix for unbuildable ghc-bignum

### DIFF
--- a/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
@@ -26,6 +26,7 @@ import Distribution.Simple.Flag (Flag)
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Types.AnnotatedId
 import Distribution.Types.ComponentInclude
+import Distribution.Types.Version
 import Distribution.Utils.Generic
 import Distribution.Utils.LogProgress
 import Distribution.Utils.MapAccum
@@ -180,9 +181,17 @@ toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
       then fmap concat $
         forM (targetBuildDepends bi) $
           \(Dependency name _ sublibs) -> do
+            let moreCtx =
+                  if unPackageName name == "ghc-bignum"
+                    && unPackageName (packageName $ package pkg_descr) == "base"
+                    && pkgVersion (package pkg_descr) < mkVersion [4, 22, 0, 0]
+                    then
+                      addProgressCtx (text "Suggestion: Bump upper bounds on base to allow a reinstallable version")
+                        <$> addProgressCtx (text "Note: This version of base is not reinstallable")
+                    else addProgressCtx PP.empty
             case Map.lookup name lib_dep_map of
               Nothing ->
-                dieProgress $
+                moreCtx <$> dieProgress $
                   text "Dependency on unbuildable"
                     <+> text "package"
                     <+> pretty name
@@ -192,7 +201,7 @@ toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
                   let comp = CLibName lib
                    in case Map.lookup comp pkg of
                         Nothing ->
-                          dieProgress $
+                          moreCtx <$> dieProgress $
                             text "Dependency on unbuildable"
                               <+> text (showLibraryName lib)
                               <+> text "from"

--- a/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
@@ -186,8 +186,8 @@ toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
                     && unPackageName (packageName $ package pkg_descr) == "base"
                     && pkgVersion (package pkg_descr) < mkVersion [4, 22, 0, 0]
                     then
-                      addProgressCtx (text "Suggestion: Bump upper bounds on base to allow a reinstallable version")
-                        <$> addProgressCtx (text "Note: This version of base is not reinstallable")
+                      transformProgressCtx (++ [text "Note: This version of base is not reinstallable"])
+                        <$> transformProgressCtx (++ [text "Suggestion: Bump upper bounds on base to allow a reinstallable version"])
                     else addProgressCtx PP.empty
             case Map.lookup name lib_dep_map of
               Nothing ->

--- a/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ConfiguredComponent.hs
@@ -188,7 +188,7 @@ toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
                     then
                       transformProgressCtx (++ [text "Note: This version of base is not reinstallable"])
                         <$> transformProgressCtx (++ [text "Suggestion: Bump upper bounds on base to allow a reinstallable version"])
-                    else addProgressCtx PP.empty
+                    else id
             case Map.lookup name lib_dep_map of
               Nothing ->
                 moreCtx <$> dieProgress $

--- a/Cabal/src/Distribution/Utils/LogProgress.hs
+++ b/Cabal/src/Distribution/Utils/LogProgress.hs
@@ -8,6 +8,7 @@ module Distribution.Utils.LogProgress
   , infoProgress
   , dieProgress
   , addProgressCtx
+  , transformProgressCtx
   ) where
 
 import Distribution.Compat.Prelude
@@ -103,5 +104,9 @@ formatMsg ctx doc = doc $$ vcat ctx
 
 -- | Add a message to the error/warning context.
 addProgressCtx :: CtxMsg -> LogProgress a -> LogProgress a
-addProgressCtx s (LogProgress m) = LogProgress $ \env ->
-  m env{le_context = s : le_context env}
+addProgressCtx s = transformProgressCtx (s :)
+
+-- | Transform the messages in the error/warning context.
+transformProgressCtx :: ([CtxMsg] -> [CtxMsg]) -> LogProgress a -> LogProgress a
+transformProgressCtx f (LogProgress m) = LogProgress $ \env ->
+  m env{le_context = f $ le_context env}


### PR DESCRIPTION
Fix #11356.

This adds a note and suggestion when `base` has a dependency on an unbuildable `ghc-bignum`. Aside from `transformProgressCtx`, changes are local to where the message is generated. Within `toConfiguredComponent` we don't know the version of GHC.

## Manual QA Notes

Here's the changed behaviour, from the reproduction of https://github.com/haskell/cabal/issues/11356#issuecomment-4736705200 with `cabal-fmt`:

```diff
$ cabal freeze
Error:
    Dependency on unbuildable library from ghc-bignum
    In the stanza 'library'
    In the package 'base-4.19.2.0'
+   Note: This version of base is not reinstallable
+   Suggestion: Bump upper bounds on base to allow a reinstallable version
 ```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

