### PR TITLE
Monoid of no Mappend

### DIFF
--- a/Cabal-described/src/Distribution/Utils/CharSet.hs
+++ b/Cabal-described/src/Distribution/Utils/CharSet.hs
@@ -61,7 +61,6 @@ instance Semigroup CharSet where
 
 instance Monoid CharSet where
     mempty = empty
-    mappend = (<>)
 
 -- | Empty character set.
 empty :: CharSet

--- a/Cabal-described/src/Distribution/Utils/GrammarRegex.hs
+++ b/Cabal-described/src/Distribution/Utils/GrammarRegex.hs
@@ -77,7 +77,6 @@ instance Semigroup (GrammarRegex a) where
 
 instance Monoid (GrammarRegex a) where
     mempty = REAppend []
-    mappend = (<>)
 
 -------------------------------------------------------------------------------
 -- Smart constructors

--- a/Cabal-syntax/src/Distribution/Compat/DList.hs
+++ b/Cabal-syntax/src/Distribution/Compat/DList.hs
@@ -48,7 +48,6 @@ snoc xs x = xs <> singleton x
 
 instance Monoid (DList a) where
   mempty = empty
-  mappend = (<>)
 
 instance Semigroup (DList a) where
   DList a <> DList b = DList (a . b)

--- a/Cabal-syntax/src/Distribution/Compiler.hs
+++ b/Cabal-syntax/src/Distribution/Compiler.hs
@@ -164,7 +164,6 @@ instance Semigroup a => Semigroup (PerCompilerFlavor a) where
 
 instance Monoid a => Monoid (PerCompilerFlavor a) where
   mempty = PerCompilerFlavor mempty mempty
-  mappend = (<>)
 
 -- ------------------------------------------------------------
 

--- a/Cabal-syntax/src/Distribution/FieldGrammar/Class.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Class.hs
@@ -121,7 +121,7 @@ class
 
   -- | Monoidal field.
   --
-  -- Values are combined with 'mappend'.
+  -- Values are combined with '(<>)'.
   --
   -- /Note:/ 'optionalFieldAla' is a @monoidalField@ with 'Last' monoid.
   monoidalFieldAla
@@ -221,7 +221,7 @@ optionalFieldDef
   -> g s a
 optionalFieldDef fn l x = optionalFieldDefAla fn Identity l x
 
--- | Field which can be define multiple times, and the results are @mappend@ed.
+-- | Field which can be define multiple times, and the results are combined with '(<>)'.
 monoidalField
   :: (FieldGrammar c g, c (Identity a), Monoid a)
   => FieldName

--- a/Cabal-syntax/src/Distribution/FieldGrammar/FieldDescrs.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/FieldDescrs.hs
@@ -38,7 +38,7 @@ newtype FieldDescrs s a = F {runF :: Map P.FieldName (SP s)}
 
 instance Applicative (FieldDescrs s) where
   pure _ = F mempty
-  f <*> x = F (mappend (runF f) (runF x))
+  f <*> x = F (runF f <> runF x)
 
 singletonF :: P.FieldName -> (s -> Disp.Doc) -> (forall m. P.CabalParsing m => s -> m s) -> FieldDescrs s a
 singletonF fn f g = F $ Map.singleton fn (SP f g)
@@ -102,7 +102,7 @@ instance FieldGrammar ParsecPretty FieldDescrs where
   monoidalFieldAla fn _pack l = singletonF fn f g
     where
       f s = pretty (pack' _pack (aview l s))
-      g s = cloneLens l (\x -> mappend x . unpack' _pack <$> P.parsec) s
+      g s = cloneLens l (\x -> (x <>) . unpack' _pack <$> P.parsec) s
 
   prefixedFields _fnPfx _l = F mempty
   knownField _ = pure ()

--- a/Cabal-syntax/src/Distribution/FieldGrammar/Parsec.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Parsec.hs
@@ -154,8 +154,8 @@ instance Applicative (ParsecFieldGrammar s) where
 
   ParsecFG f f' f'' <*> ParsecFG x x' x'' =
     ParsecFG
-      (mappend f x)
-      (mappend f' x')
+      (f <> x)
+      (f' <> x')
       (\v fields -> f'' v fields <*> x'' v fields)
   {-# INLINE (<*>) #-}
 

--- a/Cabal-syntax/src/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/Configuration.hs
@@ -155,7 +155,6 @@ data DepTestRslt
 
 instance Monoid DepTestRslt where
   mempty = DepOk
-  mappend = (<>)
 
 instance Semigroup DepTestRslt where
   DepOk <> x = x
@@ -402,7 +401,6 @@ data PDTagged
 
 instance Monoid PDTagged where
   mempty = PDNull
-  mappend = (<>)
 
 instance Semigroup PDTagged where
   PDNull <> x = x

--- a/Cabal-syntax/src/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/Parsec.hs
@@ -717,10 +717,10 @@ onAllBranches p = go mempty
     -- done. If not, then one of the conditional branches below the current node
     -- must satisfy it. Each node may have multiple immediate children; we only
     -- one need one to satisfy the property because the configure step uses
-    -- 'mappend' to join together the results of flag resolution.
+    -- '(<>)' to join together the results of flag resolution.
     go :: a -> CondTree v a -> Bool
     go acc ct =
-      let acc' = acc `mappend` condTreeData ct
+      let acc' = acc <> condTreeData ct
        in p acc' || any (goBranch acc') (condTreeComponents ct)
 
     -- Both the 'true' and the 'false' block must satisfy the property.

--- a/Cabal-syntax/src/Distribution/Types/Benchmark.hs
+++ b/Cabal-syntax/src/Distribution/Types/Benchmark.hs
@@ -43,7 +43,6 @@ instance Monoid Benchmark where
       , benchmarkInterface = mempty
       , benchmarkBuildInfo = mempty
       }
-  mappend = (<>)
 
 instance Semigroup Benchmark where
   a <> b =
@@ -53,7 +52,7 @@ instance Semigroup Benchmark where
       , benchmarkBuildInfo = combine benchmarkBuildInfo
       }
     where
-      combine field = field a `mappend` field b
+      combine field = field a <> field b
 
 emptyBenchmark :: Benchmark
 emptyBenchmark = mempty

--- a/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
@@ -35,7 +35,6 @@ instance NFData BenchmarkInterface
 
 instance Monoid BenchmarkInterface where
   mempty = BenchmarkUnsupported (BenchmarkTypeUnknown mempty nullVersion)
-  mappend = (<>)
 
 instance Semigroup BenchmarkInterface where
   a <> (BenchmarkUnsupported _) = a

--- a/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
@@ -205,7 +205,6 @@ instance Monoid BuildInfo where
       , targetBuildDepends = []
       , mixins = []
       }
-  mappend = (<>)
 
 instance Semigroup BuildInfo where
   a <> b =
@@ -260,7 +259,7 @@ instance Semigroup BuildInfo where
       , mixins = combine mixins
       }
     where
-      combine field = field a `mappend` field b
+      combine field = field a <> field b
       combineNub field = ordNub (combine field)
       combineMby field = field b `mplus` field a
 

--- a/Cabal-syntax/src/Distribution/Types/CondTree.hs
+++ b/Cabal-syntax/src/Distribution/Types/CondTree.hs
@@ -67,7 +67,6 @@ instance Semigroup a => Semigroup (CondTree v a) where
   (CondNode a bs) <> (CondNode a' bs') = CondNode (a <> a') (bs <> bs')
 
 instance Monoid a => Monoid (CondTree v a) where
-  mappend = (<>)
   mempty = CondNode mempty mempty
 
 -- | A 'CondBranch' represents a conditional branch, e.g., @if

--- a/Cabal-syntax/src/Distribution/Types/Condition.hs
+++ b/Cabal-syntax/src/Distribution/Types/Condition.hs
@@ -58,8 +58,8 @@ instance Foldable Condition where
   f `foldMap` Var c = f c
   _ `foldMap` Lit _ = mempty
   f `foldMap` CNot c = foldMap f c
-  f `foldMap` COr c d = foldMap f c `mappend` foldMap f d
-  f `foldMap` CAnd c d = foldMap f c `mappend` foldMap f d
+  f `foldMap` COr c d = foldMap f c <> foldMap f d
+  f `foldMap` CAnd c d = foldMap f c <> foldMap f d
 
 instance Traversable Condition where
   f `traverse` Var c = Var `fmap` f c
@@ -85,18 +85,17 @@ instance Monad Condition where
 
 instance Monoid (Condition a) where
   mempty = Lit False
-  mappend = (<>)
 
 instance Semigroup (Condition a) where
   (<>) = COr
 
 instance Alternative Condition where
   empty = mempty
-  (<|>) = mappend
+  (<|>) = (<>)
 
 instance MonadPlus Condition where
   mzero = mempty
-  mplus = mappend
+  mplus = (<>)
 
 instance Binary c => Binary (Condition c)
 instance Structured c => Structured (Condition c)

--- a/Cabal-syntax/src/Distribution/Types/DependencyMap.hs
+++ b/Cabal-syntax/src/Distribution/Types/DependencyMap.hs
@@ -23,7 +23,6 @@ newtype DependencyMap = DependencyMap {unDependencyMap :: Map PackageName (Versi
 
 instance Monoid DependencyMap where
   mempty = DependencyMap Map.empty
-  mappend = (<>)
 
 instance Semigroup DependencyMap where
   (DependencyMap a) <> (DependencyMap b) =

--- a/Cabal-syntax/src/Distribution/Types/Executable.hs
+++ b/Cabal-syntax/src/Distribution/Types/Executable.hs
@@ -43,7 +43,6 @@ instance Monoid Executable where
       , exeScope = mempty
       , buildInfo = mempty
       }
-  mappend = (<>)
 
 instance Semigroup Executable where
   a <> b =
@@ -54,7 +53,7 @@ instance Semigroup Executable where
       , buildInfo = combine buildInfo
       }
     where
-      combine field = field a `mappend` field b
+      combine field = field a <> field b
 
 emptyExecutable :: Executable
 emptyExecutable = mempty

--- a/Cabal-syntax/src/Distribution/Types/ExecutableScope.hs
+++ b/Cabal-syntax/src/Distribution/Types/ExecutableScope.hs
@@ -42,4 +42,3 @@ instance Semigroup ExecutableScope where
 -- | 'mempty' = 'ExecutablePublic'
 instance Monoid ExecutableScope where
   mempty = ExecutablePublic
-  mappend = (<>)

--- a/Cabal-syntax/src/Distribution/Types/Flag.hs
+++ b/Cabal-syntax/src/Distribution/Types/Flag.hs
@@ -159,7 +159,6 @@ instance Semigroup FlagAssignment where
 
 instance Monoid FlagAssignment where
   mempty = FlagAssignment Map.empty
-  mappend = (<>)
 
 -- | Construct a 'FlagAssignment' from a list of flag/value pairs.
 --

--- a/Cabal-syntax/src/Distribution/Types/ForeignLib.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLib.hs
@@ -152,7 +152,7 @@ instance Semigroup ForeignLib where
       , foreignLibModDefFile = combine foreignLibModDefFile
       }
     where
-      combine field = field a `mappend` field b
+      combine field = field a <> field b
       -- chooseLast: the second field overrides the first, unless it is Nothing
       chooseLast field = getLast (Last (field a) <> Last (field b))
 
@@ -167,7 +167,6 @@ instance Monoid ForeignLib where
       , foreignLibVersionLinux = Nothing
       , foreignLibModDefFile = []
       }
-  mappend = (<>)
 
 -- | An empty foreign library.
 emptyForeignLib :: ForeignLib

--- a/Cabal-syntax/src/Distribution/Types/ForeignLibType.hs
+++ b/Cabal-syntax/src/Distribution/Types/ForeignLibType.hs
@@ -53,7 +53,6 @@ instance Semigroup ForeignLibType where
 
 instance Monoid ForeignLibType where
   mempty = ForeignLibTypeUnknown
-  mappend = (<>)
 
 knownForeignLibTypes :: [ForeignLibType]
 knownForeignLibTypes =

--- a/Cabal-syntax/src/Distribution/Types/Library.hs
+++ b/Cabal-syntax/src/Distribution/Types/Library.hs
@@ -61,7 +61,6 @@ emptyLibrary =
 -- libraries when `buildable: false`. This may cause problems.
 instance Monoid Library where
   mempty = emptyLibrary
-  mappend = (<>)
 
 instance Semigroup Library where
   a <> b =
@@ -75,7 +74,7 @@ instance Semigroup Library where
       , libBuildInfo = combine libBuildInfo
       }
     where
-      combine field = field a `mappend` field b
+      combine field = field a <> field b
 
 -- | Get all the module names from the library (exposed and internal modules)
 -- which are explicitly listed in the package description which would

--- a/Cabal-syntax/src/Distribution/Types/LibraryVisibility.hs
+++ b/Cabal-syntax/src/Distribution/Types/LibraryVisibility.hs
@@ -47,4 +47,3 @@ instance Semigroup LibraryVisibility where
 
 instance Monoid LibraryVisibility where
   mempty = LibraryVisibilityPrivate
-  mappend = (<>)

--- a/Cabal-syntax/src/Distribution/Types/PackageDescription.hs
+++ b/Cabal-syntax/src/Distribution/Types/PackageDescription.hs
@@ -380,7 +380,7 @@ updatePackageDescription (mb_lib_bi, exe_bi) p =
     }
   where
     updateLibrary :: Maybe BuildInfo -> Maybe Library -> Maybe Library
-    updateLibrary (Just bi) (Just lib) = Just (lib{libBuildInfo = bi `mappend` libBuildInfo lib})
+    updateLibrary (Just bi) (Just lib) = Just (lib{libBuildInfo = bi <> libBuildInfo lib})
     updateLibrary Nothing mb_lib = mb_lib
     updateLibrary (Just _) Nothing = Nothing
 
@@ -402,7 +402,7 @@ updatePackageDescription (mb_lib_bi, exe_bi) p =
     -- \^list with exeName updated
     updateExecutable _ [] = []
     updateExecutable exe_bi'@(name, bi) (exe : exes)
-      | exeName exe == name = exe{buildInfo = bi `mappend` buildInfo exe} : exes
+      | exeName exe == name = exe{buildInfo = bi <> buildInfo exe} : exes
       | otherwise = exe : updateExecutable exe_bi' exes
 
 -- -----------------------------------------------------------------------------

--- a/Cabal-syntax/src/Distribution/Types/SetupBuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/SetupBuildInfo.hs
@@ -33,7 +33,6 @@ instance NFData SetupBuildInfo
 
 instance Monoid SetupBuildInfo where
   mempty = SetupBuildInfo [] False
-  mappend = (<>)
 
 instance Semigroup SetupBuildInfo where
   a <> b =

--- a/Cabal-syntax/src/Distribution/Types/TestSuite.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestSuite.hs
@@ -46,7 +46,6 @@ instance Monoid TestSuite where
       , testBuildInfo = mempty
       , testCodeGenerators = mempty
       }
-  mappend = (<>)
 
 instance Semigroup TestSuite where
   a <> b =
@@ -57,7 +56,7 @@ instance Semigroup TestSuite where
       , testCodeGenerators = combine testCodeGenerators
       }
     where
-      combine field = field a `mappend` field b
+      combine field = field a <> field b
 
 emptyTestSuite :: TestSuite
 emptyTestSuite = mempty

--- a/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
@@ -39,7 +39,6 @@ instance NFData TestSuiteInterface
 
 instance Monoid TestSuiteInterface where
   mempty = TestSuiteUnsupported (TestTypeUnknown mempty nullVersion)
-  mappend = (<>)
 
 instance Semigroup TestSuiteInterface where
   a <> (TestSuiteUnsupported _) = a

--- a/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
@@ -123,7 +123,7 @@ stage2 = sortBy lowerboundCmp
 
 lowerboundCmp :: VersionInterval -> VersionInterval -> Ordering
 lowerboundCmp (VersionInterval (LowerBound v vb) _) (VersionInterval (LowerBound u ub) _) =
-  compare v u `mappend` compareBound vb ub
+  compare v u <> compareBound vb ub
   where
     compareBound :: Bound -> Bound -> Ordering
     compareBound InclusiveBound InclusiveBound = EQ

--- a/Cabal-tests/tests/HackageTests.hs
+++ b/Cabal-tests/tests/HackageTests.hs
@@ -196,7 +196,6 @@ instance Semigroup ParsecResult where
 
 instance Monoid ParsecResult where
     mempty  = ParsecResult 0 0 0
-    mappend = (<>)
 
 instance NFData ParsecResult where
     rnf ParsecResult{} = ()
@@ -243,7 +242,6 @@ instance Semigroup CheckResult where
 
 instance Monoid CheckResult where
     mempty = CheckResult 0 0 0 0 0 0 0 0
-    mappend = (<>)
 
 toCheckResult :: PackageCheck -> CheckResult
 toCheckResult PackageBuildImpossible {}    = CheckResult 0 0 1 1 0 0 0 0
@@ -472,4 +470,4 @@ fieldLinesToString fieldLines =
 foldIO :: forall a m. (Monoid m) => (a -> IO m) -> [a] -> IO m
 foldIO f = go mempty where
     go !acc [] = acc
-    go !acc (x:xs) = go (mappend acc (f x)) xs
+    go !acc (x:xs) = go (acc <> f x) xs

--- a/Cabal-tests/tests/Test/Laws.hs
+++ b/Cabal-tests/tests/Test/Laws.hs
@@ -35,39 +35,38 @@ fmap_2 :: (Eq (f c), Functor f) => (b -> c) -> (a -> b) -> f a -> Bool
 fmap_2 f g x = fmap (f . g) x == (fmap f . fmap g) x
 
 
--- | The monoid identity law, 'mempty' is a left and right identity of
--- 'mappend':
+-- | The monoid identity law, 'mempty' is a left and right identity of '(<>)':
 --
--- > mempty `mappend` x = x
--- > x `mappend` mempty = x
+-- > mempty <> x = x
+-- > x <> mempty = x
 --
 monoid_1 :: (Eq a, Data.Monoid.Monoid a) => a -> Bool
-monoid_1 x = mempty `mappend` x == x
-          && x `mappend` mempty == x
+monoid_1 x = mempty <> x == x
+          && x <> mempty == x
 
--- | The monoid associativity law, 'mappend' must be associative.
+-- | The monoid associativity law, '(<>)' must be associative.
 --
--- > (x `mappend` y) `mappend` z = x `mappend` (y `mappend` z)
+-- > (x <> y) <> z = x <> (y <> z)
 --
 monoid_2 :: (Eq a, Data.Monoid.Monoid a) => a -> a -> a -> Bool
-monoid_2 x y z = (x `mappend`  y) `mappend` z
-              ==  x `mappend` (y  `mappend` z)
+monoid_2 x y z = (x <>  y) <> z
+              ==  x <> (y  <> z)
 
 -- | The 'mconcat' definition. It can be overridden for the sake of efficiency
 -- but it must still satisfy the property given by the default definition:
 --
--- > mconcat = foldr mappend mempty
+-- > mconcat = foldr (<>) mempty
 --
 monoid_3 :: (Eq a, Data.Monoid.Monoid a) => [a] -> Bool
-monoid_3 xs = mconcat xs == foldr mappend mempty xs
+monoid_3 xs = mconcat xs == foldr (<>) mempty xs
 
 
 -- | First 'Foldable' law
 --
--- > Foldable.fold = Foldable.foldr mappend mempty
+-- > Foldable.fold = Foldable.foldr (<>) mempty
 --
 foldable_1 :: (Foldable.Foldable t, Monoid m, Eq m) => t m -> Bool
-foldable_1 x = Foldable.fold x == Foldable.foldr mappend mempty x
+foldable_1 x = Foldable.fold x == Foldable.foldr (<>) mempty x
 
 -- | Second 'Foldable' law
 --

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/NubList.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/NubList.hs
@@ -69,9 +69,9 @@ prop_Nub xs = rhs === lhs
 
 prop_Identity :: [Int] -> Bool
 prop_Identity xs =
-    mempty `mappend` toNubList xs == toNubList xs `mappend` mempty
+    mempty <> toNubList xs == toNubList xs <> mempty
 
 prop_Associativity :: [Int] -> [Int] -> [Int] -> Bool
 prop_Associativity xs ys zs =
-    (toNubList xs `mappend` toNubList ys) `mappend` toNubList zs
-            == toNubList xs `mappend` (toNubList ys `mappend` toNubList zs)
+    (toNubList xs <> toNubList ys) <> toNubList zs
+            == toNubList xs <> (toNubList ys <> toNubList zs)

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/ShortText.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/ShortText.hs
@@ -2,7 +2,6 @@ module UnitTests.Distribution.Utils.ShortText
     ( tests
     ) where
 
-import Data.Monoid as Mon
 import Test.Tasty
 import Test.Tasty.QuickCheck
 
@@ -14,7 +13,7 @@ prop_ShortTextOrd :: String -> String -> Bool
 prop_ShortTextOrd a b = compare a b == compare (toShortText a) (toShortText b)
 
 prop_ShortTextMonoid :: String -> String -> Bool
-prop_ShortTextMonoid a b = Mon.mappend a b == fromShortText (mappend (toShortText a) (toShortText b))
+prop_ShortTextMonoid a b = a <> b == fromShortText (toShortText a <> toShortText b)
 
 prop_ShortTextId :: String -> Bool
 prop_ShortTextId a = (fromShortText . toShortText) a == a

--- a/Cabal/src/Distribution/Lex.hs
+++ b/Cabal/src/Distribution/Lex.hs
@@ -47,4 +47,4 @@ tokenizeQuotedWords = filter (not . null) . go False mempty
     go True accum (c : cs)
       | c == '"' = go False accum cs
     go quoted accum (c : cs) =
-      go quoted (accum `mappend` singleton c) cs
+      go quoted (accum <> singleton c) cs

--- a/Cabal/src/Distribution/Simple/CCompiler.hs
+++ b/Cabal/src/Distribution/Simple/CCompiler.hs
@@ -53,8 +53,8 @@ import System.FilePath
   ( takeExtension
   )
 
--- | Represents a dialect of C.  The Monoid instance expresses backward
---   compatibility, in the sense that 'mappend a b' is the least inclusive
+-- | Represents a dialect of C.  The Semigroup instance expresses backward
+--   compatibility, in the sense that 'a <> b' is the least inclusive
 --   dialect which both 'a' and 'b' can be correctly interpreted as.
 data CDialect
   = C
@@ -65,7 +65,6 @@ data CDialect
 
 instance Monoid CDialect where
   mempty = C
-  mappend = (<>)
 
 instance Semigroup CDialect where
   C <> anything = anything

--- a/Cabal/src/Distribution/Simple/Command.hs
+++ b/Cabal/src/Distribution/Simple/Command.hs
@@ -240,7 +240,7 @@ reqArg ad mkflag showflag sf lf d get set =
     d
     (sf, lf)
     ad
-    (fmap (\a b -> set (get b `mappend` a) b) mkflag)
+    (fmap (\a b -> set (get b <> a) b) mkflag)
     (showflag . get)
 
 -- | Create a string-valued command line interface with a default value.
@@ -256,8 +256,8 @@ optArg ad mkflag (dv, mkDef) showflag sf lf d get set =
     d
     (sf, lf)
     ad
-    (fmap (\a b -> set (get b `mappend` a) b) mkflag)
-    (dv, \b -> set (get b `mappend` mkDef) b)
+    (fmap (\a b -> set (get b <> a) b) mkflag)
+    (dv, \b -> set (get b <> mkDef) b)
     (showflag . get)
 
 -- | (String -> a) variant of "reqArg"

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -439,7 +439,7 @@ findDistPref
   -> IO (SymbolicPath Pkg (Dir Dist))
 findDistPref defDistPref overrideDistPref = do
   envDistPref <- parseEnvDistPref <$> lookupEnv "CABAL_BUILDDIR"
-  return $ fromFlagOrDefault defDistPref (mappend envDistPref overrideDistPref)
+  return $ fromFlagOrDefault defDistPref (envDistPref <> overrideDistPref)
   where
     parseEnvDistPref env =
       case env of
@@ -1320,31 +1320,31 @@ addExtraIncludeLibDirsFromConfigFlags pkg_descr cfg =
         l
           { libBuildInfo =
               libBuildInfo l
-                `mappend` extraBi
+                <> extraBi
           }
       modifyExecutable e =
         e
           { buildInfo =
               buildInfo e
-                `mappend` extraBi
+                <> extraBi
           }
       modifyForeignLib f =
         f
           { foreignLibBuildInfo =
               foreignLibBuildInfo f
-                `mappend` extraBi
+                <> extraBi
           }
       modifyTestsuite t =
         t
           { testBuildInfo =
               testBuildInfo t
-                `mappend` extraBi
+                <> extraBi
           }
       modifyBenchmark b =
         b
           { benchmarkBuildInfo =
               benchmarkBuildInfo b
-                `mappend` extraBi
+                <> extraBi
           }
    in pkg_descr
         { library = modifyLib `fmap` library pkg_descr
@@ -1931,7 +1931,7 @@ configureCoverage verbosity cfg comp = do
       tryLibCoverage =
         fromFlagOrDefault
           tryExeCoverage
-          (mappend (configCoverage cfg) (configLibCoverage cfg))
+          (configCoverage cfg <> configLibCoverage cfg)
   -- TODO: Should we also enforce something here on that --coverage-for cannot
   -- include indefinite components or instantiations?
   if coverageSupported comp
@@ -1980,7 +1980,7 @@ computeEffectiveProfiling cfg =
       tryExeProfiling =
         fromFlagOrDefault
           False
-          (mappend (configProf cfg) (configProfExe cfg))
+          (configProf cfg <> configProfExe cfg)
       tryLibProfiling =
         fromFlagOrDefault
           (tryExeProfiling && not dynamicExe)
@@ -2008,10 +2008,7 @@ configureProfiling verbosity cfg comp = do
       tryLibProfileLevel =
         fromFlagOrDefault
           ProfDetailDefault
-          ( mappend
-              (configProfDetail cfg)
-              (configProfLibDetail cfg)
-          )
+          (configProfDetail cfg <> configProfLibDetail cfg)
 
       checkProfileLevel (ProfDetailOther other) = do
         warn
@@ -2609,7 +2606,7 @@ configurePkgconfigPackages verbosity pkg_descr progdb enabled
     -- Adds pkgconfig dependencies to the build info for a component
     addPkgConfigBI compBI setCompBI comp = do
       bi <- pkgconfigBuildInfo (pkgconfigDepends (compBI comp))
-      return $ setCompBI comp (compBI comp `mappend` bi)
+      return $ setCompBI comp (compBI comp <> bi)
 
     -- Adds pkgconfig dependencies to the build info for a library
     addPkgConfigBILib = addPkgConfigBI libBuildInfo $

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -791,13 +791,13 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
     mbWorkDir = mbWorkDirLBI lbi
     vanillaArgs =
       Internal.componentGhcOptions (verbosityLevel verbosity) lbi libBi clbi (componentBuildDir lbi clbi)
-        `mappend` mempty
+        <> mempty
           { ghcOptMode = toFlag GhcModeAbiHash
           , ghcOptInputModules = toNubListR $ exposedModules lib
           }
     sharedArgs =
       vanillaArgs
-        `mappend` mempty
+        <> mempty
           { ghcOptDynLinkMode = toFlag GhcDynamicOnly
           , ghcOptFPic = toFlag True
           , ghcOptHiSuffix = toFlag "dyn_hi"
@@ -806,7 +806,7 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
           }
     profArgs =
       vanillaArgs
-        `mappend` mempty
+        <> mempty
           { ghcOptProfilingMode = toFlag True
           , ghcOptProfilingAuto =
               Internal.profDetailLevelFlag
@@ -818,7 +818,7 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
           }
     profDynArgs =
       vanillaArgs
-        `mappend` mempty
+        <> mempty
           { ghcOptProfilingMode = toFlag True
           , ghcOptProfilingAuto =
               Internal.profDetailLevelFlag

--- a/Cabal/src/Distribution/Simple/GHC/Build/ExtraSources.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/ExtraSources.hs
@@ -211,18 +211,18 @@ buildExtraSources
                 baseSrcOpts{ghcOptFPic = toFlag True}
               profSrcOpts =
                 vanillaSrcOpts
-                  `mappend` mempty
+                  <> mempty
                     { ghcOptProfilingMode = toFlag True
                     }
               sharedSrcOpts =
                 vanillaSrcOpts
-                  `mappend` mempty
+                  <> mempty
                     { ghcOptFPic = toFlag True
                     , ghcOptDynLinkMode = toFlag GhcDynamicOnly
                     }
               profSharedSrcOpts =
                 vanillaSrcOpts
-                  `mappend` mempty
+                  <> mempty
                     { ghcOptProfilingMode = toFlag True
                     , ghcOptFPic = toFlag True
                     , ghcOptDynLinkMode = toFlag GhcDynamicOnly

--- a/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
@@ -173,8 +173,8 @@ linkOrLoadComponent
               -- TODO: The repl doesn't use the runtime paths from linkerOpts
               -- (ghcOptRPaths), which looks like a bug. After the refactor we
               -- can fix this.
-              `mappend` linkerOpts mempty
-              `mappend` mempty
+              <> linkerOpts mempty
+              <> mempty
                 { ghcOptMode = toFlag GhcModeInteractive
                 , ghcOptOptimisation = toFlag GhcNoOptimisation
                 }
@@ -463,8 +463,8 @@ linkExecutable linkerOpts (way, buildOpts) targetDir targetName runGhcProg lbi =
   let baseOpts = buildOpts way
       linkOpts =
         baseOpts
-          `mappend` linkerOpts
-          `mappend` mempty
+          <> linkerOpts
+          <> mempty
             { -- If there are no input Haskell files we pass -no-hs-main, and
               -- assume there is a main function in another non-haskell object
               ghcOptLinkNoHsMain = toFlag (ghcOptInputFiles baseOpts == mempty && ghcOptInputScripts baseOpts == mempty)
@@ -528,9 +528,9 @@ linkFLib flib bi lbi linkerOpts (way, buildOpts) targetDir runGhcProg = do
     linkOpts = case foreignLibType flib of
       ForeignLibNativeShared ->
         buildOpts way
-          `mappend` linkerOpts
-          `mappend` rtsLinkOpts
-          `mappend` mempty
+          <> linkerOpts
+          <> rtsLinkOpts
+          <> mempty
             { ghcOptLinkNoHsMain = toFlag True
             , ghcOptShared = toFlag True
             , ghcOptFPic = toFlag True

--- a/Cabal/src/Distribution/Simple/GHC/Build/Modules.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Modules.hs
@@ -174,7 +174,7 @@ buildHaskellModules numJobs ghcProg mbMainFile inputModules buildTargetDir neede
     -- 'buildHaskellModules'
     baseOpts way =
       Internal.componentGhcOptions (verbosityLevel verbosity) lbi bi clbi buildTargetDir
-        `mappend` mempty
+        <> mempty
           { ghcOptMode = toFlag GhcModeMake
           , -- Previously we didn't pass -no-link when building libs,
             -- but I think that could result in a bug (e.g. if a lib module is

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -590,17 +590,17 @@ buildOrReplLib mReplFlags verbosity numJobs _pkg_descr lbi lib clbi = do
           }
       vanillaOptsNoJsLib =
         baseOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptMode = toFlag GhcModeMake
             , ghcOptNumJobs = numJobs
             , ghcOptInputModules = toNubListR $ allLibModules lib clbi
             , ghcOptHPCDir = hpcdir Hpc.Vanilla
             }
-      vanillaOpts = vanillaOptsNoJsLib `mappend` linkJsLibOpts
+      vanillaOpts = vanillaOptsNoJsLib <> linkJsLibOpts
 
       profOpts =
         adjustExts "p_hi" "p_o" vanillaOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptProfilingMode = toFlag True
             , ghcOptProfilingAuto =
                 Internal.profDetailLevelFlag
@@ -614,7 +614,7 @@ buildOrReplLib mReplFlags verbosity numJobs _pkg_descr lbi lib clbi = do
 
       sharedOpts =
         adjustExts "dyn_hi" "dyn_o" vanillaOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptDynLinkMode = toFlag GhcDynamicOnly
             , ghcOptFPic = toFlag True
             , --  ghcOptHiSuffix    = toFlag "dyn_hi",
@@ -625,7 +625,7 @@ buildOrReplLib mReplFlags verbosity numJobs _pkg_descr lbi lib clbi = do
 
       vanillaSharedOpts =
         vanillaOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptDynLinkMode = toFlag GhcStaticAndDynamic
             , ghcOptDynHiSuffix = toFlag "js_dyn_hi"
             , ghcOptDynObjSuffix = toFlag "js_dyn_o"
@@ -673,11 +673,11 @@ buildOrReplLib mReplFlags verbosity numJobs _pkg_descr lbi lib clbi = do
                  vanillaCxxOpts = if isGhcjsDynamic
                                   then baseCxxOpts { ghcOptFPic = toFlag True }
                                   else baseCxxOpts
-                 profCxxOpts    = vanillaCxxOpts `mappend` mempty {
+                 profCxxOpts    = vanillaCxxOpts <> mempty {
                                     ghcOptProfilingMode = toFlag True,
                                     ghcOptObjSuffix     = toFlag "p_o"
                                   }
-                 sharedCxxOpts  = vanillaCxxOpts `mappend` mempty {
+                 sharedCxxOpts  = vanillaCxxOpts <> mempty {
                                    ghcOptFPic        = toFlag True,
                                    ghcOptDynLinkMode = toFlag GhcDynamicOnly,
                                    ghcOptObjSuffix   = toFlag "dyn_o"
@@ -710,11 +710,11 @@ buildOrReplLib mReplFlags verbosity numJobs _pkg_descr lbi lib clbi = do
                                  -- with -fPIC for REPL to work. See #2207.
                                  then baseCcOpts { ghcOptFPic = toFlag True }
                                  else baseCcOpts
-                 profCcOpts    = vanillaCcOpts `mappend` mempty {
+                 profCcOpts    = vanillaCcOpts <> mempty {
                                    ghcOptProfilingMode = toFlag True,
                                    ghcOptObjSuffix     = toFlag "p_o"
                                  }
-                 sharedCcOpts  = vanillaCcOpts `mappend` mempty {
+                 sharedCcOpts  = vanillaCcOpts <> mempty {
                                    ghcOptFPic        = toFlag True,
                                    ghcOptDynLinkMode = toFlag GhcDynamicOnly,
                                    ghcOptObjSuffix   = toFlag "dyn_o"
@@ -1287,7 +1287,7 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
         BenchComponentLocalBuildInfo{} -> True
       baseOpts =
         componentGhcOptions (verbosityLevel verbosity) lbi bnfo clbi tmpDir
-          `mappend` mempty
+          <> mempty
             { ghcOptMode = toFlag GhcModeMake
             , ghcOptInputFiles =
                 toNubListR $
@@ -1309,13 +1309,13 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
             }
       staticOpts =
         baseOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptDynLinkMode = toFlag GhcStaticOnly
             , ghcOptHPCDir = hpcdir Hpc.Vanilla
             }
       profOpts =
         baseOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptProfilingMode = toFlag True
             , ghcOptProfilingAuto =
                 Internal.profDetailLevelFlag
@@ -1328,7 +1328,7 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
             }
       dynOpts =
         baseOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptDynLinkMode = toFlag GhcDynamicOnly
             , -- TODO: Does it hurt to set -fPIC for executables?
               ghcOptFPic = toFlag True
@@ -1339,7 +1339,7 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
             }
       dynTooOpts =
         staticOpts
-          `mappend` mempty
+          <> mempty
             { ghcOptDynLinkMode = toFlag GhcStaticAndDynamic
             , ghcOptDynHiSuffix = toFlag "dyn_hi"
             , ghcOptDynObjSuffix = toFlag "dyn_o"
@@ -1377,8 +1377,8 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
           -- the one invocation, so that one has to include all the
           -- linker stuff too, like -l flags and any .o files from C
           -- files etc.
-          `mappend` linkerOpts
-          `mappend` mempty
+          <> linkerOpts
+          <> mempty
             { ghcOptMode = toFlag GhcModeInteractive
             , ghcOptOptimisation = toFlag GhcNoOptimisation
             }
@@ -1451,12 +1451,12 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
                 else baseCxxOpts
             profCxxOpts =
               vanillaCxxOpts
-                `mappend` mempty
+                <> mempty
                   { ghcOptProfilingMode = toFlag True
                   }
             sharedCxxOpts =
               vanillaCxxOpts
-                `mappend` mempty
+                <> mempty
                   { ghcOptFPic = toFlag True
                   , ghcOptDynLinkMode = toFlag GhcDynamicOnly
                   }
@@ -1491,12 +1491,12 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
                 else baseCcOpts
             profCcOpts =
               vanillaCcOpts
-                `mappend` mempty
+                <> mempty
                   { ghcOptProfilingMode = toFlag True
                   }
             sharedCcOpts =
               vanillaCcOpts
-                `mappend` mempty
+                <> mempty
                   { ghcOptFPic = toFlag True
                   , ghcOptDynLinkMode = toFlag GhcDynamicOnly
                   }
@@ -1521,11 +1521,11 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
     GBuildExe _ -> do
       let linkOpts =
             commonOpts
-              `mappend` linkerOpts
-              `mappend` mempty
+              <> linkerOpts
+              <> mempty
                 { ghcOptLinkNoHsMain = toFlag (null inputFiles)
                 }
-              `mappend` (if withDynExe lbi then dynLinkerOpts else mempty)
+              <> (if withDynExe lbi then dynLinkerOpts else mempty)
 
       info verbosity "Linking..."
       -- Work around old GHCs not relinking in this
@@ -1548,9 +1548,9 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
           linkOpts = case foreignLibType flib of
             ForeignLibNativeShared ->
               commonOpts
-                `mappend` linkerOpts
-                `mappend` dynLinkerOpts
-                `mappend` mempty
+                <> linkerOpts
+                <> dynLinkerOpts
+                <> mempty
                   { ghcOptLinkNoHsMain = toFlag True
                   , ghcOptShared = toFlag True
                   , ghcOptLinkLibs = rtsOptLinkLibs
@@ -1755,13 +1755,13 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
     mbWorkDir = mbWorkDirLBI lbi
     vanillaArgs =
       componentGhcOptions (verbosityLevel verbosity) lbi libBi clbi (componentBuildDir lbi clbi)
-        `mappend` mempty
+        <> mempty
           { ghcOptMode = toFlag GhcModeAbiHash
           , ghcOptInputModules = toNubListR $ exposedModules lib
           }
     sharedArgs =
       vanillaArgs
-        `mappend` mempty
+        <> mempty
           { ghcOptDynLinkMode = toFlag GhcDynamicOnly
           , ghcOptFPic = toFlag True
           , ghcOptHiSuffix = toFlag "js_dyn_hi"
@@ -1770,7 +1770,7 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
           }
     profArgs =
       vanillaArgs
-        `mappend` mempty
+        <> mempty
           { ghcOptProfilingMode = toFlag True
           , ghcOptProfilingAuto =
               Internal.profDetailLevelFlag
@@ -1803,7 +1803,7 @@ componentGhcOptions
 componentGhcOptions verbosity lbi bi clbi odir =
   let opts = Internal.componentGhcOptions verbosity lbi bi clbi odir
    in opts
-        { ghcOptExtra = ghcOptExtra opts `mappend` hcOptions GHCJS bi
+        { ghcOptExtra = ghcOptExtra opts <> hcOptions GHCJS bi
         }
 
 -- -----------------------------------------------------------------------------
@@ -1967,7 +1967,7 @@ installLib verbosity lbi targetDir dynlibTargetDir _bytecodeTargetDir _builtDir 
 adjustExts :: String -> String -> GhcOptions -> GhcOptions
 adjustExts hiSuf objSuf opts =
   opts
-    `mappend` mempty
+    <> mempty
       { ghcOptHiSuffix = toFlag hiSuf
       , ghcOptObjSuffix = toFlag objSuf
       }

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -334,7 +334,7 @@ haddock_setupHooks
           pkg_descr
           lbi
           suffixes
-          (defaultHscolourFlags `mappend` haddockToHscolour flags)
+          (defaultHscolourFlags <> haddockToHscolour flags)
 
     targets <- readTargetInfos verbosity pkg_descr lbi (haddockTargets flags)
 
@@ -1640,14 +1640,12 @@ haddockToHscolour flags =
 -- Boilerplate Monoid instance.
 instance Monoid HaddockArgs where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup HaddockArgs where
   (<>) = gmappend
 
 instance Monoid Directory where
   mempty = Dir "."
-  mappend = (<>)
 
 instance Semigroup Directory where
   Dir m <> Dir n = Dir $ m </> n

--- a/Cabal/src/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/src/Distribution/Simple/InstallDirs.hs
@@ -116,7 +116,6 @@ instance Structured dir => Structured (InstallDirs dir)
 
 instance Monoid dir => Monoid (InstallDirs dir) where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup dir => Semigroup (InstallDirs dir) where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/src/Distribution/Simple/PackageIndex.hs
@@ -157,11 +157,10 @@ type InstalledPackageIndex = PackageIndex IPI.InstalledPackageInfo
 
 instance Monoid (PackageIndex IPI.InstalledPackageInfo) where
   mempty = PackageIndex Map.empty Map.empty
-  mappend = (<>)
 
-  -- save one mappend with empty in the common case:
+  -- save one (<>) with empty in the common case:
   mconcat [] = mempty
-  mconcat xs = Prelude.foldr1 mappend xs
+  mconcat xs = Prelude.foldr1 (<>) xs
 
 instance Semigroup (PackageIndex IPI.InstalledPackageInfo) where
   (<>) = merge
@@ -276,7 +275,7 @@ merge (PackageIndex pids1 pnames1) (PackageIndex pids2 pnames2) =
 
 -- | Inserts a single package into the index.
 --
--- This is equivalent to (but slightly quicker than) using 'mappend' or
+-- This is equivalent to (but slightly quicker than) using '(<>)' or
 -- 'merge' with a singleton index.
 insert :: IPI.InstalledPackageInfo -> InstalledPackageIndex -> InstalledPackageIndex
 insert pkg (PackageIndex pids pnames) =

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -1055,7 +1055,6 @@ splitRTSArgs args =
 
 instance Monoid GhcOptions where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup GhcOptions where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
@@ -151,7 +151,6 @@ emptyBenchmarkFlags = mempty
 
 instance Monoid BenchmarkFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup BenchmarkFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Build.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Build.hs
@@ -178,7 +178,6 @@ emptyBuildFlags = mempty
 
 instance Monoid BuildFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup BuildFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Clean.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Clean.hs
@@ -117,7 +117,6 @@ emptyCleanFlags = mempty
 
 instance Monoid CleanFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup CleanFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -102,7 +102,6 @@ instance Semigroup CommonSetupFlags where
 
 instance Monoid CommonSetupFlags where
   mempty = gmempty
-  mappend = (<>)
 
 defaultCommonSetupFlags :: CommonSetupFlags
 defaultCommonSetupFlags =

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -1077,7 +1077,6 @@ emptyConfigFlags = mempty
 
 instance Monoid ConfigFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ConfigFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Copy.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Copy.hs
@@ -170,7 +170,6 @@ emptyCopyFlags = mempty
 
 instance Monoid CopyFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup CopyFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Global.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Global.hs
@@ -37,7 +37,7 @@ import Distribution.Utils.Path
 
 -- In fact since individual flags types are monoids and these are just sets of
 -- flags then they are also monoids pointwise. This turns out to be really
--- useful. The mempty is the set of empty flags and mappend allows us to
+-- useful. The mempty is the set of empty flags and (<>) allows us to
 -- override specific flags. For example we can start with default flags and
 -- override with the ones we get from a file or the command line, or both.
 
@@ -132,7 +132,6 @@ emptyGlobalFlags = mempty
 
 instance Monoid GlobalFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup GlobalFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -382,7 +382,6 @@ emptyHaddockFlags = mempty
 
 instance Monoid HaddockFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup HaddockFlags where
   (<>) = gmappend
@@ -634,7 +633,6 @@ emptyHaddockProjectFlags = mempty
 
 instance Monoid HaddockProjectFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup HaddockProjectFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Hscolour.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Hscolour.hs
@@ -99,7 +99,6 @@ defaultHscolourFlags =
 
 instance Monoid HscolourFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup HscolourFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Install.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Install.hs
@@ -178,7 +178,6 @@ emptyInstallFlags = mempty
 
 instance Monoid InstallFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup InstallFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Register.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Register.hs
@@ -211,7 +211,6 @@ emptyRegisterFlags = mempty
 
 instance Monoid RegisterFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup RegisterFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Repl.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Repl.hs
@@ -87,7 +87,6 @@ instance Structured ReplOptions
 
 instance Monoid ReplOptions where
   mempty = ReplOptions mempty (Flag False) NoFlag NoFlag
-  mappend = (<>)
 
 instance Semigroup ReplOptions where
   (<>) = gmappend
@@ -116,7 +115,6 @@ defaultReplFlags =
 
 instance Monoid ReplFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ReplFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/SDist.hs
+++ b/Cabal/src/Distribution/Simple/Setup/SDist.hs
@@ -135,7 +135,6 @@ emptySDistFlags = mempty
 
 instance Monoid SDistFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup SDistFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Simple/Setup/Test.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Test.hs
@@ -83,7 +83,6 @@ instance Parsec TestShowDetails where
 -- TODO: do we need this instance?
 instance Monoid TestShowDetails where
   mempty = Never
-  mappend = (<>)
 
 instance Semigroup TestShowDetails where
   a <> b = max a b
@@ -279,7 +278,6 @@ emptyTestFlags = mempty
 
 instance Monoid TestFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup TestFlags where
   (<>) = gmappend

--- a/Cabal/src/Distribution/Utils/NubList.hs
+++ b/Cabal/src/Distribution/Utils/NubList.hs
@@ -41,17 +41,16 @@ overNubList f (NubList list) = toNubList . f $ list
 -- identity, associativity and closure.
 --
 -- Identity : by inspection:
---      mempty `mappend` NubList xs == NubList xs `mappend` mempty
+--      mempty <> NubList xs == NubList xs <> mempty
 --
 -- Associativity : by inspection:
---      (NubList xs `mappend` NubList ys) `mappend` NubList zs
---      == NubList xs `mappend` (NubList ys `mappend` NubList zs)
+--      (NubList xs <> NubList ys) <> NubList zs
+--      == NubList xs <> (NubList ys <> NubList zs)
 --
 -- Closure : appending two lists of type a and removing duplicates obviously
 -- does not change the type.
 instance Ord a => Monoid (NubList a) where
   mempty = NubList []
-  mappend = (<>)
 
 instance Ord a => Semigroup (NubList a) where
   (NubList xs) <> (NubList ys) = NubList $ xs `listUnion` ys
@@ -95,7 +94,6 @@ overNubListR f (NubListR list) = toNubListR . f $ list
 
 instance Ord a => Monoid (NubListR a) where
   mempty = NubListR []
-  mappend = (<>)
 
 instance Ord a => Semigroup (NubListR a) where
   (NubListR xs) <> (NubListR ys) = NubListR $ xs `listUnionRight` ys

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Assignment.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Assignment.hs
@@ -68,12 +68,12 @@ toCPs (A pa fa sa) rdm =
     -- Determine the flags per package, by walking over and regrouping the
     -- complete flag assignment by package.
     fapp :: Map QPN FlagAssignment
-    fapp = M.fromListWith mappend $
+    fapp = M.fromListWith (<>) $
            L.map (\ (FN qpn fn, b) -> (qpn, mkFlagAssignment [(fn, b)])) $
            M.toList fa
     -- Stanzas per package.
     sapp :: Map QPN OptionalStanzaSet
-    sapp = M.fromListWith mappend
+    sapp = M.fromListWith (<>)
          $ L.map (\ (SN qpn sn, b) -> (qpn, if b then optStanzaSetSingleton sn else mempty))
          $ M.toList sa
     -- Dependencies per package.

--- a/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ComponentDeps.hs
@@ -91,7 +91,6 @@ newtype ComponentDeps a = ComponentDeps { unComponentDeps :: Map Component a }
 
 instance Semigroup a => Monoid (ComponentDeps a) where
   mempty = ComponentDeps Map.empty
-  mappend = (<>)
 
 instance Semigroup a => Semigroup (ComponentDeps a) where
   ComponentDeps d <> ComponentDeps d' =
@@ -122,7 +121,7 @@ empty :: ComponentDeps a
 empty = ComponentDeps Map.empty
 
 fromList :: Monoid a => [ComponentDep a] -> ComponentDeps a
-fromList = ComponentDeps . Map.fromListWith mappend
+fromList = ComponentDeps . Map.fromListWith (<>)
 
 singleton :: Component -> a -> ComponentDeps a
 singleton comp = ComponentDeps . Map.singleton comp
@@ -131,7 +130,7 @@ insert :: Monoid a => Component -> a -> ComponentDeps a -> ComponentDeps a
 insert comp a = ComponentDeps . Map.alter aux comp . unComponentDeps
   where
     aux Nothing   = Just a
-    aux (Just a') = Just $ a `mappend` a'
+    aux (Just a') = Just $ a <> a'
 
 -- | Zip two 'ComponentDeps' together by 'Component', using 'mempty'
 -- as the neutral element when a 'Component' is present only in one.

--- a/cabal-install-solver/src/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/OptionalStanza.hs
@@ -109,7 +109,6 @@ instance Semigroup OptionalStanzaSet where
 
 instance Monoid OptionalStanzaSet where
     mempty = OptionalStanzaSet 0
-    mappend = (<>)
 
 -------------------------------------------------------------------------------
 -- OptionalStanzaMap

--- a/cabal-install-solver/src/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PackageIndex.hs
@@ -88,10 +88,9 @@ instance Package pkg => Semigroup (PackageIndex pkg) where
 
 instance Package pkg => Monoid (PackageIndex pkg) where
   mempty  = PackageIndex Map.empty
-  mappend = (<>)
-  --save one mappend with empty in the common case:
+  --save one (<>) with empty in the common case:
   mconcat [] = mempty
-  mconcat xs = Prelude.foldr1 mappend xs
+  mconcat xs = Prelude.foldr1 (<>) xs
 
 instance Binary pkg => Binary (PackageIndex pkg)
 
@@ -207,7 +206,7 @@ overrideOrMerge strategy i1@(PackageIndex m1) i2@(PackageIndex m2) =
 
 -- | Inserts a single package into the index.
 --
--- This is equivalent to (but slightly quicker than) using 'mappend' or
+-- This is equivalent to (but slightly quicker than) using '(<>)' or
 -- 'merge' with a singleton index.
 --
 insert :: Package pkg => pkg -> PackageIndex pkg -> PackageIndex pkg

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -745,7 +745,7 @@ getClientInstallFlags :: Verbosity -> GlobalFlags -> ClientInstallFlags -> IO Cl
 getClientInstallFlags verbosity globalFlags existingClientInstallFlags = do
   let configFileFlag = globalConfigFile globalFlags
   savedConfig <- loadConfig verbosity configFileFlag
-  pure $ savedClientInstallFlags savedConfig `mappend` existingClientInstallFlags
+  pure $ savedClientInstallFlags savedConfig <> existingClientInstallFlags
 
 getSpecsAndTargetSelectors
   :: Verbosity
@@ -1246,7 +1246,7 @@ installBuiltExe
 
 -- | Create 'GhcEnvironmentFileEntry's for packages with exposed libraries.
 entriesForLibraryComponents :: TargetsMap -> [GhcEnvironmentFileEntry FilePath]
-entriesForLibraryComponents = Map.foldrWithKey' (\k v -> mappend (go k v)) []
+entriesForLibraryComponents = Map.foldrWithKey' (\k v -> (go k v <>)) []
   where
     hasLib :: (ComponentTarget, NonEmpty TargetSelector) -> Bool
     hasLib (ComponentTarget (CLibName _) _, _) = True

--- a/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
@@ -55,7 +55,6 @@ data ClientInstallFlags = ClientInstallFlags
 
 instance Monoid ClientInstallFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ClientInstallFlags where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -119,7 +119,6 @@ data IgnoreMajorVersionBumps
 
 instance Monoid IgnoreMajorVersionBumps where
   mempty = IgnoreMajorVersionBumpsNone
-  mappend = (<>)
 
 instance Semigroup IgnoreMajorVersionBumps where
   IgnoreMajorVersionBumpsNone <> r = r
@@ -378,7 +377,7 @@ instance Pretty (OutdatedDependencyX Version) where
 
 instance Pretty (OutdatedDependencyX ()) where
   pretty (OutdatedDependency dep _ src) =
-    pretty dep <+> PP.text "(from:" <+> PP.text (prettyOutdatedDependencySource src) `mappend` PP.text ")"
+    pretty dep <+> PP.text "(from:" <+> (PP.text (prettyOutdatedDependencySource src) <> PP.text ")")
 
 data OutdatedDependencySource = ConfigSource ConstraintSource | ComponentSource PackageId ComponentTarget
 

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -280,7 +280,6 @@ data SavedConfig = SavedConfig
 
 instance Monoid SavedConfig where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup SavedConfig where
   a <> b =
@@ -302,7 +301,7 @@ instance Semigroup SavedConfig where
       , savedReplMulti = combinedSavedReplMulti
       }
     where
-      -- This is ugly, but necessary. If we're mappending two config files, we
+      -- This is ugly, but necessary. If we're combining two config files, we
       -- want the values of the *non-empty* list fields from the second one to
       -- \*override* the corresponding values from the first one. Default
       -- behaviour (concatenation) is confusing and makes some use cases (see
@@ -321,7 +320,7 @@ instance Semigroup SavedConfig where
       -- NB: the signature prevents us from using 'combine' on lists.
       combine' :: (SavedConfig -> flags) -> (flags -> Flag a) -> Flag a
       combine' field subfield =
-        (subfield . field $ a) `mappend` (subfield . field $ b)
+        subfield (field a) <> subfield (field b)
 
       combineMonoid
         :: Monoid mon
@@ -329,7 +328,7 @@ instance Semigroup SavedConfig where
         -> (flags -> mon)
         -> mon
       combineMonoid field subfield =
-        (subfield . field $ a) `mappend` (subfield . field $ b)
+        subfield (field a) <> subfield (field b)
 
       lastNonEmpty' :: (SavedConfig -> flags) -> (flags -> [a]) -> [a]
       lastNonEmpty' field subfield =
@@ -512,10 +511,9 @@ instance Semigroup SavedConfig where
           , configDebugInfo = combine configDebugInfo
           , configProgPrefix = combine configProgPrefix
           , configProgSuffix = combine configProgSuffix
-          , -- Parametrised by (Flag PathTemplate), so safe to use 'mappend'.
+          , -- Parametrised by (Flag PathTemplate), so safe to use '(<>)'.
             configInstallDirs =
-              (configInstallDirs . savedConfigureFlags $ a)
-                `mappend` (configInstallDirs . savedConfigureFlags $ b)
+              configInstallDirs (savedConfigureFlags a) <> configInstallDirs (savedConfigureFlags b)
           , configScratchDir = combine configScratchDir
           , -- TODO: NubListify
             configExtraLibDirs = lastNonEmpty configExtraLibDirs
@@ -584,15 +582,13 @@ instance Semigroup SavedConfig where
           combine = combine' savedConfigureExFlags
           lastNonEmpty = lastNonEmpty' savedConfigureExFlags
 
-      -- Parametrised by (Flag PathTemplate), so safe to use 'mappend'.
+      -- Parametrised by (Flag PathTemplate), so safe to use '(<>)'.
       combinedSavedUserInstallDirs =
-        savedUserInstallDirs a
-          `mappend` savedUserInstallDirs b
+        savedUserInstallDirs a <> savedUserInstallDirs b
 
-      -- Parametrised by (Flag PathTemplate), so safe to use 'mappend'.
+      -- Parametrised by (Flag PathTemplate), so safe to use '(<>)'.
       combinedSavedGlobalInstallDirs =
-        savedGlobalInstallDirs a
-          `mappend` savedGlobalInstallDirs b
+        savedGlobalInstallDirs a <> savedGlobalInstallDirs b
 
       combinedSavedUploadFlags =
         UploadFlags
@@ -964,7 +960,7 @@ loadConfig verbosity configFileFlag = do
 extendToEffectiveConfig :: SavedConfig -> IO SavedConfig
 extendToEffectiveConfig config = do
   base <- baseSavedConfig
-  let effective0 = base `mappend` config
+  let effective0 = base <> config
       globalFlags0 = savedGlobalFlags effective0
       effective =
         effective0
@@ -1074,7 +1070,7 @@ createDefaultConfigFile verbosity extraLines filePath = do
   initialConf <- initialSavedConfig
   extraConf <- parseExtraLines verbosity extraLines
   notice verbosity $ "Writing default configuration to " ++ filePath
-  writeConfigFile filePath commentConf (initialConf `mappend` extraConf)
+  writeConfigFile filePath commentConf (initialConf <> extraConf)
   return initialConf
 
 writeConfigFile :: FilePath -> SavedConfig -> SavedConfig -> IO ()
@@ -1954,7 +1950,7 @@ userConfigDiff verbosity globalFlags extraLines = do
       M.unionWith
         combine
         (M.fromList . map justFst $ filterShow testConfig)
-        (M.fromList . map justSnd $ filterShow (userConfig `mappend` extraConfig))
+        (M.fromList . map justSnd $ filterShow (userConfig <> extraConfig))
   where
     justFst (a, b) = (a, (Just b, Nothing))
     justSnd (a, b) = (a, (Nothing, Just b))
@@ -2012,4 +2008,4 @@ userConfigUpdate verbosity globalFlags extraLines = do
   writeConfigFile
     cabalFile
     commentConf
-    (newConfig `mappend` userConfig `mappend` extraConfig)
+    (newConfig <> userConfig <> extraConfig)

--- a/cabal-install/src/Distribution/Client/Configure.hs
+++ b/cabal-install/src/Distribution/Client/Configure.hs
@@ -544,10 +544,10 @@ configurePackage
               -- (But if they didn't, let solver decide.)
               configBenchmarks =
                 toFlag (BenchStanzas `optStanzaSetMember` stanzas)
-                  `mappend` configBenchmarks configFlags
+                  <> configBenchmarks configFlags
             , configTests =
                 toFlag (TestStanzas `optStanzaSetMember` stanzas)
-                  `mappend` configTests configFlags
+                  <> configTests configFlags
             }
 
       pkg :: PkgDesc.PackageDescription

--- a/cabal-install/src/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/src/Distribution/Client/GlobalFlags.hs
@@ -121,7 +121,6 @@ defaultGlobalFlags =
 
 instance Monoid GlobalFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup GlobalFlags where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -137,7 +137,6 @@ data InitFlags = InitFlags
 
 instance Monoid InitFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup InitFlags where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -591,9 +591,9 @@ configureAction (configFlags, configExFlags) extraArgs globalFlags = do
       <$> loadConfigOrSandboxConfig verbosity globalFlags
   distPref <- getSymbolicPath <$> findSavedDistPref config (setupDistPref common)
 
-  let configFlags' = savedConfigureFlags config `mappend` configFlags
-      configExFlags' = savedConfigureExFlags config `mappend` configExFlags
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
+  let configFlags' = savedConfigureFlags config <> configFlags
+      configExFlags' = savedConfigureExFlags config <> configExFlags
+      globalFlags' = savedGlobalFlags config <> globalFlags
   (comp, platform, progdb) <- configCompilerAuxEx (verbosityHandles verbosity) configFlags'
 
   writeConfigFlags verbosity distPref (configFlags', configExFlags')
@@ -730,7 +730,7 @@ filterBuildFlags' version config buildFlags
         { -- Take the 'jobs' setting config file into account.
           buildNumJobs =
             Flag . Just . determineNumJobs $
-              (numJobsConfigFlag `mappend` numJobsCmdLineFlag)
+              (numJobsConfigFlag <> numJobsCmdLineFlag)
         }
     numJobsConfigFlag = installNumJobs . savedInstallFlags $ config
     numJobsCmdLineFlag = buildNumJobs buildFlags
@@ -863,7 +863,7 @@ installAction
       let configFlags' =
             maybeForceTests installFlags' $
               savedConfigureFlags config
-                `mappend` configFlags
+                <> configFlags
                   { configCommonFlags =
                       (configCommonFlags configFlags)
                         { setupDistPref = toFlag dist
@@ -871,16 +871,16 @@ installAction
                   }
           configExFlags' =
             defaultConfigExFlags
-              `mappend` savedConfigureExFlags config
-              `mappend` configExFlags
+              <> savedConfigureExFlags config
+              <> configExFlags
           installFlags' =
             defaultInstallFlags
-              `mappend` savedInstallFlags config
-              `mappend` installFlags
+              <> savedInstallFlags config
+              <> installFlags
           haddockFlags' =
             defaultHaddockFlags
-              `mappend` savedHaddockFlags config
-              `mappend` haddockFlags
+              <> savedHaddockFlags config
+              <> haddockFlags
                 { haddockCommonFlags =
                     (haddockCommonFlags haddockFlags)
                       { setupDistPref = toFlag dist
@@ -888,8 +888,8 @@ installAction
                 }
           testFlags' =
             Cabal.defaultTestFlags
-              `mappend` savedTestFlags config
-              `mappend` testFlags
+              <> savedTestFlags config
+              <> testFlags
                 { testCommonFlags =
                     (testCommonFlags testFlags)
                       { setupDistPref = toFlag dist
@@ -897,14 +897,14 @@ installAction
                 }
           benchmarkFlags' =
             Cabal.defaultBenchmarkFlags
-              `mappend` savedBenchmarkFlags config
-              `mappend` benchmarkFlags
+              <> savedBenchmarkFlags config
+              <> benchmarkFlags
                 { benchmarkCommonFlags =
                     (benchmarkCommonFlags benchmarkFlags)
                       { setupDistPref = toFlag dist
                       }
                 }
-          globalFlags' = savedGlobalFlags config `mappend` globalFlags
+          globalFlags' = savedGlobalFlags config <> globalFlags
       (comp, platform, progdb) <- configCompilerAux' configFlags'
 
       -- TODO: Redesign ProgramDB API to prevent such problems as #2241 in the
@@ -1158,8 +1158,8 @@ haddockAction haddockFlags extraArgs globalFlags = do
   let mbWorkDir = flagToMaybe $ setupWorkingDir common
       haddockFlags' =
         defaultHaddockFlags
-          `mappend` savedHaddockFlags config'
-          `mappend` haddockFlags
+          <> savedHaddockFlags config'
+          <> haddockFlags
             { haddockCommonFlags =
                 (haddockCommonFlags haddockFlags)
                   { setupDistPref = toFlag distPref
@@ -1231,10 +1231,10 @@ listAction listFlags extraArgs globalFlags = do
         configFlags'
           { configPackageDBs =
               configPackageDBs configFlags'
-                `mappend` listPackageDBs listFlags
+                <> listPackageDBs listFlags
           , configHcPath = listHcPath listFlags
           }
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
+      globalFlags' = savedGlobalFlags config <> globalFlags
   compProgdb <-
     if listNeedsCompiler listFlags
       then do
@@ -1262,9 +1262,9 @@ infoAction infoFlags extraArgs globalFlags = do
         configFlags'
           { configPackageDBs =
               configPackageDBs configFlags'
-                `mappend` infoPackageDBs infoFlags
+                <> infoPackageDBs infoFlags
           }
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
+      globalFlags' = savedGlobalFlags config <> globalFlags
   (comp, _, progdb) <- configCompilerAuxEx defaultVerbosityHandles configFlags
   withRepoContext verbosity globalFlags' $ \repoContext ->
     List.info
@@ -1285,7 +1285,7 @@ fetchAction fetchFlags extraArgs globalFlags = do
   targets <- readUserTargets verbosity extraArgs
   config <- loadConfig verbosity (globalConfigFile globalFlags)
   let configFlags = savedConfigureFlags config
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
+      globalFlags' = savedGlobalFlags config <> globalFlags
   (comp, platform, progdb) <- configCompilerAux' configFlags
   withRepoContext verbosity globalFlags' $ \repoContext ->
     fetch
@@ -1306,7 +1306,7 @@ freezeAction freezeFlags _extraArgs globalFlags = do
           fromFlag (freezeVerbosity freezeFlags)
   config <- loadConfigOrSandboxConfig verbosity globalFlags
   let configFlags = savedConfigureFlags config
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
+      globalFlags' = savedGlobalFlags config <> globalFlags
   (comp, platform, progdb) <- configCompilerAux' configFlags
 
   withRepoContext verbosity globalFlags' $ \repoContext ->
@@ -1327,7 +1327,7 @@ genBoundsAction freezeFlags _extraArgs globalFlags = do
           fromFlag (freezeVerbosity freezeFlags)
   config <- loadConfigOrSandboxConfig verbosity globalFlags
   let configFlags = savedConfigureFlags config
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
+      globalFlags' = savedGlobalFlags config <> globalFlags
   (comp, platform, progdb) <- configCompilerAux' configFlags
 
   withRepoContext verbosity globalFlags' $ \repoContext ->
@@ -1344,8 +1344,8 @@ genBoundsAction freezeFlags _extraArgs globalFlags = do
 uploadAction :: UploadFlags -> [String] -> Action
 uploadAction uploadFlags extraArgs globalFlags = do
   config <- loadConfig verbosity (globalConfigFile globalFlags)
-  let uploadFlags' = savedUploadFlags config `mappend` uploadFlags
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
+  let uploadFlags' = savedUploadFlags config <> uploadFlags
+      globalFlags' = savedGlobalFlags config <> globalFlags
       tarfiles = extraArgs
       chosenRepo = flagToMaybe $ uploadRepoName uploadFlags'
   when (null tarfiles && not (fromFlag (uploadDoc uploadFlags'))) $
@@ -1448,8 +1448,8 @@ reportAction reportFlags extraArgs globalFlags = do
     dieWithException verbosity $
       ReportAction extraArgs
   config <- loadConfig verbosity (globalConfigFile globalFlags)
-  let globalFlags' = savedGlobalFlags config `mappend` globalFlags
-      reportFlags' = savedReportFlags config `mappend` reportFlags
+  let globalFlags' = savedGlobalFlags config <> globalFlags
+      reportFlags' = savedReportFlags config <> reportFlags
       chosenRepo = flagToMaybe $ reportRepoName reportFlags'
   withRepoContext verbosity globalFlags' $ \repoContext -> do
     filteredRepoContext <- chooseRepo verbosity repoContext (unRepoName <$> chosenRepo)
@@ -1493,7 +1493,7 @@ getAction getFlags extraArgs globalFlags = do
           fromFlag (getVerbosity getFlags)
   targets <- readUserTargets verbosity extraArgs
   config <- loadConfigOrSandboxConfig verbosity globalFlags
-  let globalFlags' = savedGlobalFlags config `mappend` globalFlags
+  let globalFlags' = savedGlobalFlags config <> globalFlags
       chosenRepo = flagToMaybe $ getRepoName getFlags
   withRepoContext verbosity (savedGlobalFlags config) $ \repoContext -> do
     filteredRepoContext <- chooseRepo verbosity repoContext (unRepoName <$> chosenRepo)
@@ -1522,9 +1522,9 @@ initAction initFlags extraArgs globalFlags = do
     initAction' = do
       confFlags <- loadConfigOrSandboxConfig verbosity globalFlags
       -- override with `--with-compiler` from CLI if available
-      let confFlags' = savedConfigureFlags confFlags `mappend` compFlags
-          initFlags' = savedInitFlags confFlags `mappend` initFlags
-          globalFlags' = savedGlobalFlags confFlags `mappend` globalFlags
+      let confFlags' = savedConfigureFlags confFlags <> compFlags
+          initFlags' = savedInitFlags confFlags <> initFlags
+          globalFlags' = savedGlobalFlags confFlags <> globalFlags
 
       (comp, _, progdb) <- configCompilerAux' confFlags'
 

--- a/cabal-install/src/Distribution/Client/ManpageFlags.hs
+++ b/cabal-install/src/Distribution/Client/ManpageFlags.hs
@@ -20,7 +20,6 @@ data ManpageFlags = ManpageFlags
 
 instance Monoid ManpageFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ManpageFlags where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -397,7 +397,6 @@ data LegacyProjectConfig = LegacyProjectConfig
 
 instance Monoid LegacyProjectConfig where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup LegacyProjectConfig where
   (<>) = gmappend
@@ -413,7 +412,6 @@ data LegacyPackageConfig = LegacyPackageConfig
 
 instance Monoid LegacyPackageConfig where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup LegacyPackageConfig where
   (<>) = gmappend
@@ -431,7 +429,6 @@ data LegacySharedConfig = LegacySharedConfig
 
 instance Monoid LegacySharedConfig where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup LegacySharedConfig where
   (<>) = gmappend
@@ -1896,7 +1893,7 @@ packageSpecificOptionsSectionDescr =
                 { legacySpecificConfig =
                     MapMappend $
                       Map.insertWith
-                        mappend
+                        (<>)
                         pkgname
                         pkgconf
                         (getMapMappend $ legacySpecificConfig projconf)
@@ -2072,7 +2069,7 @@ monoidFieldParsec
 monoidFieldParsec name showF readF get' set =
   liftField get' set' $ ParseUtils.fieldParsec name showF readF
   where
-    set' xs b = set (get' b `mappend` xs) b
+    set' xs b = set (get' b <> xs) b
 
 -- TODO: [code cleanup] local redefinition that should replace the version in
 -- D.ParseUtils called showFilePath. This version escapes "." and "--" which

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -383,15 +383,14 @@ instance (NFData k, NFData v) => NFData (MapLast k v)
 
 instance Ord k => Monoid (MapLast k v) where
   mempty = MapLast Map.empty
-  mappend = (<>)
 
 instance Ord k => Semigroup (MapLast k v) where
   MapLast a <> MapLast b = MapLast $ Map.union b a
 
 -- rather than Map.union which is the normal Map monoid instance
 
--- | Newtype wrapper for 'Map' that provides a 'Monoid' instance that
--- 'mappend's values of overlapping keys rather than taking the first.
+-- | Newtype wrapper for 'Map' that provides a 'Semigroup' instance that
+-- combines values of overlapping keys with `(<>)` rather than taking the first.
 newtype MapMappend k v = MapMappend {getMapMappend :: Map k v}
   deriving (Eq, Show, Functor, Generic, Binary)
 
@@ -401,7 +400,6 @@ instance (NFData k, NFData v) => NFData (MapMappend k v)
 
 instance (Semigroup v, Ord k) => Monoid (MapMappend k v) where
   mempty = MapMappend Map.empty
-  mappend = (<>)
 
 instance (Semigroup v, Ord k) => Semigroup (MapMappend k v) where
   MapMappend a <> MapMappend b = MapMappend (Map.unionWith (<>) a b)
@@ -410,28 +408,24 @@ instance (Semigroup v, Ord k) => Semigroup (MapMappend k v) where
 
 instance Monoid ProjectConfig where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ProjectConfig where
   (<>) = gmappend
 
 instance Monoid ProjectConfigBuildOnly where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ProjectConfigBuildOnly where
   (<>) = gmappend
 
 instance Monoid ProjectConfigShared where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ProjectConfigShared where
   (<>) = gmappend
 
 instance Monoid PackageConfig where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup PackageConfig where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/ProjectFlags.hs
+++ b/cabal-install/src/Distribution/Client/ProjectFlags.hs
@@ -125,7 +125,6 @@ removeIgnoreProjectOption = filter (\o -> optionName o /= "ignore-project")
 
 instance Monoid ProjectFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ProjectFlags where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2522,7 +2522,7 @@ elaborateInstallPlan
         -- This is where we merge the options from the project config that
         -- apply to all packages, all project local packages, and to specific
         -- named packages
-        global `mappend` local `mappend` perpkg
+        global <> local <> perpkg
         where
           global = f allPackagesConfig
           local

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -122,7 +122,6 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (fold)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
-import qualified Data.Monoid as Mon
 import Distribution.Verbosity
 import System.FilePath ((</>))
 import Text.PrettyPrint (hsep, parens, text)
@@ -792,7 +791,7 @@ whyNotPerComponent = \case
 pkgOrderDependencies :: ElaboratedPackage -> ComponentDeps [UnitId]
 pkgOrderDependencies pkg =
   fmap (map (newSimpleUnitId . confInstId)) (map fst <$> pkgLibDependencies pkg)
-    `Mon.mappend` fmap (map (newSimpleUnitId . confInstId)) (pkgExeDependencies pkg)
+    <> fmap (map (newSimpleUnitId . confInstId)) (pkgExeDependencies pkg)
 
 -- | This is used in the install plan to indicate how the package will be
 -- built.

--- a/cabal-install/src/Distribution/Client/Reconfigure.hs
+++ b/cabal-install/src/Distribution/Client/Reconfigure.hs
@@ -47,7 +47,6 @@ instance Semigroup (Check a) where
 
 instance Monoid (Check a) where
   mempty = Check $ \_ a -> return (mempty, a)
-  mappend = (<>)
 
 -- | Re-configure the package in the current directory if needed. Deciding
 -- when to reconfigure and with which options is convoluted:

--- a/cabal-install/src/Distribution/Client/Sandbox.hs
+++ b/cabal-install/src/Distribution/Client/Sandbox.hs
@@ -84,7 +84,7 @@ updateInstallDirs userInstallFlag savedConfig =
     userInstall =
       fromFlagOrDefault
         defaultUserInstall
-        (configUserInstall configureFlags `mappend` userInstallFlag)
+        (configUserInstall configureFlags <> userInstallFlag)
 
 -- | Check which type of package environment we're in and return a
 -- correctly-initialised @SavedConfig@ and a @UseSandbox@ value that indicates
@@ -105,7 +105,7 @@ loadConfigOrSandboxConfig verbosity globalFlags = do
     UserPackageEnvironment -> do
       config <- loadConfig verbosity configFileFlag
       userConfig <- loadUserConfig verbosity pkgEnvDir Nothing
-      let config' = config `mappend` userConfig
+      let config' = config <> userConfig
       return config'
 
     -- Neither @cabal.sandbox.config@ nor @cabal.config@ are present.
@@ -115,7 +115,7 @@ loadConfigOrSandboxConfig verbosity globalFlags = do
             flagToMaybe . globalConstraintsFile . savedGlobalFlags $ config
       globalConstraintConfig <-
         loadUserConfig verbosity pkgEnvDir globalConstraintsOpt
-      let config' = config `mappend` globalConstraintConfig
+      let config' = config <> globalConstraintConfig
       return config'
 
 -- | Return the saved \"dist/\" prefix, or the default prefix.
@@ -124,7 +124,7 @@ findSavedDistPref config flagDistPref = do
   let defDistPref = useDistPref defaultSetupScriptOptions
       flagDistPref' =
         setupDistPref (configCommonFlags $ savedConfigureFlags config)
-          `mappend` flagDistPref
+          <> flagDistPref
   findDistPref defDistPref flagDistPref'
 
 -- Utils (transitionary)

--- a/cabal-install/src/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/src/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -84,7 +84,6 @@ data PackageEnvironment = PackageEnvironment
 
 instance Monoid PackageEnvironment where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup PackageEnvironment where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1081,7 +1081,6 @@ relaxDepsPrinter (Just (RelaxDepsSome pkgs)) = map (Just . prettyShow) pkgs
 
 instance Monoid ConfigExFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ConfigExFlags where
   (<>) = gmappend
@@ -1891,7 +1890,6 @@ reportCommand =
 
 instance Monoid ReportFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ReportFlags where
   (<>) = gmappend
@@ -2057,7 +2055,6 @@ unpackCommand =
 
 instance Monoid GetFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup GetFlags where
   (<>) = gmappend
@@ -2170,7 +2167,6 @@ listNeedsCompiler f =
 
 instance Monoid ListFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ListFlags where
   (<>) = gmappend
@@ -2226,7 +2222,6 @@ infoCommand =
 
 instance Monoid InfoFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup InfoFlags where
   (<>) = gmappend
@@ -2866,7 +2861,6 @@ optionNumJobs get set =
 
 instance Monoid InstallFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup InstallFlags where
   (<>) = gmappend
@@ -3000,7 +2994,6 @@ uploadCommand =
 
 instance Monoid UploadFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup UploadFlags where
   (<>) = gmappend
@@ -3486,7 +3479,6 @@ actAsSetupCommand =
 
 instance Monoid ActAsSetupFlags where
   mempty = gmempty
-  mappend = (<>)
 
 instance Semigroup ActAsSetupFlags where
   (<>) = gmappend
@@ -3511,7 +3503,6 @@ instance Monoid UserConfigFlags where
       , userConfigForce = toFlag False
       , userConfigAppendLines = toFlag []
       }
-  mappend = (<>)
 
 instance Semigroup UserConfigFlags where
   (<>) = gmappend

--- a/cabal-install/src/Distribution/Client/Targets.hs
+++ b/cabal-install/src/Distribution/Client/Targets.hs
@@ -513,10 +513,7 @@ disambiguatePackageTargets availablePkgIndex availableExtra targets =
 
     -- use any extra specific available packages to help us disambiguate
     packageNameEnv :: PackageNameEnv
-    packageNameEnv =
-      mappend
-        (indexPackageNameEnv availablePkgIndex)
-        (extraPackageNameEnv availableExtra)
+    packageNameEnv = indexPackageNameEnv availablePkgIndex <> extraPackageNameEnv availableExtra
 
 -- | Report problems to the user. That is, if there are any problems
 -- then raise an exception.
@@ -567,7 +564,6 @@ newtype PackageNameEnv = PackageNameEnv (PackageName -> [PackageName])
 
 instance Monoid PackageNameEnv where
   mempty = PackageNameEnv (const [])
-  mappend = (<>)
 
 instance Semigroup PackageNameEnv where
   PackageNameEnv lookupA <> PackageNameEnv lookupB =

--- a/cabal-install/src/Distribution/Client/Types/AllowNewer.hs
+++ b/cabal-install/src/Distribution/Client/Types/AllowNewer.hs
@@ -241,7 +241,6 @@ instance Semigroup RelaxDeps where
 -- | @'RelaxDepsSome' []@ is the /identity element/
 instance Monoid RelaxDeps where
   mempty = RelaxDepsSome []
-  mappend = (<>)
 
 instance Semigroup AllowNewer where
   AllowNewer x <> AllowNewer y = AllowNewer (x <> y)
@@ -251,8 +250,6 @@ instance Semigroup AllowOlder where
 
 instance Monoid AllowNewer where
   mempty = AllowNewer mempty
-  mappend = (<>)
 
 instance Monoid AllowOlder where
   mempty = AllowOlder mempty
-  mappend = (<>)

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1970,7 +1970,7 @@ testBuildKeepGoing :: ProjectConfig -> Assertion
 testBuildKeepGoing config = do
   -- P is expected to fail, Q does not depend on P but without
   -- parallel build and without keep-going then we don't build Q yet.
-  (plan1, res1) <- executePlan =<< planProject testdir (config `mappend` keepGoing False)
+  (plan1, res1) <- executePlan =<< planProject testdir (config <> keepGoing False)
   (_, failure1) <- expectPackageFailed plan1 res1 "p-0.1"
   expectBuildFailed failure1
   _ <- expectPackageConfigured plan1 res1 "q-0.1"
@@ -1978,7 +1978,7 @@ testBuildKeepGoing config = do
   -- With keep-going then we should go on to successfully build Q
   (plan2, res2) <-
     executePlan
-      =<< planProject testdir (config `mappend` keepGoing True)
+      =<< planProject testdir (config <> keepGoing True)
   (_, failure2) <- expectPackageFailed plan2 res2 "p-0.1"
   expectBuildFailed failure2
   _ <- expectPackageInstalled plan2 res2 "q-0.1"

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init.hs
@@ -24,9 +24,9 @@ tests :: IO [TestTree]
 tests = do
   confFlags <- loadConfigOrSandboxConfig v defaultGlobalFlags
 
-  let confFlags' = savedConfigureFlags confFlags `mappend` compFlags
-      initFlags' = savedInitFlags confFlags `mappend` emptyFlags
-      globalFlags' = savedGlobalFlags confFlags `mappend` defaultGlobalFlags
+  let confFlags' = savedConfigureFlags confFlags <> compFlags
+      initFlags' = savedInitFlags confFlags <> emptyFlags
+      globalFlags' = savedGlobalFlags confFlags <> defaultGlobalFlags
 
   (comp, _, progdb) <- configCompilerAux' confFlags'
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -176,7 +176,6 @@ instance Monoid Dependencies where
       , depsIsBuildable = True
       , depsExampleDependencies = []
       }
-  mappend = (<>)
 
 dependencies :: [ExampleDependency] -> Dependencies
 dependencies deps = mempty{depsExampleDependencies = deps}

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Types/OptionalStanza.hs
@@ -23,5 +23,5 @@ tests =
       optStanzaTabulate (optStanzaIndex xs) === (xs :: OptionalStanzaMap Int)
   , testProperty "keysFilteredByValue" $ \xs ->
       let set i = if optStanzaIndex xs i then optStanzaSetSingleton i else mempty
-       in optStanzaKeysFilteredByValue id xs === set TestStanzas `mappend` set BenchStanzas
+       in optStanzaKeysFilteredByValue id xs === set TestStanzas <> set BenchStanzas
   ]


### PR DESCRIPTION
Stop defining `mappend`, it's absolutely pointless now, the default definition is good enough. Also stop using it, `(<>)` is shorter and nicer to type.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
