### PR TITLE
Follow hlint suggestion: use bimap

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -14,7 +14,6 @@
 - ignore: {name: "Use :"} # 30 hints
 - ignore: {name: "Use <$>"} # 83 hints
 - ignore: {name: "Use Down"} # 3 hints
-- ignore: {name: "Use bimap"} # 7 hints
 - ignore: {name: "Use camelCase"} # 92 hints
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use fst"} # 2 hints

--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -42,7 +42,7 @@ module Distribution.Simple.BuildTarget
   , reportBuildTargetProblems
   ) where
 
-import Data.Bifunctor (second)
+import Data.Bifunctor (bimap, second)
 import Distribution.Compat.Prelude
 import Prelude ()
 
@@ -421,10 +421,9 @@ reportBuildTargetProblems verbosity problems = do
       dieWithException verbosity $
         AmbiguousBuildTarget $
           map
-            ( \(target, amb) ->
-                ( showUserBuildTarget target
-                , map (\(ut, bt) -> (showUserBuildTarget ut, showBuildTargetKind bt)) amb
-                )
+            ( bimap
+                showUserBuildTarget
+                (map (bimap showUserBuildTarget showBuildTargetKind))
             )
             targets
   where

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -275,6 +275,7 @@ import Distribution.Version
   , foldVersionRange
   )
 
+import Data.Bifunctor (bimap)
 import qualified Data.ByteString as BS
 import Data.Foldable (fold)
 import Distribution.Client.Errors
@@ -1355,7 +1356,7 @@ printBuildFailures verbosity buildOutcomes =
     failed ->
       dieWithException verbosity $
         SomePackagesFailedToInstall $
-          map (\(pkgid, reason) -> (prettyShow pkgid, printFailureReason reason)) failed
+          map (bimap prettyShow printFailureReason) failed
   where
     printFailureReason reason = case reason of
       GracefulFailure msg -> msg

--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -100,7 +100,7 @@ import Control.Arrow ((&&&))
 import Control.Monad hiding
   ( mfilter
   )
-import Data.Bifunctor (second)
+import Data.Bifunctor (bimap, second)
 #if MIN_VERSION_base(4,20,0)
 import Data.Functor as UZ (unzip)
 #else
@@ -807,10 +807,9 @@ reportTargetSelectorProblems verbosity problems = do
           (showTargetSelector originalMatch)
           (showTargetSelectorKind originalMatch)
         $ map
-          ( \(rendering, matches) ->
-              ( showTargetString rendering
-              , map (\match -> showTargetSelector match ++ " (" ++ showTargetSelectorKind match ++ ")") matches
-              )
+          ( bimap
+              showTargetString
+              (map (\match -> showTargetSelector match ++ " (" ++ showTargetSelectorKind match ++ ")"))
           )
           renderingsAndMatches
 
@@ -834,10 +833,9 @@ reportTargetSelectorProblems verbosity problems = do
       dieWithException verbosity $
         TargetSelectorAmbiguousErr $
           map
-            ( \(target, amb) ->
-                ( showTargetString target
-                , map (\(ut, bt) -> (showTargetString ut, showTargetSelectorKind bt)) amb
-                )
+            ( bimap
+                showTargetString
+                (map (bimap showTargetString showTargetSelectorKind))
             )
             targets
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
@@ -22,6 +22,7 @@ import Distribution.Version
 import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM)
 import Data.Array hiding (index)
+import Data.Bifunctor (bimap)
 import Data.Graph
 import Data.IORef
 import Data.List ()
@@ -236,7 +237,7 @@ arbitraryInstallPlan
 arbitraryInstallPlan mkIPkg mkSrcPkg ipkgProportion graph = do
   (ipkgvs, srcpkgvs) <-
     fmap
-      ( (\(ipkgs, srcpkgs) -> (map fst ipkgs, map fst srcpkgs))
+      ( bimap (map fst) (map fst)
           . partition snd
       )
       $ sequenceA


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "use bimap" suggestion so that this will be suggested by our CI linting.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
