### PR TITLE
Follow hlint suggestion: redundant lambda

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -7,7 +7,6 @@
 - ignore: {name: "Redundant $!"} # 3 hints
 - ignore: {name: "Redundant guard"} # 1 hint
 - ignore: {name: "Redundant if"} # 6 hints
-- ignore: {name: "Redundant lambda"} # 16 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant return"} # 7 hints
 - ignore: {name: "Use ++"} # 4 hints

--- a/Cabal/src/Distribution/Compat/Async.hs
+++ b/Cabal/src/Distribution/Compat/Async.hs
@@ -72,7 +72,7 @@ withAsyncNF m = inline withAsyncUsing forkIO (m >>= evaluateNF)
 withAsyncUsing :: (IO () -> IO ThreadId) -> IO a -> (AsyncM a -> IO b) -> IO b
 -- The bracket version works, but is slow.  We can do better by
 -- hand-coding it:
-withAsyncUsing doFork = \action inner -> do
+withAsyncUsing doFork action inner = do
   var <- newEmptyMVar
   mask $ \restore -> do
     t <- doFork $ try (restore action) >>= putMVar var

--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -611,13 +611,13 @@ showComponentKindShort BenchKind = "bench"
 --
 
 matchComponent1 :: [ComponentInfo] -> String -> Match BuildTarget
-matchComponent1 cs = \str1 -> do
+matchComponent1 cs str1 = do
   guardComponentName str1
   c <- matchComponentName cs str1
   return (BuildTargetComponent (cinfoName c))
 
 matchComponent2 :: [ComponentInfo] -> String -> String -> Match BuildTarget
-matchComponent2 cs = \str1 str2 -> do
+matchComponent2 cs str1 str2 = do
   ckind <- matchComponentKind str1
   guardComponentName str2
   c <- matchComponentKindAndName cs ckind str2
@@ -666,7 +666,7 @@ matchComponentKindAndName cs ckind str =
 --
 
 matchModule1 :: [ComponentInfo] -> String -> Match BuildTarget
-matchModule1 cs = \str1 -> do
+matchModule1 cs str1 = do
   guardModuleName str1
   nubMatchErrors $ do
     c <- tryEach cs
@@ -675,7 +675,7 @@ matchModule1 cs = \str1 -> do
     return (BuildTargetModule (cinfoName c) m)
 
 matchModule2 :: [ComponentInfo] -> String -> String -> Match BuildTarget
-matchModule2 cs = \str1 str2 -> do
+matchModule2 cs str1 str2 = do
   guardComponentName str1
   guardModuleName str2
   c <- matchComponentName cs str1

--- a/Cabal/src/Distribution/Simple/GHC/Build/ExtraSources.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/ExtraSources.hs
@@ -171,108 +171,108 @@ buildExtraSources
   ghcProg
   buildTargetDir
   (neededLibWays, neededFLibWay, neededExeWay)
-  verbHandles =
-    \PreBuildComponentInputs{buildingWhat, localBuildInfo = lbi, targetInfo} -> do
-      let
-        bi = componentBuildInfo (targetComponent targetInfo)
-        verbosity = mkVerbosity verbHandles $ buildingWhatVerbosity buildingWhat
-        clbi = targetCLBI targetInfo
-        isIndef = componentIsIndefinite clbi
-        mbWorkDir = mbWorkDirLBI lbi
-        i = interpretSymbolicPath mbWorkDir
-        sources = viewSources (targetComponent targetInfo)
-        comp = compiler lbi
-        platform = hostPlatform lbi
-        tempFileOptions = commonSetupTempFileOptions $ buildingWhatCommonFlags buildingWhat
-        runGhcProg =
-          runGHCWithResponseFile
-            "ghc.rsp"
-            Nothing
-            tempFileOptions
-            verbosity
-            ghcProg
-            comp
-            platform
-            mbWorkDir
+  verbHandles
+  PreBuildComponentInputs{buildingWhat, localBuildInfo = lbi, targetInfo} = do
+    let
+      bi = componentBuildInfo (targetComponent targetInfo)
+      verbosity = mkVerbosity verbHandles $ buildingWhatVerbosity buildingWhat
+      clbi = targetCLBI targetInfo
+      isIndef = componentIsIndefinite clbi
+      mbWorkDir = mbWorkDirLBI lbi
+      i = interpretSymbolicPath mbWorkDir
+      sources = viewSources (targetComponent targetInfo)
+      comp = compiler lbi
+      platform = hostPlatform lbi
+      tempFileOptions = commonSetupTempFileOptions $ buildingWhatCommonFlags buildingWhat
+      runGhcProg =
+        runGHCWithResponseFile
+          "ghc.rsp"
+          Nothing
+          tempFileOptions
+          verbosity
+          ghcProg
+          comp
+          platform
+          mbWorkDir
 
-        buildAction :: SymbolicPath Pkg File -> IO ()
-        buildAction sourceFile = do
-          let baseSrcOpts =
-                componentSourceGhcOptions
-                  (verbosityLevel verbosity)
-                  lbi
-                  bi
-                  clbi
-                  buildTargetDir
-                  sourceFile
-              vanillaSrcOpts =
-                -- -fPIC is used in case you are using the repl
-                -- of a dynamically linked GHC
-                baseSrcOpts{ghcOptFPic = toFlag True}
-              profSrcOpts =
-                vanillaSrcOpts
-                  <> mempty
-                    { ghcOptProfilingMode = toFlag True
-                    }
-              sharedSrcOpts =
-                vanillaSrcOpts
-                  <> mempty
-                    { ghcOptFPic = toFlag True
-                    , ghcOptDynLinkMode = toFlag GhcDynamicOnly
-                    }
-              profSharedSrcOpts =
-                vanillaSrcOpts
-                  <> mempty
-                    { ghcOptProfilingMode = toFlag True
-                    , ghcOptFPic = toFlag True
-                    , ghcOptDynLinkMode = toFlag GhcDynamicOnly
-                    }
-              -- TODO: Placing all Haskell, C, & C++ objects in a single directory
-              --       Has the potential for file collisions. In general we would
-              --       consider this a user error. However, we should strive to
-              --       add a warning if this occurs.
-              odir = fromFlag (ghcOptObjDir vanillaSrcOpts)
+      buildAction :: SymbolicPath Pkg File -> IO ()
+      buildAction sourceFile = do
+        let baseSrcOpts =
+              componentSourceGhcOptions
+                (verbosityLevel verbosity)
+                lbi
+                bi
+                clbi
+                buildTargetDir
+                sourceFile
+            vanillaSrcOpts =
+              -- -fPIC is used in case you are using the repl
+              -- of a dynamically linked GHC
+              baseSrcOpts{ghcOptFPic = toFlag True}
+            profSrcOpts =
+              vanillaSrcOpts
+                <> mempty
+                  { ghcOptProfilingMode = toFlag True
+                  }
+            sharedSrcOpts =
+              vanillaSrcOpts
+                <> mempty
+                  { ghcOptFPic = toFlag True
+                  , ghcOptDynLinkMode = toFlag GhcDynamicOnly
+                  }
+            profSharedSrcOpts =
+              vanillaSrcOpts
+                <> mempty
+                  { ghcOptProfilingMode = toFlag True
+                  , ghcOptFPic = toFlag True
+                  , ghcOptDynLinkMode = toFlag GhcDynamicOnly
+                  }
+            -- TODO: Placing all Haskell, C, & C++ objects in a single directory
+            --       Has the potential for file collisions. In general we would
+            --       consider this a user error. However, we should strive to
+            --       add a warning if this occurs.
+            odir = fromFlag (ghcOptObjDir vanillaSrcOpts)
 
-              compileIfNeeded :: GhcOptions -> IO ()
-              compileIfNeeded opts = do
-                needsRecomp <- checkNeedsRecompilation mbWorkDir sourceFile opts
-                when needsRecomp $ runGhcProg opts
+            compileIfNeeded :: GhcOptions -> IO ()
+            compileIfNeeded opts = do
+              needsRecomp <- checkNeedsRecompilation mbWorkDir sourceFile opts
+              when needsRecomp $ runGhcProg opts
 
-          createDirectoryIfMissingVerbose verbosity True (i odir)
-          case targetComponent targetInfo of
-            -- For libraries, we compile extra objects in the four ways: vanilla, shared, profiled and profiled shared.
-            -- We suffix shared objects with `.dyn_o`, profiled ones with `.p_o` and profiled shared ones with `.p_dyn_o`.
-            CLib _lib
-              -- Unless for repl, in which case we only need the vanilla way
-              | BuildRepl _ <- buildingWhat ->
-                  compileIfNeeded vanillaSrcOpts
-              | otherwise ->
-                  do
-                    forM_ (neededLibWays isIndef) $ \case
-                      StaticWay -> compileIfNeeded vanillaSrcOpts
-                      DynWay -> compileIfNeeded sharedSrcOpts{ghcOptObjSuffix = toFlag "dyn_o"}
-                      ProfWay -> compileIfNeeded profSrcOpts{ghcOptObjSuffix = toFlag "p_o"}
-                      ProfDynWay -> compileIfNeeded profSharedSrcOpts{ghcOptObjSuffix = toFlag "p_dyn_o"}
-            CFLib flib ->
-              case neededFLibWay (withDynFLib flib) of
-                StaticWay -> compileIfNeeded vanillaSrcOpts
-                DynWay -> compileIfNeeded sharedSrcOpts
-                ProfWay -> compileIfNeeded profSrcOpts
-                ProfDynWay -> compileIfNeeded profSharedSrcOpts
-            -- For the remaining component types (Exec, Test, Bench), we also
-            -- determine with which options to build the objects (vanilla vs shared vs
-            -- profiled), but predicate is the same for the three kinds.
-            _exeLike ->
-              case neededExeWay of
-                StaticWay -> compileIfNeeded vanillaSrcOpts
-                DynWay -> compileIfNeeded sharedSrcOpts
-                ProfWay -> compileIfNeeded profSrcOpts
-                ProfDynWay -> compileIfNeeded profSharedSrcOpts
+        createDirectoryIfMissingVerbose verbosity True (i odir)
+        case targetComponent targetInfo of
+          -- For libraries, we compile extra objects in the four ways: vanilla, shared, profiled and profiled shared.
+          -- We suffix shared objects with `.dyn_o`, profiled ones with `.p_o` and profiled shared ones with `.p_dyn_o`.
+          CLib _lib
+            -- Unless for repl, in which case we only need the vanilla way
+            | BuildRepl _ <- buildingWhat ->
+                compileIfNeeded vanillaSrcOpts
+            | otherwise ->
+                do
+                  forM_ (neededLibWays isIndef) $ \case
+                    StaticWay -> compileIfNeeded vanillaSrcOpts
+                    DynWay -> compileIfNeeded sharedSrcOpts{ghcOptObjSuffix = toFlag "dyn_o"}
+                    ProfWay -> compileIfNeeded profSrcOpts{ghcOptObjSuffix = toFlag "p_o"}
+                    ProfDynWay -> compileIfNeeded profSharedSrcOpts{ghcOptObjSuffix = toFlag "p_dyn_o"}
+          CFLib flib ->
+            case neededFLibWay (withDynFLib flib) of
+              StaticWay -> compileIfNeeded vanillaSrcOpts
+              DynWay -> compileIfNeeded sharedSrcOpts
+              ProfWay -> compileIfNeeded profSrcOpts
+              ProfDynWay -> compileIfNeeded profSharedSrcOpts
+          -- For the remaining component types (Exec, Test, Bench), we also
+          -- determine with which options to build the objects (vanilla vs shared vs
+          -- profiled), but predicate is the same for the three kinds.
+          _exeLike ->
+            case neededExeWay of
+              StaticWay -> compileIfNeeded vanillaSrcOpts
+              DynWay -> compileIfNeeded sharedSrcOpts
+              ProfWay -> compileIfNeeded profSrcOpts
+              ProfDynWay -> compileIfNeeded profSharedSrcOpts
 
-      -- build any sources
-      if null sources || componentIsIndefinite clbi
-        then return mempty
-        else do
-          info verbosity ("Building " ++ description ++ "...")
-          traverse_ buildAction sources
-          return (toNubListR sources)
+    -- build any sources
+    if null sources || componentIsIndefinite clbi
+      then return mempty
+      else do
+        info verbosity ("Building " ++ description ++ "...")
+        traverse_ buildAction sources
+        return (toNubListR sources)

--- a/Cabal/src/Distribution/Simple/SrcDist.hs
+++ b/Cabal/src/Distribution/Simple/SrcDist.hs
@@ -429,7 +429,7 @@ filterAutogenModules pkg_descr0 =
         }
     pathsModule = autogenPathsModuleName pkg_descr0
     packageInfoModule = autogenPackageInfoModuleName pkg_descr0
-    filterFunction bi = \mn ->
+    filterFunction bi mn =
       mn /= pathsModule
         && mn /= packageInfoModule
         && notElem mn (autogenModules bi)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
@@ -254,21 +254,21 @@ enforcePackageConstraints pcs = go
     go (PChoiceF qpn@(Q _ pn) rdm gr                    ts) =
       let c = varToConflictSet (P qpn)
           -- compose the transformation functions for each of the relevant constraint
-          g = \ (POption i _) -> foldl (\ h pc -> h . processPackageConstraintP qpn c i pc)
+          g (POption i _) = foldl (\ h pc -> h . processPackageConstraintP qpn c i pc)
                                        id
                                        (M.findWithDefault [] pn pcs)
       in PChoiceF qpn rdm gr        (W.mapWithKey g ts)
     go (FChoiceF qfn@(FN qpn@(Q _ pn) f) rdm gr tr m d ts) =
       let c = varToConflictSet (F qfn)
           -- compose the transformation functions for each of the relevant constraint
-          g = \ b -> foldl (\ h pc -> h . processPackageConstraintF qpn f c b pc)
+          g b = foldl (\ h pc -> h . processPackageConstraintF qpn f c b pc)
                            id
                            (M.findWithDefault [] pn pcs)
       in FChoiceF qfn rdm gr tr m d (W.mapWithKey g ts)
     go (SChoiceF qsn@(SN qpn@(Q _ pn) f) rdm gr tr   ts) =
       let c = varToConflictSet (S qsn)
           -- compose the transformation functions for each of the relevant constraint
-          g = \ b -> foldl (\ h pc -> h . processPackageConstraintS qpn f c b pc)
+          g b = foldl (\ h pc -> h . processPackageConstraintS qpn f c b pc)
                            id
                            (M.findWithDefault [] pn pcs)
       in SChoiceF qsn rdm gr tr     (W.mapWithKey g ts)

--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -2082,7 +2082,7 @@ guardPackageFile _ (FileStatusExistsFile file)
 guardPackageFile str _ = matchErrorExpected "package .cabal file" str
 
 matchPackage :: [KnownPackage] -> String -> FileStatus -> Match KnownPackage
-matchPackage pinfo = \str fstatus ->
+matchPackage pinfo str fstatus =
   orNoThingIn "project" "" $
     matchPackageName pinfo str
       </> ( matchPackageNameUnknown str
@@ -2091,7 +2091,7 @@ matchPackage pinfo = \str fstatus ->
           )
 
 matchPackageName :: [KnownPackage] -> String -> Match KnownPackage
-matchPackageName ps = \str -> do
+matchPackageName ps str = do
   guard (validPackageName str)
   orNoSuchThing
     "package"

--- a/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
@@ -78,7 +78,7 @@ testHttp = withFakeRepoCtxt get200 $ \repoCtxt repo -> do
       pkgId' @?= pkgId
     _ -> assertFailure $ "expected RepoTarballPackage, got " ++ show res
   where
-    get200 = \_uri -> return 200
+    get200 _uri = return 200
 
 testGetInterrupt :: Assertion
 testGetInterrupt = testGetAny UserInterrupt

--- a/cabal-install/tests/UnitTests/Distribution/Client/Tar.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Tar.hs
@@ -1,23 +1,13 @@
-module UnitTests.Distribution.Client.Tar
-  ( tests
-  ) where
+module UnitTests.Distribution.Client.Tar (tests) where
 
-import Codec.Archive.Tar
-  ( foldEntries
-  )
-import Codec.Archive.Tar.Entry
-  ( simpleEntry
-  , toTarPath
-  )
-import Distribution.Client.Tar
-  ( filterEntries
-  , filterEntriesM
-  )
+import Codec.Archive.Tar (GenEntry, foldEntries)
+import Codec.Archive.Tar.Entry (simpleEntry, toTarPath)
+import Distribution.Client.Tar (filterEntries, filterEntriesM)
 
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Control.Monad.Writer.Lazy (runWriterT, tell)
+import Control.Monad.Writer.Lazy (WriterT, runWriterT, tell)
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 
@@ -33,24 +23,17 @@ filterTest :: Assertion
 filterTest = do
   let e1 = getFileEntry "file1" "x"
       e2 = getFileEntry "file2" "y"
-      p =
-        ( \e ->
-            let str = BS.Char8.unpack $ case entryContent e of
-                  NormalFile dta _ -> dta
-                  _ -> error "Invalid entryContent"
-             in str /= "y"
-        )
   assertEqual "Unexpected result for filter" "xz" $
     entriesToString $
-      filterEntries p $
+      filterEntries unpackCheck $
         Next e1 $
           Next e2 Done
   assertEqual "Unexpected result for filter" "z" $
     entriesToString $
-      filterEntries p Done
+      filterEntries unpackCheck Done
   assertEqual "Unexpected result for filter" "xf" $
     entriesToString $
-      filterEntries p $
+      filterEntries unpackCheck $
         Next e1 $
           Next e2 $
             Fail "f"
@@ -59,23 +42,15 @@ filterMTest :: Assertion
 filterMTest = do
   let e1 = getFileEntry "file1" "x"
       e2 = getFileEntry "file2" "y"
-      p =
-        ( \e ->
-            let str = BS.Char8.unpack $ case entryContent e of
-                  NormalFile dta _ -> dta
-                  _ -> error "Invalid entryContent"
-             in tell "t" >> return (str /= "y")
-        )
-
-  (r, w) <- runWriterT $ filterEntriesM p $ Next e1 $ Next e2 Done
+  (r, w) <- runWriterT $ filterEntriesM unpackCheckM $ Next e1 $ Next e2 Done
   assertEqual "Unexpected result for filterM" "xz" $ entriesToString r
   assertEqual "Unexpected result for filterM w" "tt" w
 
-  (r1, w1) <- runWriterT $ filterEntriesM p Done
+  (r1, w1) <- runWriterT $ filterEntriesM unpackCheckM Done
   assertEqual "Unexpected result for filterM" "z" $ entriesToString r1
   assertEqual "Unexpected result for filterM w" "" w1
 
-  (r2, w2) <- runWriterT $ filterEntriesM p $ Next e1 $ Next e2 $ Fail "f"
+  (r2, w2) <- runWriterT $ filterEntriesM unpackCheckM $ Next e1 $ Next e2 $ Fail "f"
   assertEqual "Unexpected result for filterM" "xf" $ entriesToString r2
   assertEqual "Unexpected result for filterM w" "tt" w2
 
@@ -88,14 +63,16 @@ getFileEntry pth dta =
       Left e -> error e
     dta' = BS.Char8.pack dta
 
+unpackNormalFile :: GenEntry BS.ByteString tarPath linkTarget -> String
+unpackNormalFile e = BS.Char8.unpack $ case entryContent e of
+  NormalFile dta _ -> dta
+  _ -> error "Invalid entryContent"
+
+unpackCheck :: GenEntry BS.ByteString tarPath linkTarget -> Bool
+unpackCheck e = unpackNormalFile e /= "y"
+
+unpackCheckM :: GenEntry BS.ByteString tarPath linkTarget -> WriterT String IO Bool
+unpackCheckM e = tell "t" >> return (unpackCheck e)
+
 entriesToString :: Entries String -> String
-entriesToString =
-  foldEntries
-    ( \e acc ->
-        let str = BS.Char8.unpack $ case entryContent e of
-              NormalFile dta _ -> dta
-              _ -> error "Invalid entryContent"
-         in str ++ acc
-    )
-    "z"
-    id
+entriesToString = foldEntries (\e acc -> unpackNormalFile e ++ acc) "z" id

--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/basic/basic/Basic.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/basic/basic/Basic.hs
@@ -1,7 +1,7 @@
 module Basic where
 
 funcs :: (a -> b -> c) -> ((a -> b -> c) -> a -> b -> c) -> b -> a -> c
-funcs f g = \a b -> g f b a
+funcs f g a b = g f b a
 
 name :: String
 name = "Basic"


### PR DESCRIPTION
See #9110. Discharges and no longer ignores HLint's "redundant lamda" suggestion so that this will be suggested by our CI linting.

I'll squash commits before applying the merge label if this pull request is approved. I've left these commits so that restyling after HLint suggestion can be reviewed by itself, the one that changes only indentation.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
