### PR TITLE
Monad of no Return

### DIFF
--- a/Cabal-syntax/src/Distribution/Fields/LexerMonad.hs
+++ b/Cabal-syntax/src/Distribution/Fields/LexerMonad.hs
@@ -55,7 +55,6 @@ instance Applicative Lex where
   (<*>) = ap
 
 instance Monad Lex where
-  return = pure
   (>>=) = thenLex
 
 data LexResult a = LexResult {-# UNPACK #-} !LexState a

--- a/Cabal-syntax/src/Distribution/Fields/ParseResult.hs
+++ b/Cabal-syntax/src/Distribution/Fields/ParseResult.hs
@@ -128,7 +128,6 @@ instance Applicative (ParseResult src) where
   {-# INLINE (<*) #-}
 
 instance Monad (ParseResult src) where
-  return = pure
   (>>) = (*>)
 
   m >>= k = PR $ \ !s fp failure success ->

--- a/Cabal-syntax/src/Distribution/Parsec.hs
+++ b/Cabal-syntax/src/Distribution/Parsec.hs
@@ -145,8 +145,6 @@ instance Alternative ParsecParser where
   {-# INLINE some #-}
 
 instance Monad ParsecParser where
-  return = pure
-
   m >>= k = PP $ \v -> unPP m v >>= \x -> unPP (k x) v
   {-# INLINE (>>=) #-}
   (>>) = (*>)

--- a/Cabal-syntax/src/Distribution/Types/Condition.hs
+++ b/Cabal-syntax/src/Distribution/Types/Condition.hs
@@ -73,8 +73,6 @@ instance Applicative Condition where
   (<*>) = ap
 
 instance Monad Condition where
-  return = pure
-
   -- Terminating cases
   (>>=) (Lit x) _ = Lit x
   (>>=) (Var x) f = f x

--- a/Cabal/src/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/src/Distribution/Backpack/ReadyComponent.hs
@@ -218,7 +218,6 @@ instance Applicative InstM where
      in (f' x', s'')
 
 instance Monad InstM where
-  return = pure
   InstM m >>= f = InstM $ \s ->
     let (x, s') = m s
      in runInstM (f x) s'

--- a/Cabal/src/Distribution/Backpack/UnifyM.hs
+++ b/Cabal/src/Distribution/Backpack/UnifyM.hs
@@ -152,7 +152,6 @@ instance Applicative (UnifyM s) where
           Just x'' -> return (Just (f'' x''))
 
 instance Monad (UnifyM s) where
-  return = pure
   UnifyM m >>= f = UnifyM $ \r -> do
     x <- m r
     case x of

--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -908,8 +908,6 @@ instance Applicative Match where
   (<*>) = ap
 
 instance Monad Match where
-  return = pure
-
   NoMatch d ms >>= _ = NoMatch d ms
   ExactMatch d xs >>= f =
     addDepth d $

--- a/Cabal/src/Distribution/Utils/LogProgress.hs
+++ b/Cabal/src/Distribution/Utils/LogProgress.hs
@@ -41,7 +41,6 @@ instance Applicative LogProgress where
   LogProgress f <*> LogProgress x = LogProgress $ \r -> f r `ap` x r
 
 instance Monad LogProgress where
-  return = pure
   LogProgress m >>= f = LogProgress $ \r -> m r >>= \x -> unLogProgress (f x) r
 
 -- | Run 'LogProgress', outputting traces according to 'Verbosity',

--- a/Cabal/src/Distribution/Utils/Progress.hs
+++ b/Cabal/src/Distribution/Utils/Progress.hs
@@ -57,7 +57,6 @@ foldProgress step err done = fold
     fold (Done r) = done r
 
 instance Monad (Progress step fail) where
-  return = pure
   p >>= f = foldProgress Step Fail f p
 
 instance Applicative (Progress step fail) where

--- a/Cabal/src/Distribution/ZinzaPrelude.hs
+++ b/Cabal/src/Distribution/ZinzaPrelude.hs
@@ -33,7 +33,6 @@ instance Applicative Writer where
   (<*>) = ap
 
 instance Monad Writer where
-  return = pure
   m >>= k = W $ \s1 ->
     let (s2, x) = unW m s1
      in unW (k x) s2

--- a/cabal-install-solver/src/Distribution/Solver/Types/Progress.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Progress.hs
@@ -36,7 +36,6 @@ foldProgress step' fail' done' = fold
         fold (Done r)   = done' r
 
 instance Monad (Progress step fail) where
-  return   = pure
   p >>= f  = foldProgress Step Fail f p
 
 instance MonadFail (Progress step String) where

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -330,7 +330,6 @@ instance Applicative PurePrompt where
       Right (a, s'') -> Right (f a, s'')
 
 instance Monad PurePrompt where
-  return = pure
   PurePrompt a >>= k = PurePrompt $ \s -> case a s of
     Left e -> Left e
     Right (a', s') -> runPromptState (k a') s'

--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -2365,7 +2365,6 @@ instance Alternative Match where
   (<|>) = matchPlus
 
 instance Monad Match where
-  return = pure
   NoMatch d ms >>= _ = NoMatch d ms
   Match m d xs >>= f =
     -- To understand this, it needs to be read in context with the

--- a/cabal-install/src/Distribution/Deprecated/ParseUtils.hs
+++ b/cabal-install/src/Distribution/Deprecated/ParseUtils.hs
@@ -124,7 +124,6 @@ instance Applicative ParseResult where
   (<*>) = ap
 
 instance Monad ParseResult where
-  return = pure
   ParseFailed err >>= _ = ParseFailed err
   ParseOk ws x >>= f = case f x of
     ParseFailed err -> ParseFailed err

--- a/cabal-install/src/Distribution/Deprecated/ProjectParseUtils.hs
+++ b/cabal-install/src/Distribution/Deprecated/ProjectParseUtils.hs
@@ -41,7 +41,6 @@ instance Applicative ProjectParseResult where
   (<*>) = ap
 
 instance Monad ProjectParseResult where
-  return = pure
   ProjectParseFailed err >>= _ = ProjectParseFailed err
   ProjectParseOk ws x >>= f = case f x of
     ProjectParseFailed err -> ProjectParseFailed err


### PR DESCRIPTION
Defining `return` serves no purpose, let's clean it up. Also cf. https://github.com/haskell/core-libraries-committee/issues/418

**Template B: This PR does not modify behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
