### PR TITLE
Re #11498 Better document Cabal's --semaphore=SEMAPHORE option

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Build.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Build.hs
@@ -151,7 +151,7 @@ buildOptions progDb showOrParseArgs =
     , option
         []
         ["semaphore"]
-        "Use the specified semaphore so GHC can compile components in parallel"
+        "Use the specified semaphore identifier so GHC can compile components in parallel"
         buildUseSemaphore
         (\v flags -> flags{buildUseSemaphore = v})
         (reqArg' "SEMAPHORE" Flag flagToList)

--- a/changelog.d/pr-12022.md
+++ b/changelog.d/pr-12022.md
@@ -1,0 +1,10 @@
+synopsis: Better document Cabal's `--semaphore=SEMAPHORE` option in light of `semaphore-compat-2.0.0`
+packages: Cabal
+prs: #12022
+significance:
+
+description: {
+
+- Cabal's `--semaphore=SEMAPHORE` option is better documented in the user's guide and in `--help`.
+
+}

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -1091,8 +1091,17 @@ This command takes the following options:
 
     GHC 9.8.1 and later can act as a jobserver client, which enables two or more
     GHC processes running at once to share system resources with each other,
-    communicating via a specified system semaphore. The system semaphore is
-    identified by a name (a string).
+    communicating via a semaphore, as implemented by the
+    `semaphore-compat <https://hackage.haskell.org/package/semaphore-compat>`_
+    library.
+    
+    The expected usage is that a jobserver (the build system controlling the build,
+    e.g. ``cabal-install``, ``stack``, ``nix``, ``buck2``...) creates or obtains a semaphore using ``semaphore-compat``,
+    passing down the semaphore to jobclients in order to control the total
+    amount of parallelism. This is done by passing the corresponding semaphore identifier to ``Cabal`` via the ``--semaphore`` flag.
+    
+    Refer to `semaphore-compat <https://hackage.haskell.org/package/semaphore-compat>`_
+    for more details.
 
     This option causes Cabal to control parallelism by using the specified
     system semaphore.

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -1089,22 +1089,22 @@ This command takes the following options:
 
     :since: 3.12.0.0
 
+    This option causes Cabal to control parallelism by using the specified
+    semaphore.
+
     GHC 9.8.1 and later can act as a jobserver client, which enables two or more
     GHC processes running at once to share system resources with each other,
-    communicating via a semaphore, as implemented by the
-    `semaphore-compat <https://hackage.haskell.org/package/semaphore-compat>`_
-    library.
-    
-    The expected usage is that a jobserver (the build system controlling the build,
-    e.g. ``cabal-install``, ``stack``, ``nix``, ``buck2``...) creates or obtains a semaphore using ``semaphore-compat``,
-    passing down the semaphore to jobclients in order to control the total
-    amount of parallelism. This is done by passing the corresponding semaphore identifier to ``Cabal`` via the ``--semaphore`` flag.
-    
-    Refer to `semaphore-compat <https://hackage.haskell.org/package/semaphore-compat>`_
-    for more details.
+    communicating via a semaphore.
 
-    This option causes Cabal to control parallelism by using the specified
-    system semaphore.
+    The expected use is that the system controlling the build (e.g.
+    ``cabal-install``, ``stack``, ``nix`` or ``buck2``) (a jobserver) creates or
+    obtains a semaphore using the ``semaphore-compat`` library. It then passes
+    the semaphore to jobserver clients in order to control the amount of
+    parallelism. This is done by passing the corresponding semaphore identifier
+    to Cabal via the ``--semaphore`` option.
+
+    For more information, see
+    `semaphore-compat <https://hackage.haskell.org/package/semaphore-compat>`_.
 
 .. _setup-haddock:
 


### PR DESCRIPTION
EDIT: To be clear, this is only about documenting Cabal (the library) under `runhaskell Setup.hs build` and not about the executable provided by the `cabal-install` package.

This is follows GHC's dependency on `semaphore-compat-2.0.0` (first reflected in GHC 9.12.5-rc2).

The terminology of the dependency package now:
* introduces the concept of protocol versions for semaphores (there remains only one protocol version on Windows);
* distinguishes server semaphores and corresponding client semaphores; and
* distinguishes unversioned client semaphore names and client semaphore identifiers.

This conforms the language in Cabal's User Guide to that of the package.

**This PR does not modify behaviour or interface**
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). N/A