### PR TITLE
feat!: Store logs under XDG_STATE_HOME

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -828,7 +828,7 @@ defaultStoreDir =
 
 defaultLogsDir :: IO FilePath
 defaultLogsDir =
-  getDefaultDir XdgCache "logs"
+  getDefaultDir XdgState "logs"
 
 defaultReportsDir :: IO FilePath
 defaultReportsDir =

--- a/changelog.d/pr-12051.md
+++ b/changelog.d/pr-12051.md
@@ -1,0 +1,9 @@
+---
+synopsis: Store logs under XDG_STATE_HOME instead of XDG_CACHE_HOME
+packages: [cabal-install]
+prs: 12051
+---
+
+- before: logs are stored under `${XDG_CACHE_HOME:-$HOME/.cache}/cabal/logs`
+- after: logs are stored under `${XDG_STATE_HOME:-$HOME/.local/state}/cabal/logs`
+- ref: <https://specifications.freedesktop.org/basedir/0.8/#variables>

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -743,7 +743,7 @@ installed binaries, and so on.
     compiler-store-path: /home/alice/.local/state/cabal/store/ghc-9.8.2
     cache-home: /home/alice/.cache/cabal
     remote-repo-cache: /home/alice/.cache/cabal/packages
-    logs-dir: /home/alice/.cache/cabal/logs
+    logs-dir: /home/alice/.local/state/cabal/logs
     store-dir: /home/alice/.local/state/cabal/store
     config-file: /home/alice/.config/cabal/config
     installdir: /home/alice/.local/bin
@@ -767,7 +767,7 @@ Or using the json output:
       },
       "cache-home": "/home/alice/.cache/cabal",
       "remote-repo-cache": "/home/alice/.cache/cabal/packages",
-      "logs-dir": "/home/alice/.cache/cabal/logs",
+      "logs-dir": "/home/alice/.local/state/cabal/logs",
       "store-dir": "/home/alice/.local/state/cabal/store",
       "config-file": "/home/alice/.config/cabal/config",
       "installdir": "/home/alice/.local/bin"

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -267,7 +267,7 @@ cabal preferences. It is very useful when you are e.g. first configuring
 
   .. option:: --config-file=PATH
 
-      Specify config file path. (default: ``~/.cabal/config``).
+      Specify config file path. (default: ``~/.config/cabal/config``).
 
   .. option:: -f, --force
 
@@ -738,13 +738,15 @@ installed binaries, and so on.
     $ cabal path
     compiler-flavour: ghc
     compiler-id: ghc-9.8.2
+    compiler-abi-tag: ghc-9.8.2
     compiler-path: /home/alice/.ghcup/bin/ghc
-    cache-home: /home/alice/.cabal
-    remote-repo-cache: /home/alice/.cabal/packages
-    logs-dir: /home/alice/.cabal/logs
-    store-dir: /home/alice/.cabal/store
-    config-file: /home/alice/.cabal/config
-    installdir: /home/alice/.cabal/bin
+    compiler-store-path: /home/alice/.local/state/cabal/store/ghc-9.8.2
+    cache-home: /home/alice/.cache/cabal
+    remote-repo-cache: /home/alice/.cache/cabal/packages
+    logs-dir: /home/alice/.cache/cabal/logs
+    store-dir: /home/alice/.local/state/cabal/store
+    config-file: /home/alice/.config/cabal/config
+    installdir: /home/alice/.local/bin
 
 Or using the json output:
 
@@ -755,18 +757,20 @@ Or using the json output:
 .. code-block:: json
 
     {
-      "cabal-version": "3.13.0.0",
+      "cabal-version": "3.17.0.0",
       "compiler": {
         "flavour": "ghc",
         "id": "ghc-9.8.2",
-        "path": "/home/alice/.ghcup/bin/ghc"
+        "abi-tag": "ghc-9.8.2",
+        "path": "/home/alice/.ghcup/bin/ghc",
+        "store-path": "/home/alice/.local/state/cabal/store/ghc-9.8.2"
       },
-      "cache-home": "/home/alice/.cabal",
-      "remote-repo-cache": "/home/alice/.cabal/packages",
-      "logs-dir": "/home/alice/.cabal/logs",
-      "store-dir": "/home/alice/.cabal/store",
-      "config-file": "/home/alice/.cabal/config",
-      "installdir": "/home/alice/.cabal/bin"
+      "cache-home": "/home/alice/.cache/cabal",
+      "remote-repo-cache": "/home/alice/.cache/cabal/packages",
+      "logs-dir": "/home/alice/.cache/cabal/logs",
+      "store-dir": "/home/alice/.local/state/cabal/store",
+      "config-file": "/home/alice/.config/cabal/config",
+      "installdir": "/home/alice/.local/bin"
     }
 
 If ``cabal path`` is passed a single option naming a path, then that
@@ -775,7 +779,7 @@ path will be printed *without* any label:
 ::
 
    $ cabal path --installdir
-   /home/alice/.cabal/bin
+   /home/alice/.local/bin
 
 While this interface is intended to be used for scripting, it is an experimental command.
 Scripting example:

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -879,7 +879,7 @@ Build options
                --logs-dir=DIR
     :synopsis: Directory to store build logs.
 
-    :default: ``~/.cache/cabal/logs``
+    :default: ``~/.local/state/cabal/logs``
 
     :strike:`The location where build logs for packages are stored.`
     Not implemented yet.
@@ -890,7 +890,7 @@ Build options
                --build-summary=TEMPLATE
     :synopsis: Build summaries location.
 
-    :default: ``~/.cache/cabal/logs/build.log``
+    :default: ``~/.local/state/cabal/logs/build.log``
 
     :strike:`The file to save build summaries.` Not implemented yet.
 

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -879,7 +879,7 @@ Build options
                --logs-dir=DIR
     :synopsis: Directory to store build logs.
 
-    :default: ``~/.cabal/logs``
+    :default: ``~/.cache/cabal/logs``
 
     :strike:`The location where build logs for packages are stored.`
     Not implemented yet.
@@ -890,7 +890,7 @@ Build options
                --build-summary=TEMPLATE
     :synopsis: Build summaries location.
 
-    :default: ``~/.cabal/logs/build.log``
+    :default: ``~/.cache/cabal/logs/build.log``
 
     :strike:`The file to save build summaries.` Not implemented yet.
 
@@ -1976,7 +1976,7 @@ Advanced global options
                --remote-repo-cache=DIR
     :synopsis: Location of packages cache.
 
-    :default: ``~/.cabal/packages``
+    :default: ``~/.cache/cabal/packages``
 
     The location where packages downloaded from remote repositories will be
     cached.


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir/0.8/#variables:

> The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:
>
> * actions history (logs, history, recently used files, …)
> * current state of the application that can be reused on a restart (view, layout, open files, undo history, …)

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

<!--
---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
-->