### PR TITLE
Fix `runRuleDynDepsCmd` binary format mismatch

### DIFF
--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/DynDep.c
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/DynDep.c
@@ -1,0 +1,4 @@
+
+int abccd(int x) {
+  return (x * 32);
+}

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/Main.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/Main.hs
@@ -8,7 +8,10 @@ import A (bobble, isNeeded)
 
 foreign import ccall razzle :: CInt -> CInt
 
+foreign import ccall abccd :: CInt -> CInt
+
 main = do
   print bobble
   print $ razzle 3
   print $ isNeeded 77
+  print $ abccd 1

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/SetupHooks.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/SetupHooks.hs
@@ -13,7 +13,7 @@ module SetupHooks where
 import Distribution.Compat.Binary
 import Distribution.ModuleName
 import Distribution.Simple.LocalBuildInfo
-  ( interpretSymbolicPathLBI )
+  ( interpretSymbolicPathLBI, mbWorkDirLBI )
 import Distribution.Simple.SetupHooks
 import Distribution.Simple.Utils
 import Distribution.Types.LocalBuildInfo
@@ -65,7 +65,8 @@ pcc (PreConfComponentInputs _lbc pbd _comp) =
             --    recompilation checking.
             emptyBuildInfo
               { cSources = [ autogenDir </> unsafeMakeSymbolicPath "Gen.c"
-                           , autogenDir </> unsafeMakeSymbolicPath "Gen2.c"]
+                           , autogenDir </> unsafeMakeSymbolicPath "Gen2.c"
+                           , autogenDir </> unsafeMakeSymbolicPath "DynDep.c"]
               }
         }
   where
@@ -77,6 +78,7 @@ preBuildRules (PreBuildComponentInputs { buildingWhat = what, localBuildInfo = l
       clbi = targetCLBI tgt
       autogenDir = autogenComponentModulesDir lbi clbi
       buildDir = componentBuildDir lbi clbi
+      mbWorkDir = mbWorkDirLBI lbi
 
       runPpAction1 (PpInput {..}) = do
         let verbosity = mkVerbosity defaultVerbosityHandles verbosityFlags
@@ -131,6 +133,18 @@ preBuildRules (PreBuildComponentInputs { buildingWhat = what, localBuildInfo = l
         warn verbosity "Running MyPp4"
         rewriteFileEx verbosity (getSymbolicPath genDir </> "GenLib.a") ""
 
+      runDynPpDependencyAction5 :: PpInput -> IO ([Dependency], ())
+      runDynPpDependencyAction5 (PpInput {..}) = do
+        let verbosity = mkVerbosity defaultVerbosityHandles verbosityFlags
+        warn verbosity "Running DynMyPpDependency5"
+        pure ([FileDependency $ Location sameDirectory (unsafeMakeSymbolicPath "DynDep.c")], ())
+
+      runDynPpAction5 :: PpInput -> () -> IO ()
+      runDynPpAction5 (PpInput {..}) () = do
+        let verbosity = mkVerbosity defaultVerbosityHandles verbosityFlags
+        warn verbosity "Running DynMyPp5"
+        copyFileToCwd verbosity mbWorkDir genDir (makeRelativePathEx "DynDep.c")
+
       mkRule1 =
         staticRule
           (mkCommand (static Dict) (static runPpAction1) $ PpInput {genDir = autogenDir, ..})
@@ -157,16 +171,24 @@ preBuildRules (PreBuildComponentInputs { buildingWhat = what, localBuildInfo = l
           [ ]
           ( Location autogenDir (unsafeMakeSymbolicPath "GenLib.a") NE.:| [] )
 
+      depsCmd = mkCommand (static Dict) (static runDynPpDependencyAction5) $ PpInput {genDir = autogenDir, ..}
+      genCmd = mkCommand (static Dict) (static runDynPpAction5) $ PpInput {genDir = autogenDir, ..}
+      output = Location autogenDir (unsafeMakeSymbolicPath "DynDep.c")
+      mkRule5 =
+        dynamicRule (static Dict) depsCmd genCmd [] (output NE.:| [])
+
   r1 <- registerRule "MyPP1" mkRule1
   void $ registerRule "MyPP2" (mkRule2 r1)
   void $ registerRule "MyPP3" mkRule3
   void $ registerRule "MyPP4" mkRule4
+  void $ registerRule "DynMyPP5" mkRule5
 
 -- | Input to preprocessor command
 data PpInput
   = PpInput
   { verbosityFlags :: VerbosityFlags
   , genDir         :: SymbolicPath Pkg (Dir Source)
+  , mbWorkDir      :: Maybe (SymbolicPath CWD (Dir Pkg))
   }
   deriving stock ( Show, Generic )
   deriving anyclass Binary

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/cabal.out
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNonHs/cabal.out
@@ -4,11 +4,13 @@ Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - setup-hooks-non-hs-rules-test-0.1.0.0 (exe:NonHs) (first run)
 Configuring setup-hooks-non-hs-rules-test-0.1.0.0...
+Warning: Running DynMyPpDependency5
 Warning: Running MyPp4
 Warning: Running MyPp3
 Warning: "cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/setup-hooks-non-hs-rules-test-0.1.0.0/build/NonHs/autogen"
 Warning: Running MyPp1
 Warning: Running MyPp2
+Warning: Running DynMyPp5
 Preprocessing executable 'NonHs' for setup-hooks-non-hs-rules-test-0.1.0.0...
 Building executable 'NonHs' for setup-hooks-non-hs-rules-test-0.1.0.0...
 # cabal run
@@ -17,10 +19,12 @@ Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - setup-hooks-non-hs-rules-test-0.1.0.0 (exe:NonHs) (first run)
 Configuring setup-hooks-non-hs-rules-test-0.1.0.0...
+Warning: Running DynMyPpDependency5
 Warning: Running MyPp4
 Warning: Running MyPp3
 Warning: "<ROOT>/cabal.dist/work/./inner/dist/build/<ARCH>/ghc-<GHCVER>/setup-hooks-non-hs-rules-test-0.1.0.0/build/NonHs/autogen"
 Warning: Running MyPp1
 Warning: Running MyPp2
+Warning: Running DynMyPp5
 Preprocessing executable 'NonHs' for setup-hooks-non-hs-rules-test-0.1.0.0...
 Building executable 'NonHs' for setup-hooks-non-hs-rules-test-0.1.0.0...

--- a/changelog.d/issue-12053
+++ b/changelog.d/issue-12053
@@ -1,0 +1,21 @@
+synopsis: Fixed binary format mismatch resulting in `runRuleDynDepsCmd` build error
+packages: Cabal-hooks
+prs: #12054
+issues: #12053
+
+description: {
+
+A build containing a `dynamicRule` would fail with the following error:
+
+```
+Error: [Cabal-7125]
+Failed to build hooks-0.1.0.0. The exception was:
+  Missing ByteString argument in 'ruleExecCmd'.
+Run 'runRuleDynDepsCmd' on the rule to obtain this data.
+```
+
+This was caused by a mismatch between the binary formats used to encode and decode the rules.
+The hook produced a result of type `([Dependency], LBS.ByteString)`, which was then encoded into a `Binary` blob.
+However, `hooks-exe` decoded this data as `Maybe ([Dependency], LBS.ByteString)`, causing the build error.
+
+}

--- a/hooks-exe/cli/Distribution/Client/SetupHooks/CallHooksExe.hs
+++ b/hooks-exe/cli/Distribution/Client/SetupHooks/CallHooksExe.hs
@@ -218,7 +218,7 @@ runExternalPreBuildRules verbHandles hooksExe
     SSystem
     ( \ rId cmd -> case cmd of
       StaticRuleCommand {} -> return Nothing
-      DynamicRuleCommands {} -> hook "runPreBuildRuleDeps" (rId, cmd)
+      DynamicRuleCommands {} -> Just <$> hook "runPreBuildRuleDeps" (rId, cmd)
     )
     ( \ rId cmd -> hook "runPreBuildRule" (rId, cmd) )
     verbosity lbi tgt rulesMap


### PR DESCRIPTION
This change fixes the binary format mismatch between the build rules producer and the consumer, resulting in
`Missing ByteString argument in 'ruleExecCmd'` error during builds. When a hook creates a dynamic hook with a command for discovering dynamic dependencies, the hook creates a result of type `([Dependency], LBS.ByteString)`, but the consumer decodes it as `Maybe ([Dependency], LBS.ByteString)`.

Added a test case to SetupHooksNonHs that covers this scenario.

Fixes #12053

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
