### PR TITLE
cabal-install: base <4.22 is still non-reinstallable

### DIFF
--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -453,6 +453,14 @@ dependOnWiredIns compiler params = addConstraints extraConstraints params
         ConstraintSourceNonReinstallablePackage
       | (pkgName, unitId) <- fromMaybe [] $ compilerInfoWiredInUnitIds compiler
       ]
+        ++
+        -- Old versions of `base` must be excluded from build plans still as they do not depend on any version of a wired-in unit.
+        -- If we do not do this then we will get confusing error messages about old versions of `base` being unbuildable.
+        -- Newer versions of `base` will be handled gracefully as they were designed to be reinstallable.
+        [ LabeledPackageConstraint
+            (PackageConstraint (ScopeAnyQualifier $ mkPackageName "base") (PackagePropertyVersion (orLaterVersion (mkVersion [4, 22]))))
+            ConstraintSourceNonReinstallablePackage
+        ]
 
 -- | Some packages are specific to a given compiler version and should never be
 -- reinstalled.

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -201,7 +201,7 @@ tests =
       "Non-reinstallable base, template-haskell and ghc (GHC without wiredInUnitIds)"
       [ runTest $
           mkTest dbBase "Refuse to install base without --allow-boot-library-installs" ["base"] $
-            solverFailure (isInfixOf "rejecting: base-1 (constraint from non-reinstallable package requires installed instance)")
+            solverFailure (isInfixOf "rejecting: base-5 (constraint from non-reinstallable package requires installed instance)")
       , runTest $
           mkTest dbTH "Refuse to install template-haskell without --allow-boot-library-installs" ["template-haskell"] $
             solverFailure (isInfixOf "rejecting: template-haskell-1 (constraint from non-reinstallable package requires installed instance)")
@@ -211,18 +211,18 @@ tests =
       , runTest $
           allowBootLibInstalls $
             mkTest dbBase "Install base with --allow-boot-library-installs" ["base"] $
-              solverSuccess [("base", 1), ("ghc-prim", 1), ("integer-gmp", 1), ("integer-simple", 1)]
+              solverSuccess [("base", 5), ("ghc-prim", 1), ("integer-gmp", 1), ("integer-simple", 1)]
       ]
   , testGroup
       "Reinstallable base, template-haskell, but not ghc{,-internal} (GHC with wiredInUnitIds)"
       [ runTest $
           wiredInUnitIds $
             mkTest dbBase "Allows reinstalling base even without --allow-boot-library-installs" ["base"] $
-              solverSuccess [("base", 1), ("ghc-prim", 1), ("integer-gmp", 1), ("integer-simple", 1)]
+              solverSuccess [("base", 5), ("ghc-prim", 1), ("integer-gmp", 1), ("integer-simple", 1)]
       , runTest $
           wiredInUnitIds $
             mkTest dbTH "Allows reinstalling template-haskell even without --allow-boot-library-installs" ["template-haskell"] $
-              solverSuccess [("base", 1), ("ghc-prim", 1), ("pretty", 1), ("template-haskell", 1)]
+              solverSuccess [("base", 5), ("ghc-prim", 1), ("pretty", 1), ("template-haskell", 1)]
       , runTest $
           wiredInUnitIds $
             mkTest dbGhcInternal "Fails to reinstall ghc-internal as its wired-in" ["ghc-internal"] $
@@ -231,6 +231,10 @@ tests =
           wiredInUnitIds $
             mkTest dbNonupgrade "Refuse to install newer ghc requested by another library" ["A"] $
               solverFailure (isInfixOf "rejecting: ghc-2 (constraint from non-reinstallable package requires installed instance with unit id ghc-1)")
+      , runTest $
+          wiredInUnitIds $
+            mkTest dbBaseOld "Refuse to install very old base" ["base"] $
+              solverFailure (isInfixOf "rejecting: base-1 (constraint from non-reinstallable package requires >=4.22)")
       ]
   , testGroup
       "reject-unconstrained"
@@ -1405,12 +1409,15 @@ db11s2 =
             `withSetupDeps` [ExFix "base" 3]
       ]
 
+dbBaseOld :: ExampleDb
+dbBaseOld = [Right $ exAv "base" 1 []]
+
 dbBase :: ExampleDb
 dbBase =
   [ Right $
       exAv
         "base"
-        1
+        5
         [ExAny "ghc-prim", ExAny "integer-simple", ExAny "integer-gmp"]
   , Right $ exAv "ghc-prim" 1 []
   , Right $ exAv "integer-simple" 1 []
@@ -1435,7 +1442,7 @@ dbTH =
       , Left $ exInst "ghc-internal" 1 "ghc-internal-1" []
       , Left $ exInst "ghc-boot-th" 1 "ghc-boot-th-1" []
       , Right $ exAv "pretty" 1 [boundedBase]
-      , Right $ exAv "base" 1 [ExAny "ghc-prim", ExAny "ghc-internal"]
+      , Right $ exAv "base" 5 [ExAny "ghc-prim", ExAny "ghc-internal"]
       ]
 
 dbGhcInternal :: ExampleDb

--- a/changelog.d/pr-10982
+++ b/changelog.d/pr-10982
@@ -1,6 +1,6 @@
 synopsis: Allow reinstalling packages like base and template-haskell for GHC>=9.14
 packages: cabal-install cabal-install-solver
-prs: #10982
+prs: #10982 #12055
 issues: #10087
 significance: significant
 


### PR DESCRIPTION
GHC-9.14 ships with base-4.22. Since that release of GHC, base is "reinstallable". This means that we can install a version of base that is not the one that was shipped with GHC.
In #10982, we extended cabal-install to allow reinstalling base when GHC>=9.14

Yet, we should *not* allow solving for very old versions of base. Older versions of base can be picked by the solver, but they are unbuildable and give confusing error messages.

We need both a version of GHC>=9.14 *and* a version of base>=4.22, otherwise we are forced to use the version that was shipped with GHC.

To solve this, we simply also add a constraint that base must be >=4.22 if we take it to be reinstallable. So, now the error mentions that versions of base <4.22 are non-reinstallable.

This is an unfortunate hack to resolve this error, but it's the best we can do.
Alternatively we could try to revise old versions of base so that the solver does not pick them, but then we would still get a somewhat confusing error message (old versions of base require such and such a version of the rts), and it would require that users have a version of the Hackage tarball that is latter than the revisions.

Resolves #11356

I have not added a changelog entry as this just modifies the behaviour of an unreleased feature. I think the existing changelog entry is sufficient.

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [X] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added.


### Manual QA notes

- With GHC-9.14 try building a package which has this in its build-depends `base <4.22`
- You should get an error that is a bit more helpful than before
- Then loosen the bound to `base <4.23` and rebuild
- and it should build