### PR TITLE
Minimal repro for "stanzas explicitly disabled should not be available"

### DIFF
--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/app/Main.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/app/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable-enable.out
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable-enable.out
@@ -1,0 +1,10 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+Assertion failed
+
+HasCallStack backtrace:
+  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:_:_ in ghc-internal:GHC.Internal.IO.Exception
+  assert, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable-enable.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable-enable.project
@@ -1,0 +1,7 @@
+packages: .
+
+package *
+  tests: False
+
+package *
+  tests: True

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable.out
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable.out
@@ -1,0 +1,10 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+Assertion failed
+
+HasCallStack backtrace:
+  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:_:_ in ghc-internal:GHC.Internal.IO.Exception
+  assert, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.disable.project
@@ -1,0 +1,4 @@
+packages: .
+
+package *
+  tests: False

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.enable-disable.out
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.enable-disable.out
@@ -1,0 +1,6 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - exe-test-0.1.0.0 (exe:exe) (first run)
+ - exe-test-0.1.0.0 (test:test) (first run)

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.enable-disable.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.enable-disable.project
@@ -1,0 +1,7 @@
+packages: .
+
+package *
+  tests: True
+
+package *
+  tests: False

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-disable.out
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-disable.out
@@ -1,0 +1,10 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+Assertion failed
+
+HasCallStack backtrace:
+  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:_:_ in ghc-internal:GHC.Internal.IO.Exception
+  assert, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-disable.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-disable.project
@@ -1,0 +1,7 @@
+packages: .
+
+-- The order matters, tests need to be true then false.
+package *
+  tests: True
+
+import: disable-tests.config

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-enable.out
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-enable.out
@@ -1,0 +1,10 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+Assertion failed
+
+HasCallStack backtrace:
+  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:_:_ in ghc-internal:GHC.Internal.IO.Exception
+  assert, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
+

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-enable.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.import-enable.project
@@ -1,0 +1,7 @@
+packages: .
+
+-- The order matters, tests need to be true then false.
+import: enable-tests.config
+
+package *
+  tests: False

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/cabal.test.hs
@@ -1,0 +1,22 @@
+import Test.Cabal.Prelude
+
+main = do
+  cabalTest' "disable-enable" . recordMode RecordMarked $ do
+    res <- fails $ cabal' "build" ["--project-file=cabal.disable-enable.project", "--dry-run"]
+    assertOutputContains "Assertion failed" res
+
+  cabalTest' "enable-disable" . recordMode RecordMarked $ do
+    res <- cabal' "build" ["--project-file=cabal.enable-disable.project", "--dry-run"]
+    assertOutputDoesNotContain "Assertion failed" res
+
+  cabalTest' "disable" . recordMode RecordMarked $ do
+    res <- fails $ cabal' "build" ["--project-file=cabal.disable.project", "--dry-run"]
+    assertOutputContains "Assertion failed" res
+
+  cabalTest' "import-disable" . recordMode RecordMarked $ do
+    res <- fails $ cabal' "build" ["--project-file=cabal.import-disable.project", "--dry-run"]
+    assertOutputContains "Assertion failed" res
+
+  cabalTest' "import-enable" . recordMode RecordMarked $ do
+    res <- fails $ cabal' "build" ["--project-file=cabal.import-enable.project", "--dry-run"]
+    assertOutputContains "Assertion failed" res

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/disable-tests.config
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/disable-tests.config
@@ -1,0 +1,2 @@
+package *
+  tests: False

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/enable-tests.config
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/enable-tests.config
@@ -1,0 +1,2 @@
+package *
+  tests: True

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/exe-test.cabal
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/exe-test.cabal
@@ -1,0 +1,18 @@
+cabal-version:      3.0
+name:               exe-test
+version:            0.1.0.0
+license:            BSD-3-Clause
+build-type:         Simple
+
+executable exe
+    hs-source-dirs:   app
+    main-is:          Main.hs
+    build-depends:    base
+    default-language: Haskell2010
+
+test-suite test
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:    base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/test/Main.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/AssertDisabledAvailable/test/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = puStrLn "Test suite not yet implemented."


### PR DESCRIPTION
Adds ~a minimal~ multiple small reproductions of the assertion failure of #11568.

Do not merge without a fix.

> [!NOTE]
> The fix is in #12080.

---
Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

