### PR TITLE
Remove a stale comment about assert failure

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -255,11 +255,6 @@ sanityCheckElaboratedConfiguredPackage
         ElabPackage pkg -> sanityCheckElaboratedPackage elab pkg
         ElabComponent comp -> sanityCheckElaboratedComponent elab comp
     )
-      -- The assertion below fails occasionally for unknown reason
-      -- so it was muted until we figure it out, otherwise it severely
-      -- hinders our ability to share and test development builds of cabal-install.
-      -- Tracking issue: https://github.com/haskell/cabal/issues/6006
-      --
       -- either a package is being built inplace, or the
       -- 'installedPackageId' we assigned is consistent with
       -- the 'hashedInstalledPackageId' we would compute from


### PR DESCRIPTION
Follow on from #9446. Remove a stale comment that no longer applies.

This could easily have been missed at review as the GitHub review, unless expanded upwards, didn't show the stale comment to reviewers:

<img width="990" height="642" alt="image" src="https://github.com/user-attachments/assets/1bbd55cb-60df-4af4-be3a-1dbbd9eaa2e5" />

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
