### PR TITLE
Add project monitoring logging

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -80,6 +80,7 @@ import Distribution.Simple.Utils
   ( createDirectoryIfMissingVerbose
   , debug
   , dieWithException
+  , info
   , maybeExit
   , notice
   , noticeDoc
@@ -213,9 +214,6 @@ import Distribution.Utils.NubList
   ( fromNubList
   )
 import Distribution.Verbosity
-  ( makeVerbose
-  , modifyVerbosityFlags
-  )
 import Distribution.Version
 
 import qualified Codec.Archive.Tar as Tar
@@ -849,25 +847,39 @@ readProjectFileSkeletonGen :: Verbosity -> HttpTransport -> DistDirLayout -> Pro
 readProjectFileSkeletonGen
   verbosity
   httpTransport
-  dir
+  DistDirLayout{distProjectFile, distProjectRootDirectory}
   key
   parseConfig =
     do
       exists <- liftIO $ doesFileExist extensionFile
       if exists
         then do
+          monitorLog $ "Monitor existing: " ++ fileWithAbsolute extensionFile
           monitorFiles [monitorFileHashed extensionFile]
           pcs <- liftIO $ parseConfig extensionFile
-          monitorFiles
-            [ monitorFileHashed (projectConfigPathRoot path)
-            | (Nothing, path) <- projectSkeletonImports pcs
-            ]
+          let paths =
+                [ projectConfigPathRoot path
+                | (Nothing, path) <- projectSkeletonImports pcs
+                ]
+          for_ paths $ \p -> do
+            monitorLog $ "Monitor imported: " ++ fileWithAbsolute p
+          monitorFiles $ monitorFileHashed <$> paths
           return pcs
         else do
+          monitorLog $ "Monitor nonexistent: " ++ fileWithAbsolute extensionFile
           monitorFiles [monitorNonExistentFile extensionFile]
           return mempty
     where
-      extensionFile = distProjectFile dir key
+      monitorLog = liftIO . info verbosity
+      extensionFile = distProjectFile key
+
+      fileWithAbsolute f
+        | isAbsolute f = f
+        | otherwise = f ++ " (" ++ makeAbsolute f ++ ")"
+
+      makeAbsolute f
+        | isAbsolute f = f
+        | otherwise = distProjectRootDirectory </> f
 
 -- There are 3 different variants of the project parsing function.
 -- 1. readProjectFileSkeletonLegacy: always uses the legacy parser

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -266,11 +266,6 @@ sanityCheckElaboratedConfiguredPackage
               == hashedInstalledPackageId
                 (packageHashInputs sharedConfig elab)
         )
-      -- the stanzas explicitly disabled should not be available
-      . assert
-        ( optStanzaSetNull $
-            optStanzaKeysFilteredByValue (maybe False not) elabStanzasRequested `optStanzaSetIntersection` elabStanzasAvailable
-        )
       -- either a package is built inplace, or we are not attempting to
       -- build any test suites or benchmarks (we never build these
       -- for remote packages!)

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/app/Main.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/app/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal-project-repro.cabal
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal-project-repro.cabal
@@ -1,0 +1,25 @@
+cabal-version:      3.0
+name:               cabal-project-repro
+version:            0.1.0.0
+license:            BSD-3-Clause
+author:             Julian Ospald
+maintainer:         hasufell@posteo.de
+build-type:         Simple
+
+common warnings
+    ghc-options: -Wall
+
+executable filemonitor-test
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    base, filepath
+    hs-source-dirs:   app
+    default-language: Haskell2010
+
+test-suite cabal-project-repro-test
+    import:           warnings
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:    base

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.actual.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.actual.txt
@@ -1,0 +1,5 @@
+Monitor existing: <ROOT>/cabal.freeze-only.project
+Monitor existing: <ROOT>/cabal.freeze-only.project.freeze
+Monitor imported: cabal.freeze-only.project.freeze (<ROOT>/cabal.freeze-only.project.freeze)
+Monitor imported: cabal.freeze-only.project.freeze (<ROOT>/cabal.freeze-only.project.freeze)
+Monitor imported: cabal.freeze-only.project.freeze (<ROOT>/cabal.freeze-only.project.freeze)

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.expect.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.expect.txt
@@ -1,0 +1,6 @@
+Monitor existing: <ROOT>/cabal.freeze-only.project
+Monitor existing: <ROOT>/cabal.freeze-only.project.freeze
+Monitor imported: nested/hop.config (<ROOT>/nested/hop.config)
+Monitor imported: nested/deeply-nested/hop.config (<ROOT>/nested/deeply-nested/hop.config)
+Monitor imported: test/tests-toggle.config (<ROOT>/test/tests-toggle.config)
+Monitor nonexistent: <ROOT>/cabal.freeze-only.project.local

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.project
@@ -1,0 +1,2 @@
+-- NOTE: Intentionally empty as we can't specify
+-- --project-file=cabal.freeze-only.project when that file doesn't exist.

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.project.freeze
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.project.freeze
@@ -1,0 +1,6 @@
+packages: ./cabal-project-repro.cabal
+
+package *
+  Tests: True
+
+import: nested/hop.config

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.actual.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.actual.txt
@@ -1,0 +1,6 @@
+Monitor existing: <ROOT>/cabal.local-only.project
+Monitor nonexistent: <ROOT>/cabal.local-only.project.freeze
+Monitor existing: <ROOT>/cabal.local-only.project.local
+Monitor imported: cabal.local-only.project.local (<ROOT>/cabal.local-only.project.local)
+Monitor imported: cabal.local-only.project.local (<ROOT>/cabal.local-only.project.local)
+Monitor imported: cabal.local-only.project.local (<ROOT>/cabal.local-only.project.local)

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.expect.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.expect.txt
@@ -1,0 +1,6 @@
+Monitor existing: <ROOT>/cabal.local-only.project
+Monitor nonexistent: <ROOT>/cabal.local-only.project.freeze
+Monitor existing: <ROOT>/cabal.local-only.project.local
+Monitor imported: nested/hop.config (<ROOT>/nested/hop.config)
+Monitor imported: nested/deeply-nested/hop.config (<ROOT>/nested/deeply-nested/hop.config)
+Monitor imported: test/tests-toggle.config (<ROOT>/test/tests-toggle.config)

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.project
@@ -1,0 +1,2 @@
+-- NOTE: Intentionally empty as we can't specify
+-- --project-file=cabal.local-only.project when that file doesn't exist.

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.project.local
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.project.local
@@ -1,0 +1,6 @@
+packages: ./cabal-project-repro.cabal
+
+package *
+  Tests: True
+
+import: nested/hop.config

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.actual.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.actual.txt
@@ -1,0 +1,6 @@
+Monitor existing: <ROOT>/cabal.project
+Monitor imported: cabal.project (<ROOT>/cabal.project)
+Monitor imported: cabal.project (<ROOT>/cabal.project)
+Monitor imported: cabal.project (<ROOT>/cabal.project)
+Monitor nonexistent: <ROOT>/cabal.project.freeze
+Monitor nonexistent: <ROOT>/cabal.project.local

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.expect.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.expect.txt
@@ -1,0 +1,3 @@
+Monitor existing: <ROOT>/cabal.project
+Monitor nonexistent: <ROOT>/cabal.project.freeze
+Monitor nonexistent: <ROOT>/cabal.project.local

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project
@@ -1,0 +1,6 @@
+packages: ./cabal-project-repro.cabal
+
+package *
+  Tests: True
+
+import: nested/hop.config

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.test.hs
@@ -1,0 +1,142 @@
+import Control.Monad.Trans.Reader
+import Data.List
+import Prelude hiding (log)
+import System.Directory (doesFileExist, removeFile)
+import System.Exit (ExitCode(ExitFailure))
+import System.IO
+import Test.Cabal.OutputNormalizer
+import Test.Cabal.Prelude
+
+-- If tests are enabled then we get this output:
+-- [1 of 1] Compiling Main
+-- test/Main.hs:4:8: error: [GHC-88464]
+--     Variable not in scope: puStrLn :: [Char] -> IO ()
+--     Suggested fix: Perhaps use ‘putStrLn’ (imported from Prelude)
+--   |
+-- 4 | main = puStrLn "Test suite not yet implemented."
+--   |
+main = do
+  cabalTest' "main-project" . recordMode DoNotRecord $ do
+    let opts = ["--project-file=cabal.project"]
+    expectedMonitoring <-
+      -- TODO: When fixed, use expected output, not the actual output and delete
+      -- the actual output file.
+      -- readFileVerbatim "cabal.main-project.expect.txt"
+      readFileVerbatim "cabal.main-project.actual.txt"
+    runProjectTest expectedMonitoring opts
+    runCommandTest opts
+    runConfigureTest "cabal.project.local" opts
+
+  -- Don't run the configure test for the local-only project because the
+  -- configure command will back up and rename the existing .local file.
+  cabalTest' "local-only" . recordMode DoNotRecord $ do
+    let opts = ["--project-file=cabal.local-only.project"]
+    expectedMonitoring <-
+      -- TODO: When fixed, use expected output, not the actual output and delete
+      -- the actual output file.
+      -- readFileVerbatim "cabal.local-only.expect.txt"
+      readFileVerbatim "cabal.local-only.actual.txt"
+    runProjectTest expectedMonitoring opts
+    runCommandTest opts
+
+  cabalTest' "freeze-only" . recordMode DoNotRecord $ do
+    let opts = ["--project-file=cabal.freeze-only.project"]
+    expectedMonitoring <-
+      -- TODO: When fixed, use expected output, not the actual output and delete
+      -- the actual output file.
+      -- readFileVerbatim "cabal.freeze-only.expect.txt"
+      readFileVerbatim "cabal.freeze-only.actual.txt"
+    runProjectTest expectedMonitoring opts
+    runCommandTest opts
+    runConfigureTest "cabal.freeze-only.project.local" opts
+
+testNotYetImplementedMsg :: String
+testNotYetImplementedMsg = "Test suite not yet implemented"
+
+failureMsg :: String
+failureMsg = "Failed to build cabal-project-repro-0.1.0.0-inplace-cabal-project-repro-test."
+
+log :: String -> ReaderT TestEnv IO ()
+log = recordHeader . pure
+
+-- | Run the build command, with tests disabled then enabled on the command
+-- line.
+runCommandTest :: [String] -> ReaderT TestEnv IO ()
+runCommandTest projOpts = do
+  log "Disabling tests on the command line"
+  cmdDisabledTests <- cabal' "build" (projOpts ++ ["--disable-tests"])
+  assertOutputDoesNotContain testNotYetImplementedMsg cmdDisabledTests
+
+  log "Enabling tests on the command line"
+  cmdEnabledTests <- fails $ cabal' "build" (projOpts ++ ["--enable-tests"])
+  assertOutputContains testNotYetImplementedMsg cmdEnabledTests
+
+-- | Run the build command, after configuring for tests to be disabled then for
+-- tests to be enabled. The project .local is the place where this configuration
+-- is saved. The .local file that the configure command creates is deleted at
+-- the conclusion of this test.
+runConfigureTest :: String -> [String] -> ReaderT TestEnv IO ()
+runConfigureTest projectLocalFile projOpts = do
+  cwd <- testCurrentDir <$> getTestEnv
+  let localFile = cwd </> projectLocalFile
+  haveLocal <- liftIO $ doesFileExist localFile
+  let existsMsg = if haveLocal then "It exists." else "It was not found."
+  log $ "Checking for the existence of: " ++ localFile ++ ". " ++ existsMsg
+  when haveLocal . liftIO $ removeFile localFile
+
+  log "Disabling tests with configure command"
+  -- The `configure` command will create a .local file disabling tests.
+  _ <- cabal' "configure" (projOpts ++ ["--disable-tests"])
+  haveLocal <- liftIO $ doesFileExist localFile
+  unless haveLocal $ assertFailure "Was not able to find .local project file after configure command"
+  assertFileDoesContain localFile "tests: False"
+
+  cmdDisabledTests <- cabal' "build" projOpts
+  assertOutputDoesNotContain testNotYetImplementedMsg cmdDisabledTests
+  -- Revert the change, delete the .local file `configure` adds.
+  liftIO $ removeFile localFile
+
+  log "Enabling tests on the command line"
+  -- The `configure` command will create a .local file enabbling tests.
+  _ <- cabal' "configure" (projOpts ++ ["--enable-tests"])
+  haveLocal <- liftIO $ doesFileExist localFile
+  unless haveLocal $ assertFailure "Was not able to find .local project file after configure command"
+  assertFileDoesContain localFile "tests: True"
+
+  cmdEnabledTests <- fails $ cabal' "build" (projOpts ++ ["--enable-tests"])
+  assertOutputContains testNotYetImplementedMsg cmdEnabledTests
+  -- Revert the change, delete the .local file `configure` adds.
+  liftIO $ removeFile localFile
+
+-- | Runs the build command that should fail but then a write to an imported
+-- project configuration file should be noticed by file monitoring.
+--
+-- WARNING: Don't run other tests before `runProjectTest` otherwise the
+-- expected monitoring output will have already been output and missed.
+runProjectTest :: String -> [String] -> ReaderT TestEnv IO ()
+runProjectTest expectMsg projOpts = do
+  log "As-is, the project should not build"
+  projEnabledTests <- fails $ cabal' "build" projOpts
+  env <- getTestEnv
+  norm_env <- mkNormalizerEnv
+  let actual = normalizeOutput norm_env (resultOutput projEnabledTests)
+  -- The normalized comparison fails on Windows. Don't `skipIfWindows` for the
+  -- whole test, skip only this comparison.
+  unless (isWindows || expectMsg `isInfixOf` actual) $ assertFailure $ "Can't find expected output:\n" ++ expectMsg
+  assertExitCode (ExitFailure 1) projEnabledTests
+  assertOutputContains failureMsg projEnabledTests
+
+  -- Change the imported project file with "tests: False".
+  log "Rewriting an imported project file to disable tests"
+  cwd <- testCurrentDir <$> getTestEnv
+  let configFile = cwd </> "test" </> "tests-toggle.config"
+  liftIO $ writeFile configFile "package *\n  tests: False"
+  -- TODO: If project imports were properly monitored, the build
+  -- should succeed without a clean. When fixed, remove the clean.
+  log "A clean should not be necessary with proper monitoring of files a project imports."
+  _ <- cabal' "clean" projOpts
+  projDisabledTests <- cabal' "build" projOpts
+  assertOutputDoesNotContain testNotYetImplementedMsg projDisabledTests
+  assertOutputDoesNotContain failureMsg projDisabledTests
+  -- Revert the change.
+  liftIO $ writeFile configFile "package *\n  tests: True"

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/nested/deeply-nested/hop.config
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/nested/deeply-nested/hop.config
@@ -1,0 +1,1 @@
+import: ../../test/tests-toggle.config

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/nested/hop.config
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/nested/hop.config
@@ -1,0 +1,2 @@
+import: deeply-nested/hop.config
+

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/test/Main.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/test/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = puStrLn "Test suite not yet implemented."

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/test/tests-toggle.config
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/test/tests-toggle.config
@@ -1,0 +1,2 @@
+package *
+  Tests: True

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -26,6 +26,7 @@ module Test.Cabal.Monad
     -- * The test environment
   , TestEnv (..)
   , getTestEnv
+  , mkNormalizerEnv
 
     -- * Recording mode
   , RecordMode (..)

--- a/changelog.d/12069.md
+++ b/changelog.d/12069.md
@@ -1,0 +1,16 @@
+---
+synopsis: Add info level logging of project file monitoring
+packages: [cabal-install]
+prs: 12069
+---
+
+If the project configuration being monitored is not absolute, then the logging
+includes the monitored path and the absolute path. The monitored file is
+classified as existing, imported or nonexistent. Nonexistent occurs for
+something like `cabal.project.local` that is monitored but may not exist. The
+non-imported files would be `cabal.project`, `cabal.project.freeze` and
+`cabal.project.local`.
+
+Also exports `mkNormalizerEnv` for normalized comparisons in tests when the
+output is not marked. Logging at any verbosity level other than normal is not
+marked.


### PR DESCRIPTION
Split from #11884. Adds project file monitoring logging at the `info` level with tests. Logging at the `info` level is not marked so what I do for the tests is export and use `mkNormalizerEnv` for normalized comparisons.

> [!IMPORTANT]
> Removes the assertion "stanzas explicitly disabled should not be available", see #12067 and #11568.

I'll squash commits before applying the merge label if this pull request is approved.

## Manual QA

This command will surface the monitoring:

```
$ cabal run cabal-install -- build all --dry-run \
  --project-dir=cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/ -v2
...
Monitor existing:
/home/.../cabal/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project
Monitor imported: cabal.project
(/home/.../cabal/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project)
Monitor imported: cabal.project
(/home/.../cabal/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project)
Monitor imported: cabal.project
(/home/.../cabal/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project)
Monitor nonexistent:
/home/.../cabal/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project.freeze
Monitor nonexistent:
/home/.../cabal/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.project.local
```

> [!NOTE]
> The root `cabal.project` is logged as being monitored multiple times. Showing the root of the import path not the leaf as "Monitor imported: cabal.project" is a bug. I have a one-line fix for this problem, included and to be applied in a separate pull request, #11884.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

