### PR TITLE
Add a section for assertions and note marked output

### DIFF
--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -2,12 +2,45 @@
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-duplicate-exports #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- | Generally useful definitions that we expect most test scripts
 -- to use.
 module Test.Cabal.Prelude
-  ( module Test.Cabal.Prelude
+  ( -- * Assertions
+
+    -- ** Assert Marked Output
+    -- $marked-output
+    assertOutputContains
+  , assertOutputDoesNotContain
+  , assertOutputMatches
+  , assertOutputDoesNotMatch
+  , assertOn
+
+    -- ** Assert File
+  , assertFileDoesContain
+  , assertFileDoesNotContain
+  , assertFindInFile
+  , assertAnyFileContains
+  , assertNoFileContains
+
+    -- ** Assert Glob
+  , assertGlobMatches
+  , assertGlobDoesNotMatch
+  , assertGlobMatchesTestDir
+  , assertGlobDoesNotMatchTestDir
+
+    -- ** Other Assertions
+  , assertBool
+  , assertEqual
+  , assertExitCode
+  , assertFailure
+  , assertNotEqual
+  , assertRegex
+
+    -- * Re-exports
+  , module Test.Cabal.Prelude
   , module Test.Cabal.Monad
   , module Test.Cabal.NeedleHaystack
   , module Test.Cabal.Run
@@ -36,9 +69,6 @@ import Distribution.Simple.Configure
 import Distribution.Simple.PackageDescription (readGenericPackageDescription)
 import Distribution.Simple.Program
 import Distribution.Simple.Utils
-  ( tryFindPackageDesc
-  , withFileContents
-  )
 import Distribution.System (Arch (JavaScript), OS (Linux, OSX, Windows), buildArch, buildOS)
 import Distribution.Types.LocalBuildInfo
 import Distribution.Utils.Path
@@ -67,7 +97,7 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as C
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Char as Char
-import Data.List (isInfixOf, isPrefixOf, stripPrefix)
+import Data.List (isPrefixOf, stripPrefix)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Network.Wait (waitTcpVerbose)
 import System.Directory
@@ -84,6 +114,19 @@ import System.Process
 #ifndef mingw32_HOST_OS
 import System.Posix.Resource
 #endif
+
+-- $marked-output
+-- When asserting on the output of a command we only have access to the marked
+-- output. That is the output between these markers:
+--
+-- @
+-- -----BEGIN CABAL OUTPUT-----
+-- -----END CABAL OUTPUT-----
+-- @
+--
+-- This is the output from 'notice' and `warn` messages. It does not include the
+-- output from `debug` or `info` messages. This is mostly because the output
+-- from `debug` and `info` messages is not expected to be deterministic.
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
A documentation change only, add a section for assertions in the haddocks for `cabal-testsuite` and explain that we can only make assertions about marked output.

As rendered:

<img width="934" height="666" alt="image" src="https://github.com/user-attachments/assets/8635bf49-938b-40a2-bcd6-a16a301e33b5" />

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
