### PR TITLE
Bindists: reduce number of x86_64-linux bindists to 1, and same for aarch64-linux

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -71,82 +71,12 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(inputs.branches) }}
-        platform: [ { image: "debian:11"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Debian"
-                    , ARTIFACT: "x86_64-linux-deb11"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "debian:12"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Debian"
-                    , ARTIFACT: "x86_64-linux-deb12"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "ubuntu:20.04"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Ubuntu"
-                    , ARTIFACT: "x86_64-linux-ubuntu20.04"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "ubuntu:22.04"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Ubuntu"
-                    , ARTIFACT: "x86_64-linux-ubuntu22.04"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "ubuntu:24.04"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools_ncurses6 }}"
-                    , DISTRO: "Ubuntu"
-                    , ARTIFACT: "x86_64-linux-ubuntu24.04"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "fedora:33"
-                    , installCmd: "dnf install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Fedora"
-                    , ARTIFACT: "x86_64-linux-fedora33"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "fedora:36"
-                    , installCmd: "dnf install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Fedora"
-                    , ARTIFACT: "x86_64-linux-fedora36"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "fedora:38"
-                    , installCmd: "dnf install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Fedora"
-                    , ARTIFACT: "x86_64-linux-fedora38"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "rockylinux:8"
-                    , installCmd: "yum -y install epel-release && yum install -y --allowerasing"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Unknown"
-                    , ARTIFACT: "x86_64-linux-rocky8"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
-                    },
-                    { image: "alpine:3.20"
+        platform: [ { image: "alpine:3.20"
                     , installCmd: "apk update && apk add"
                     , toolRequirements: "${{ needs.tool-output.outputs.apk_tools }}"
                     , DISTRO: "Unknown"
                     , ARTIFACT: "x86_64-linux-unknown"
                     , ADD_CABAL_ARGS: "--enable-split-sections --enable-executable-static"
-                    },
-                    { image: "alpine:3.20"
-                    , installCmd: "apk update && apk add"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apk_tools }}"
-                    , DISTRO: "Unknown"
-                    , ARTIFACT: "x86_64-linux-alpine320"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
                     }
                   ]
     container:
@@ -233,10 +163,6 @@ jobs:
       matrix:
         branch: ${{ fromJSON(inputs.branches) }}
         platform: [ { ARCH: "ARM64"
-                    , DISTRO: "Debian"
-                    , ARTIFACT: "aarch64-linux-deb11"
-                    },
-                    { ARCH: "ARM64"
                     , DISTRO: "Alpine"
                     , ARTIFACT: "aarch64-linux-unknown"
                     }
@@ -246,18 +172,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - if: matrix.platform.DISTRO == 'Debian'
-        uses: docker://arm64v8/debian:11
-        name: Run build (aarch64 linux)
-        with:
-          args: sh -c "apt-get update && apt-get install -y curl bash git ${{ needs.tool-output.outputs.apt_tools }} && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/build.bash"
-        env:
-          ARTIFACT: ${{ matrix.platform.ARTIFACT }}
-          DISTRO: ${{ matrix.platform.DISTRO }}
-          ADD_CABAL_ARGS: ""
-
-      - if: matrix.platform.DISTRO == 'Alpine'
-        uses: docker://arm64v8/alpine:3.20
+      - uses: docker://arm64v8/alpine:3.20
         name: Run build (aarch64 linux alpine)
         with:
           args: sh -c "apk update && apk add curl bash git ${{ needs.tool-output.outputs.apk_tools }} && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/build.bash"
@@ -463,71 +378,11 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(inputs.branches) }}
-        platform: [ { image: "debian:11"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Debian"
-                    , ARTIFACT: "x86_64-linux-deb11"
-                    },
-                    { image: "debian:12"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Debian"
-                    , ARTIFACT: "x86_64-linux-deb12"
-                    },
-                    { image: "ubuntu:20.04"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Ubuntu"
-                    , ARTIFACT: "x86_64-linux-ubuntu20.04"
-                    },
-                    { image: "ubuntu:22.04"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools }}"
-                    , DISTRO: "Ubuntu"
-                    , ARTIFACT: "x86_64-linux-ubuntu22.04"
-                    },
-                    { image: "ubuntu:24.04"
-                    , installCmd: "apt-get update && apt-get install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apt_tools_ncurses6 }}"
-                    , DISTRO: "Ubuntu"
-                    , ARTIFACT: "x86_64-linux-ubuntu24.04"
-                    },
-                    { image: "fedora:33"
-                    , installCmd: "dnf install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Fedora"
-                    , ARTIFACT: "x86_64-linux-fedora33"
-                    },
-                    { image: "fedora:36"
-                    , installCmd: "dnf install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Fedora"
-                    , ARTIFACT: "x86_64-linux-fedora36"
-                    },
-                    { image: "fedora:38"
-                    , installCmd: "dnf install -y"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Fedora"
-                    , ARTIFACT: "x86_64-linux-fedora38"
-                    },
-                    { image: "rockylinux:8"
-                    , installCmd: "yum -y install epel-release && yum install -y --allowerasing"
-                    , toolRequirements: "${{ needs.tool-output.outputs.rpm_tools }}"
-                    , DISTRO: "Unknown"
-                    , ARTIFACT: "x86_64-linux-rocky8"
-                    },
-                    { image: "alpine:3.20"
+        platform: [ { image: "alpine:3.20"
                     , installCmd: "apk update && apk add"
                     , toolRequirements: "${{ needs.tool-output.outputs.apk_tools }}"
                     , DISTRO: "Unknown"
                     , ARTIFACT: "x86_64-linux-unknown"
-                    },
-                    { image: "alpine:3.20"
-                    , installCmd: "apk update && apk add"
-                    , toolRequirements: "${{ needs.tool-output.outputs.apk_tools }}"
-                    , DISTRO: "Unknown"
-                    , ARTIFACT: "x86_64-linux-alpine320"
                     }
                   ]
     container:
@@ -611,10 +466,6 @@ jobs:
       matrix:
         branch: ${{ fromJSON(inputs.branches) }}
         platform: [ { ARCH: "ARM64"
-                    , DISTRO: "Debian"
-                    , ARTIFACT: "aarch64-linux-deb11"
-                    },
-                    { ARCH: "ARM64"
                     , DISTRO: "Alpine"
                     , ARTIFACT: "aarch64-linux-unknown"
                     }
@@ -629,17 +480,7 @@ jobs:
           name: artifacts-${{ matrix.platform.ARTIFACT }}-${{ matrix.branch }}
           path: ./out
 
-      - if: matrix.platform.DISTRO == 'Debian'
-        uses: docker://arm64v8/debian:11
-        name: Run build (aarch64 linux)
-        with:
-          args: sh -c "apt-get update && apt-get install -y curl bash git groff-base ${{ needs.tool-output.outputs.apt_tools }} && git config --system --add safe.directory $GITHUB_WORKSPACE && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/test.bash"
-        env:
-          ARTIFACT: ${{ matrix.platform.ARTIFACT }}
-          DISTRO: ${{ matrix.platform.DISTRO }}
-
-      - if: matrix.platform.DISTRO == 'Alpine'
-        uses: docker://arm64v8/alpine:3.20
+      - uses: docker://arm64v8/alpine:3.20
         name: Run build (aarch64 linux alpine)
         with:
           args: sh -c "apk update && apk add curl bash git groff ${{ needs.tool-output.outputs.apk_tools }} && git config --system --add safe.directory $GITHUB_WORKSPACE && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/test.bash"

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -576,7 +576,6 @@ jobs:
       TARBALL_EXT: "zip"
       DISTRO: na
       CABAL_DIR: "C:\\Users\\runneradmin\\AppData\\Roaming\\cabal"
-      GHCUP_INSTALL_BASE_PREFIX: "/c"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(inputs.branches) }}
-        platform: [ { image: "alpine:3.20"
+        platform: [ { image: "alpine:3.21"
                     , installCmd: "apk update && apk add"
                     , toolRequirements: "${{ needs.tool-output.outputs.apk_tools }}"
                     , DISTRO: "Unknown"
@@ -136,7 +136,7 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Run build (32 bit linux)
-        uses: docker://i386/alpine:3.20
+        uses: docker://i386/alpine:3.21
         with:
           args: sh -c "apk update && apk add curl bash git ${{ needs.tool-output.outputs.apk_tools }} && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/build.bash"
 
@@ -172,7 +172,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - uses: docker://arm64v8/alpine:3.20
+      - uses: docker://arm64v8/alpine:3.21
         name: Run build (aarch64 linux alpine)
         with:
           args: sh -c "apk update && apk add curl bash git ${{ needs.tool-output.outputs.apk_tools }} && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/build.bash"
@@ -378,7 +378,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(inputs.branches) }}
-        platform: [ { image: "alpine:3.20"
+        platform: [ { image: "alpine:3.21"
                     , installCmd: "apk update && apk add"
                     , toolRequirements: "${{ needs.tool-output.outputs.apk_tools }}"
                     , DISTRO: "Unknown"
@@ -448,7 +448,7 @@ jobs:
 #          path: ./out
 #
 #      - name: Run build (32 bit linux)
-#        uses: docker://i386/alpine:3.20
+#        uses: docker://i386/alpine:3.21
 #        with:
 #          args: sh -c "apk update && apk add curl bash git ${{ needs.tool-output.outputs.apk_tools }} groff && git config --system --add safe.directory $GITHUB_WORKSPACE && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/build.bash"
 
@@ -480,7 +480,7 @@ jobs:
           name: artifacts-${{ matrix.platform.ARTIFACT }}-${{ matrix.branch }}
           path: ./out
 
-      - uses: docker://arm64v8/alpine:3.20
+      - uses: docker://arm64v8/alpine:3.21
         name: Run build (aarch64 linux alpine)
         with:
           args: sh -c "apk update && apk add curl bash git groff ${{ needs.tool-output.outputs.apk_tools }} && git config --system --add safe.directory $GITHUB_WORKSPACE && export PATH=$HOME/.ghcup/bin:$PATH && curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && ghcup install cabal ${{ env.CABAL_VERSION }} && bash .github/scripts/test.bash"


### PR DESCRIPTION
Closes #11926.

The extensive release matrix for Cabal-the-executable was inherited from GHC, back when they were built on the same CI machines. For quite some time it serves virtually no purpose: package distributors do not use the artifacts (they build them themselves for their respective Linux distros), and ghcup (except vanilla channel) does not use them, so who does?

Cabal-the-executable is, well, just a single executable. Normally a single statically linked executable could have served all Linuxes, except for a wart with semaphores implementation which required Cabal to be built against the same standard C Library (`glibc` or `musl`) as the GHC it uses. But it is now well-established by ghcup, which distributes only two Cabal binaries (one for `glibc` and one for `musl`), that that's it, there is no point to have more distro-specific builds.

Now that the recent work on the `semaphore-compat-0.2` package sorted out the issue with semaphores and standard C libraries, a single statically linked executable can serve all `x86_64-linux` platforms and the same holds for `aarch64-linux`. We can stop doing redundant and rather useless work and reduce the build matrix to exactly one artifact per platform, using Alpine static build.

**Template B: This PR does not modify behaviour or interface**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
