### PR TITLE
Monitor imports of projects

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -858,7 +858,7 @@ readProjectFileSkeletonGen
           monitorFiles [monitorFileHashed extensionFile]
           pcs <- liftIO $ parseConfig extensionFile
           let paths =
-                [ projectConfigPathRoot path
+                [ currentProjectConfigPath path
                 | (Nothing, path) <- projectSkeletonImports pcs
                 ]
           for_ paths $ \p -> do

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.actual.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.freeze-only.actual.txt
@@ -1,5 +1,0 @@
-Monitor existing: <ROOT>/cabal.freeze-only.project
-Monitor existing: <ROOT>/cabal.freeze-only.project.freeze
-Monitor imported: cabal.freeze-only.project.freeze (<ROOT>/cabal.freeze-only.project.freeze)
-Monitor imported: cabal.freeze-only.project.freeze (<ROOT>/cabal.freeze-only.project.freeze)
-Monitor imported: cabal.freeze-only.project.freeze (<ROOT>/cabal.freeze-only.project.freeze)

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.actual.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.local-only.actual.txt
@@ -1,6 +1,0 @@
-Monitor existing: <ROOT>/cabal.local-only.project
-Monitor nonexistent: <ROOT>/cabal.local-only.project.freeze
-Monitor existing: <ROOT>/cabal.local-only.project.local
-Monitor imported: cabal.local-only.project.local (<ROOT>/cabal.local-only.project.local)
-Monitor imported: cabal.local-only.project.local (<ROOT>/cabal.local-only.project.local)
-Monitor imported: cabal.local-only.project.local (<ROOT>/cabal.local-only.project.local)

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.actual.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.actual.txt
@@ -1,6 +1,0 @@
-Monitor existing: <ROOT>/cabal.project
-Monitor imported: cabal.project (<ROOT>/cabal.project)
-Monitor imported: cabal.project (<ROOT>/cabal.project)
-Monitor imported: cabal.project (<ROOT>/cabal.project)
-Monitor nonexistent: <ROOT>/cabal.project.freeze
-Monitor nonexistent: <ROOT>/cabal.project.local

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.expect.txt
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.main-project.expect.txt
@@ -1,3 +1,6 @@
 Monitor existing: <ROOT>/cabal.project
+Monitor imported: nested/hop.config (<ROOT>/nested/hop.config)
+Monitor imported: nested/deeply-nested/hop.config (<ROOT>/nested/deeply-nested/hop.config)
+Monitor imported: test/tests-toggle.config (<ROOT>/test/tests-toggle.config)
 Monitor nonexistent: <ROOT>/cabal.project.freeze
 Monitor nonexistent: <ROOT>/cabal.project.local

--- a/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectImport/FileMonitoring/cabal.test.hs
@@ -19,10 +19,7 @@ main = do
   cabalTest' "main-project" . recordMode DoNotRecord $ do
     let opts = ["--project-file=cabal.project"]
     expectedMonitoring <-
-      -- TODO: When fixed, use expected output, not the actual output and delete
-      -- the actual output file.
-      -- readFileVerbatim "cabal.main-project.expect.txt"
-      readFileVerbatim "cabal.main-project.actual.txt"
+      readFileVerbatim "cabal.main-project.expect.txt"
     runProjectTest expectedMonitoring opts
     runCommandTest opts
     runConfigureTest "cabal.project.local" opts
@@ -32,20 +29,14 @@ main = do
   cabalTest' "local-only" . recordMode DoNotRecord $ do
     let opts = ["--project-file=cabal.local-only.project"]
     expectedMonitoring <-
-      -- TODO: When fixed, use expected output, not the actual output and delete
-      -- the actual output file.
-      -- readFileVerbatim "cabal.local-only.expect.txt"
-      readFileVerbatim "cabal.local-only.actual.txt"
+      readFileVerbatim "cabal.local-only.expect.txt"
     runProjectTest expectedMonitoring opts
     runCommandTest opts
 
   cabalTest' "freeze-only" . recordMode DoNotRecord $ do
     let opts = ["--project-file=cabal.freeze-only.project"]
     expectedMonitoring <-
-      -- TODO: When fixed, use expected output, not the actual output and delete
-      -- the actual output file.
-      -- readFileVerbatim "cabal.freeze-only.expect.txt"
-      readFileVerbatim "cabal.freeze-only.actual.txt"
+      readFileVerbatim "cabal.freeze-only.expect.txt"
     runProjectTest expectedMonitoring opts
     runCommandTest opts
     runConfigureTest "cabal.freeze-only.project.local" opts
@@ -131,10 +122,10 @@ runProjectTest expectMsg projOpts = do
   cwd <- testCurrentDir <$> getTestEnv
   let configFile = cwd </> "test" </> "tests-toggle.config"
   liftIO $ writeFile configFile "package *\n  tests: False"
-  -- TODO: If project imports were properly monitored, the build
-  -- should succeed without a clean. When fixed, remove the clean.
+  -- NOTE: When project imports are properly monitored, the build succeeds
+  -- without a clean or touching the root project file. The change to the
+  -- imported file is noticed.
   log "A clean should not be necessary with proper monitoring of files a project imports."
-  _ <- cabal' "clean" projOpts
   projDisabledTests <- cabal' "build" projOpts
   assertOutputDoesNotContain testNotYetImplementedMsg projDisabledTests
   assertOutputDoesNotContain failureMsg projDisabledTests

--- a/changelog.d/12077.md
+++ b/changelog.d/12077.md
@@ -1,0 +1,9 @@
+---
+synopsis: Fix monitoring of project file imports
+packages: [cabal-install]
+prs: 12077
+issues: [10255]
+---
+
+Watch for changes in all project files, the root `cabal.project` and all local
+files it imports. We don't monitor remote URI imports.


### PR DESCRIPTION
Fixes #10255. Simpler than #11884. Alters existing tests for the expected behaviour.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
