### PR TITLE
Fix assert stanza disabled not available

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -56,7 +56,6 @@ module Distribution.Client.ProjectConfig
   , fetchAndReadSourcePackages
 
     -- * Resolving configuration
-  , lookupLocalPackageConfig
   , projectConfigWithBuilderRepoContext
   , projectConfigWithSolverRepoContext
   , SolverSettings (..)
@@ -258,28 +257,6 @@ import Distribution.Solver.Types.ProjectConfigPath
 ----------------------------------------
 -- Resolving configuration to settings
 --
-
--- | Look up a 'PackageConfig' field in the 'ProjectConfig' for a specific
--- 'PackageName'. This returns the configuration that applies to all local
--- packages plus any package-specific configuration for this package.
-lookupLocalPackageConfig
-  :: Monoid a
-  => (PackageConfig -> a)
-  -> ProjectConfig
-  -> PackageName
-  -> a
-lookupLocalPackageConfig
-  field
-  ProjectConfig
-    { projectConfigLocalPackages
-    , projectConfigSpecificPackage
-    }
-  pkgname =
-    field projectConfigLocalPackages
-      <> maybe
-        mempty
-        field
-        (Map.lookup pkgname (getMapMappend projectConfigSpecificPackage))
 
 -- | Use a 'RepoContext' based on the 'BuildTimeSettings'.
 projectConfigWithBuilderRepoContext

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -261,6 +261,11 @@ sanityCheckElaboratedConfiguredPackage
               == hashedInstalledPackageId
                 (packageHashInputs sharedConfig elab)
         )
+      -- the stanzas explicitly disabled should not be available
+      . assert
+        ( optStanzaSetNull $
+            optStanzaKeysFilteredByValue (maybe False not) elabStanzasRequested `optStanzaSetIntersection` elabStanzasAvailable
+        )
       -- either a package is built inplace, or we are not attempting to
       -- build any test suites or benchmarks (we never build these
       -- for remote packages!)

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- /Elaborated: worked out with great care and nicety of detail; executed with great minuteness: elaborate preparations; elaborate care./
@@ -800,6 +802,9 @@ rebuildInstallPlan
         projectConfig@ProjectConfig
           { projectConfigShared
           , projectConfigBuildOnly
+          , projectConfigAllPackages
+          , projectConfigLocalPackages
+          , projectConfigSpecificPackage
           }
         (compiler, platform, progdb)
         localPackages
@@ -868,37 +873,19 @@ rebuildInstallPlan
 
             solverSettings = resolveSolverSettings projectConfig
             logMsg message rest = debugNoWrap verbosity message >> rest
+            perPkgOption = lookupPerPkgOption (const True) projectConfigAllPackages projectConfigLocalPackages (getMapMappend projectConfigSpecificPackage)
 
+            -- TODO: "local" misnomer: we should separate
+            -- builtin/global/inplace/local packages and packages explicitly
+            -- mentioned in the project.
             localPackagesEnabledStanzas =
               Map.fromList
-                [ (pkgname, stanzas)
+                [ (pkgname, Map.fromList $ ((TestStanzas,) <$> tests) ++ ((BenchStanzas,) <$> benches))
                 | pkg <- localPackages
-                , -- TODO: misnomer: we should separate
-                -- builtin/global/inplace/local packages
-                -- and packages explicitly mentioned in the project
-                --
-                let pkgname = pkgSpecifierTarget pkg
-                    testsEnabled =
-                      lookupLocalPackageConfig
-                        packageConfigTests
-                        projectConfig
-                        pkgname
-                    benchmarksEnabled =
-                      lookupLocalPackageConfig
-                        packageConfigBenchmarks
-                        projectConfig
-                        pkgname
-                    isLocal = isJust (shouldBeLocal pkg)
-                    stanzas
-                      | isLocal =
-                          Map.fromList $
-                            [ (TestStanzas, enabled)
-                            | enabled <- flagToList testsEnabled
-                            ]
-                              ++ [ (BenchStanzas, enabled)
-                                 | enabled <- flagToList benchmarksEnabled
-                                 ]
-                      | otherwise = Map.fromList [(TestStanzas, False), (BenchStanzas, False)]
+                , let pkgname = pkgSpecifierTarget pkg
+                , let (tests, benches) = case shouldBeLocal pkg of
+                        Just (fmap flagToList . perPkgOption -> f) -> (f packageConfigTests, f packageConfigBenchmarks)
+                        Nothing -> ([False], [False])
                 ]
 
       -- Elaborate the solver's install plan to get a fully detailed plan. This
@@ -2322,7 +2309,7 @@ elaborateInstallPlan
             elabHaddockTargets = []
 
             elabBuildHaddocks =
-              perPkgOptionFlag pkgid False packageConfigDocumentation
+              perPkgOptionFlag False pkgid packageConfigDocumentation
 
             -- `documentation: true` should imply `-haddock` for GHC
             addHaddockIfDocumentationEnabled :: ConfiguredProgram -> ConfiguredProgram
@@ -2370,37 +2357,37 @@ elaborateInstallPlan
             -- 'elabBuildOptions' accurately reflects what will actually be built.
             elabBuildOptionsRaw =
               LBC.BuildOptions
-                { withVanillaLib = perPkgOptionFlag pkgid True packageConfigVanillaLib -- TODO: [required feature]: also needs to be handled recursively
+                { withVanillaLib = perPkgOptionFlag True pkgid packageConfigVanillaLib -- TODO: [required feature]: also needs to be handled recursively
                 , withSharedLib = canBuildSharedLibs && pkgid `Set.member` pkgsUseSharedLibrary
-                , withStaticLib = perPkgOptionFlag pkgid False packageConfigStaticLib
+                , withStaticLib = perPkgOptionFlag False pkgid packageConfigStaticLib
                 , withDynExe =
-                    perPkgOptionFlag pkgid False packageConfigDynExe
+                    perPkgOptionFlag False pkgid packageConfigDynExe
                       -- We can't produce a dynamic executable if the user
                       -- wants to enable executable profiling but the
                       -- compiler doesn't support prof+dyn.
                       && (okProfDyn || not profExe)
-                , withFullyStaticExe = perPkgOptionFlag pkgid False packageConfigFullyStaticExe
-                , withGHCiLib = perPkgOptionFlag pkgid False packageConfigGHCiLib -- TODO: [required feature] needs to default to enabled on windows still
+                , withFullyStaticExe = perPkgOptionFlag False pkgid packageConfigFullyStaticExe
+                , withGHCiLib = perPkgOptionFlag False pkgid packageConfigGHCiLib -- TODO: [required feature] needs to default to enabled on windows still
                 , withProfExe = profExe
                 , withProfLib = canBuildProfilingLibs && pkgid `Set.member` pkgsUseProfilingLibrary
                 , withProfLibShared = canBuildProfilingSharedLibs && pkgid `Set.member` pkgsUseProfilingLibraryShared
-                , withBytecodeLib = perPkgOptionFlag pkgid False packageConfigBytecodeLib
-                , exeCoverage = perPkgOptionFlag pkgid False packageConfigCoverage
-                , libCoverage = perPkgOptionFlag pkgid False packageConfigCoverage
-                , withOptimization = perPkgOptionFlag pkgid NormalOptimisation packageConfigOptimization
-                , splitObjs = perPkgOptionFlag pkgid False packageConfigSplitObjs
-                , splitSections = perPkgOptionFlag pkgid False packageConfigSplitSections
-                , stripLibs = perPkgOptionFlag pkgid False packageConfigStripLibs
-                , stripExes = perPkgOptionFlag pkgid False packageConfigStripExes
-                , withDebugInfo = perPkgOptionFlag pkgid NoDebugInfo packageConfigDebugInfo
-                , relocatable = perPkgOptionFlag pkgid False packageConfigRelocatable
+                , withBytecodeLib = perPkgOptionFlag False pkgid packageConfigBytecodeLib
+                , exeCoverage = perPkgOptionFlag False pkgid packageConfigCoverage
+                , libCoverage = perPkgOptionFlag False pkgid packageConfigCoverage
+                , withOptimization = perPkgOptionFlag NormalOptimisation pkgid packageConfigOptimization
+                , splitObjs = perPkgOptionFlag False pkgid packageConfigSplitObjs
+                , splitSections = perPkgOptionFlag False pkgid packageConfigSplitSections
+                , stripLibs = perPkgOptionFlag False pkgid packageConfigStripLibs
+                , stripExes = perPkgOptionFlag False pkgid packageConfigStripExes
+                , withDebugInfo = perPkgOptionFlag NoDebugInfo pkgid packageConfigDebugInfo
+                , relocatable = perPkgOptionFlag False pkgid packageConfigRelocatable
                 , withProfLibDetail = elabProfExeDetail
                 , withProfExeDetail = elabProfLibDetail
                 , programPrefix = elabProgPrefix
                 , programSuffix = elabProgSuffix
                 }
             okProfDyn = profilingDynamicSupportedOrUnknown compiler
-            profExe = perPkgOptionFlag pkgid False packageConfigProf
+            profExe = perPkgOptionFlag False pkgid packageConfigProf
 
             elabBuildOptions = Cabal.adjustBuildOptions compiler compilerProgDb elabBuildOptionsRaw
 
@@ -2408,12 +2395,12 @@ elaborateInstallPlan
               , elabProfLibDetail
               ) =
                 perPkgOptionLibExeFlag
-                  pkgid
                   ProfDetailDefault
+                  pkgid
                   packageConfigProfDetail
                   packageConfigProfLibDetail
 
-            elabDumpBuildInfo = perPkgOptionFlag pkgid NoDumpBuildInfo packageConfigDumpBuildInfo
+            elabDumpBuildInfo = perPkgOptionFlag NoDumpBuildInfo pkgid packageConfigDumpBuildInfo
 
             -- Combine the configured compiler prog settings with the user-supplied
             -- config. For the compiler progs any user-supplied config was taken
@@ -2425,7 +2412,8 @@ elaborateInstallPlan
                 [ (programId prog, programPath prog)
                 | prog <- configuredPrograms compilerProgDb
                 ]
-                <> perPkgOptionMapLast pkgid packageConfigProgramPaths
+                <> getMapLast (perPkgOption pkgid packageConfigProgramPaths)
+
             elabProgramArgs =
               -- Workaround for <https://github.com/haskell/cabal/issues/4010>
               --
@@ -2450,8 +2438,9 @@ elaborateInstallPlan
                       , not (null args)
                       ]
                   )
-                  (perPkgOptionMapMappend pkgid packageConfigProgramArgs)
-            elabProgramPathExtra = perPkgOptionNubList pkgid packageConfigProgramPathExtra
+                  (getMapMappend $ perPkgOption pkgid packageConfigProgramArgs)
+
+            elabProgramPathExtra = fromNubList $ perPkgOption pkgid packageConfigProgramPathExtra
             elabConfiguredPrograms = configuredPrograms compilerProgDb
             elabConfigureScriptArgs = perPkgOptionList pkgid packageConfigConfigureArgs
             elabExtraLibDirs = perPkgOptionList pkgid packageConfigExtraLibDirs
@@ -2461,73 +2450,51 @@ elaborateInstallPlan
             elabProgPrefix = perPkgOptionMaybe pkgid packageConfigProgPrefix
             elabProgSuffix = perPkgOptionMaybe pkgid packageConfigProgSuffix
 
-            elabHaddockHoogle = perPkgOptionFlag pkgid False packageConfigHaddockHoogle
-            elabHaddockHtml = perPkgOptionFlag pkgid False packageConfigHaddockHtml
+            elabHaddockHoogle = perPkgOptionFlag False pkgid packageConfigHaddockHoogle
+            elabHaddockHtml = perPkgOptionFlag False pkgid packageConfigHaddockHtml
             elabHaddockHtmlLocation = perPkgOptionMaybe pkgid packageConfigHaddockHtmlLocation
-            elabHaddockForeignLibs = perPkgOptionFlag pkgid False packageConfigHaddockForeignLibs
-            elabHaddockForHackage = perPkgOptionFlag pkgid Cabal.ForDevelopment packageConfigHaddockForHackage
-            elabHaddockExecutables = perPkgOptionFlag pkgid False packageConfigHaddockExecutables
-            elabHaddockTestSuites = perPkgOptionFlag pkgid False packageConfigHaddockTestSuites
-            elabHaddockBenchmarks = perPkgOptionFlag pkgid False packageConfigHaddockBenchmarks
-            elabHaddockInternal = perPkgOptionFlag pkgid False packageConfigHaddockInternal
+            elabHaddockForeignLibs = perPkgOptionFlag False pkgid packageConfigHaddockForeignLibs
+            elabHaddockForHackage = perPkgOptionFlag Cabal.ForDevelopment pkgid packageConfigHaddockForHackage
+            elabHaddockExecutables = perPkgOptionFlag False pkgid packageConfigHaddockExecutables
+            elabHaddockTestSuites = perPkgOptionFlag False pkgid packageConfigHaddockTestSuites
+            elabHaddockBenchmarks = perPkgOptionFlag False pkgid packageConfigHaddockBenchmarks
+            elabHaddockInternal = perPkgOptionFlag False pkgid packageConfigHaddockInternal
             elabHaddockCss = perPkgOptionMaybe pkgid packageConfigHaddockCss
-            elabHaddockLinkedSource = perPkgOptionFlag pkgid False packageConfigHaddockLinkedSource
-            elabHaddockQuickJump = perPkgOptionFlag pkgid False packageConfigHaddockQuickJump
+            elabHaddockLinkedSource = perPkgOptionFlag False pkgid packageConfigHaddockLinkedSource
+            elabHaddockQuickJump = perPkgOptionFlag False pkgid packageConfigHaddockQuickJump
             elabHaddockHscolourCss = perPkgOptionMaybe pkgid packageConfigHaddockHscolourCss
             elabHaddockContents = perPkgOptionMaybe pkgid packageConfigHaddockContents
             elabHaddockIndex = perPkgOptionMaybe pkgid packageConfigHaddockIndex
             elabHaddockBaseUrl = perPkgOptionMaybe pkgid packageConfigHaddockBaseUrl
             elabHaddockResourcesDir = perPkgOptionMaybe pkgid packageConfigHaddockResourcesDir
             elabHaddockOutputDir = perPkgOptionMaybe pkgid packageConfigHaddockOutputDir
-            elabHaddockUseUnicode = perPkgOptionFlag pkgid False packageConfigHaddockUseUnicode
+            elabHaddockUseUnicode = perPkgOptionFlag False pkgid packageConfigHaddockUseUnicode
 
             elabTestMachineLog = perPkgOptionMaybe pkgid packageConfigTestMachineLog
             elabTestHumanLog = perPkgOptionMaybe pkgid packageConfigTestHumanLog
             elabTestShowDetails = perPkgOptionMaybe pkgid packageConfigTestShowDetails
-            elabTestKeepTix = perPkgOptionFlag pkgid False packageConfigTestKeepTix
+            elabTestKeepTix = perPkgOptionFlag False pkgid packageConfigTestKeepTix
             elabTestWrapper = perPkgOptionMaybe pkgid packageConfigTestWrapper
-            elabTestFailWhenNoTestSuites = perPkgOptionFlag pkgid False packageConfigTestFailWhenNoTestSuites
+            elabTestFailWhenNoTestSuites = perPkgOptionFlag False pkgid packageConfigTestFailWhenNoTestSuites
             elabTestTestOptions = perPkgOptionList pkgid packageConfigTestTestOptions
 
             elabBenchmarkOptions = perPkgOptionList pkgid packageConfigBenchmarkOptions
 
-      perPkgOptionFlag :: PackageId -> a -> (PackageConfig -> Flag a) -> a
+      perPkgOptionFlag :: a -> PackageId -> (PackageConfig -> Flag a) -> a
+      perPkgOptionFlag def = fmap (fromFlagOrDefault def) . perPkgOption
+
       perPkgOptionMaybe :: PackageId -> (PackageConfig -> Flag a) -> Maybe a
+      perPkgOptionMaybe = fmap flagToMaybe . perPkgOption
+
       perPkgOptionList :: PackageId -> (PackageConfig -> [a]) -> [a]
+      perPkgOptionList = perPkgOption
 
-      perPkgOptionFlag pkgid def f = fromFlagOrDefault def (lookupPerPkgOption pkgid f)
-      perPkgOptionMaybe pkgid f = flagToMaybe (lookupPerPkgOption pkgid f)
-      perPkgOptionList pkgid f = lookupPerPkgOption pkgid f
-      perPkgOptionNubList pkgid f = fromNubList (lookupPerPkgOption pkgid f)
-      perPkgOptionMapLast pkgid f = getMapLast (lookupPerPkgOption pkgid f)
-      perPkgOptionMapMappend pkgid f = getMapMappend (lookupPerPkgOption pkgid f)
+      perPkgOptionLibExeFlag :: a -> PackageId -> (PackageConfig -> Flag a) -> (PackageConfig -> Flag a) -> (a, a)
+      perPkgOptionLibExeFlag (fromFlagOrDefault -> f) pkgid (perPkgOption pkgid -> both) (perPkgOption pkgid -> lib) =
+        (f both, f (both <> lib))
 
-      perPkgOptionLibExeFlag pkgid def fboth flib = (exe, lib)
-        where
-          exe = fromFlagOrDefault def bothflag
-          lib = fromFlagOrDefault def (bothflag <> libflag)
-
-          bothflag = lookupPerPkgOption pkgid fboth
-          libflag = lookupPerPkgOption pkgid flib
-
-      lookupPerPkgOption
-        :: (Package pkg, Monoid m)
-        => pkg
-        -> (PackageConfig -> m)
-        -> m
-      lookupPerPkgOption pkg f =
-        -- This is where we merge the options from the project config that
-        -- apply to all packages, all project local packages, and to specific
-        -- named packages
-        global <> local <> perpkg
-        where
-          global = f allPackagesConfig
-          local
-            | isLocalToProject pkg =
-                f localPackagesConfig
-            | otherwise =
-                mempty
-          perpkg = maybe mempty f (Map.lookup (packageName pkg) perPackageConfig)
+      perPkgOption :: (Package pkg, Monoid m) => pkg -> (PackageConfig -> m) -> m
+      perPkgOption = lookupPerPkgOption isLocalToProject allPackagesConfig localPackagesConfig perPackageConfig
 
       inplacePackageDbs =
         corePackageDbs
@@ -2643,8 +2610,8 @@ elaborateInstallPlan
         fromFlagOrDefault compilerShouldUseProfilingLibByDefault (profBothFlag <> profLibFlag)
         where
           pkgid = packageId pkg
-          profBothFlag = lookupPerPkgOption pkgid packageConfigProf
-          profLibFlag = lookupPerPkgOption pkgid packageConfigProfLib
+          profBothFlag = perPkgOption pkgid packageConfigProf
+          profLibFlag = perPkgOption pkgid packageConfigProfLib
 
       pkgsUseProfilingLibraryShared :: Set PackageId
       pkgsUseProfilingLibraryShared =
@@ -4684,3 +4651,23 @@ determineCoverageFor configuredPkg plan =
 
     isIndefiniteOrInstantiation :: ModuleShape -> Bool
     isIndefiniteOrInstantiation = not . Set.null . modShapeRequires
+
+-- | Look up and merge the options from the project config that apply to all
+-- packages, all project local packages, and to specific named packages.
+lookupPerPkgOption
+  :: (Package pkg, Monoid m)
+  => (pkg -> Bool)
+  -> PackageConfig
+  -> PackageConfig
+  -> Map PackageName PackageConfig
+  -> pkg
+  -> (PackageConfig -> m)
+  -> m
+lookupPerPkgOption isLocalPkg allPackagesConfig localPackagesConfig perPackageConfig pkg f =
+  global `mappend` local `mappend` perpkg
+  where
+    global = f allPackagesConfig
+    local
+      | isLocalPkg pkg = f localPackagesConfig
+      | otherwise = mempty
+    perpkg = maybe mempty f (Map.lookup (packageName pkg) perPackageConfig)

--- a/changelog.d/11568.md
+++ b/changelog.d/11568.md
@@ -1,0 +1,12 @@
+---
+synopsis: Fix assertion failure, stanzas explicitly disabled should not be available
+packages: [cabal-install]
+prs: 12080
+issues: 11568
+---
+
+Remove `lookupLocalPackageConfig`, an export from module
+`Distribution.Client.ProjectConfig`. This function would ignore
+`projectConfigAllPackages` (`package *`) and thus diverge from
+`lookupPerPkgOption`. This would then cause further divergence between
+`elabStanzasRequested`.


### PR DESCRIPTION
Fix #11568. This is the work of @hasufell in #11567 but isolated and extracted to only fix the assertion.

> [!NOTE]
> Tests were added previously in #12069. The assertion was removed then. We add it back with this fix.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

