### PR TITLE
Revert "Backport #11653: refactor(Cabal, cabal-install): add HasCallStack to dieProgress and ProjectPlanning"

### DIFF
--- a/Cabal/src/Distribution/Utils/LogProgress.hs
+++ b/Cabal/src/Distribution/Utils/LogProgress.hs
@@ -16,7 +16,6 @@ import Prelude ()
 import Distribution.Simple.Utils
 import Distribution.Utils.Progress
 import Distribution.Verbosity
-import GHC.Stack (HasCallStack, callStack, prettyCallStack)
 import System.IO (hFlush, hPutStr, hPutStrLn)
 import Text.PrettyPrint
 
@@ -88,14 +87,10 @@ infoProgress s = LogProgress $ \env ->
       InfoMsg s
 
 -- | Fail the computation with an error message.
-dieProgress :: HasCallStack => Doc -> LogProgress a
+dieProgress :: Doc -> LogProgress a
 dieProgress s = LogProgress $ \env ->
   failProgress $
-    hang (text "Error:") 4 $
-      vcat
-        [ formatMsg (le_context env) s
-        , vcat (map text (lines (prettyCallStack callStack)))
-        ]
+    hang (text "Error:") 4 (formatMsg (le_context env) s)
 
 -- | Format a message with context. (Something simple for now.)
 formatMsg :: [CtxMsg] -> Doc -> Doc

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -236,7 +236,6 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Distribution.Client.Errors
 import Distribution.Solver.Types.ProjectConfigPath
-import GHC.Stack (HasCallStack)
 import System.Directory (getCurrentDirectory)
 import System.FilePath
 import qualified Text.PrettyPrint as Disp
@@ -352,8 +351,7 @@ sanityCheckElaboratedPackage
 -- | Return the up-to-date project config and information about the local
 -- packages within the project.
 rebuildProjectConfig
-  :: HasCallStack
-  => Verbosity
+  :: Verbosity
   -> HttpTransport
   -> DistDirLayout
   -> ProjectConfig
@@ -667,8 +665,7 @@ See #9840 for more information about the problems surrounding the lossy
 -- dependencies of executables and setup scripts.
 --
 rebuildInstallPlan
-  :: HasCallStack
-  => Verbosity
+  :: Verbosity
   -> DistDirLayout
   -> CabalDirLayout
   -> ProjectConfig
@@ -909,8 +906,7 @@ rebuildInstallPlan
       -- version of the plan has the final nix-style hashed ids.
       --
       phaseElaboratePlan
-        :: HasCallStack
-        => ProjectConfig
+        :: ProjectConfig
         -> (Compiler, Platform, ProgramDb)
         -> Maybe PkgConfigDb
         -> SolverInstallPlan
@@ -1666,8 +1662,7 @@ planPackages
 -- In theory should be able to make an elaborated install plan with a policy
 -- matching that of the classic @cabal install --user@ or @--global@
 elaborateInstallPlan
-  :: HasCallStack
-  => Verbosity
+  :: Verbosity
   -> Platform
   -> Compiler
   -> ProgramDb
@@ -1726,7 +1721,8 @@ elaborateInstallPlan
                   )
           f _ = Nothing
 
-      elaboratedInstallPlan :: LogProgress ElaboratedInstallPlan
+      elaboratedInstallPlan
+        :: LogProgress (InstallPlan.GenericInstallPlan IPI.InstalledPackageInfo ElaboratedConfiguredPackage)
       elaboratedInstallPlan =
         flip InstallPlan.fromSolverInstallPlanWithProgress solverPlan $ \mapDep planpkg ->
           case planpkg of

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
@@ -12,5 +12,5 @@ Failed to build MainIsBench-0.1-inplace-Bench. The exception was:
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
+  dieWithException, called at src/Distribution/Simple/Utils.hs:1392:16 in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
 

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
@@ -11,5 +11,6 @@ Failed to build MainIsExe-0.1-inplace-Exe. The exception was:
 Error: [Cabal-7554]
 can't find source for MyDummy in ., cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/Exe/autogen, cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/global-autogen
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/PreProcess.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.PreProcess
+  dieWithException, called at src/Distribution/Simple/PreProcess.hs:311:11 in Cabal-3.17.0.0-inplace:Distribution.Simple.PreProcess
+
 

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
@@ -12,5 +12,5 @@ Failed to build MainIsTest-0.1-inplace-Test. The exception was:
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
+  dieWithException, called at src/Distribution/Simple/Utils.hs:1392:16 in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
 

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
@@ -5,5 +5,3 @@ Error:
         MissingReq
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
@@ -5,5 +5,3 @@ Error:
         MissingReq
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
@@ -3,5 +3,3 @@ Configuring Fail2-0.1.0.0...
 Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.ConfiguredComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
@@ -3,5 +3,3 @@ Configuring Fail2-0.1.0.0...
 Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.ConfiguredComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
@@ -4,5 +4,3 @@ Error:
     Non-library component has unfilled requirements:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
@@ -4,5 +4,3 @@ Error:
     Non-library component has unfilled requirements:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
@@ -6,5 +6,3 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-a
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
@@ -6,5 +6,3 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-a
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
@@ -7,5 +7,3 @@ Error:
             framework-0.1.0.0 (has unfilled signature: App)
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
@@ -7,5 +7,3 @@ Error:
             framework-0.1.0.0 (has unfilled signature: App)
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
@@ -13,5 +13,3 @@ Error:
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
       While filling requirements of build-depends: fail:mylib
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
@@ -13,5 +13,3 @@ Error:
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
       While filling requirements of build-depends: fail:mylib
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
@@ -8,5 +8,3 @@ Error:
         nor any of its 'build-depends' dependencies.
     In the stanza 'library'
     In the inplace package 'Reexport2-1.0'
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
@@ -7,5 +7,3 @@ Error:
     Try moving this module to a separate library, e.g.,
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
@@ -7,5 +7,3 @@ Error:
     Try moving this module to a separate library, e.g.,
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
@@ -5,5 +5,3 @@ Error:
     Ensure "build-depends:" doesn't include any library with signatures: 'A'
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
@@ -5,5 +5,3 @@ Error:
     Ensure "build-depends:" doesn't include any library with signatures: 'A'
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
@@ -5,8 +5,3 @@ Error:
         library bar
         library foo
     In the inplace package 'DepCycle-1.0'
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectOrchestration

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
@@ -3,5 +3,3 @@ Configuring DepCycle-1.0...
 Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
@@ -3,5 +3,3 @@ Configuring DepCycle-1.0...
 Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
+++ b/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
@@ -4,8 +4,3 @@ Error:
     Internal libraries only supported with per-component builds.
     Per-component builds were disabled because you passed --disable-per-component
     In the inplace package 'p-0.1.0.0'
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectOrchestration

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
@@ -21,5 +21,3 @@ Error:
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
@@ -21,5 +21,3 @@ Error:
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
@@ -7,5 +7,3 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
@@ -7,5 +7,3 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
@@ -7,5 +7,3 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
@@ -7,5 +7,3 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -95,7 +95,6 @@ normalizeOutput nenv =
     -- hackage-security locks occur non-deterministically
     . resub "(Released|Acquired|Waiting) .*hackage-security-lock\n" ""
     . resub "installed: [0-9]+(\\.[0-9]+)*" "installed: <VERSION>"
-    . resub "\\.hs:[0-9]+:[0-9]+" ".hs:_:_"
   where
     sameDir = "(\\.((\\\\)+|\\/))*"
     packageIdRegex pid =


### PR DESCRIPTION
Reverts haskell/cabal#12009

This is necessary, on the 3.18 branch, to fix CI, which breaks in tests modified by this PR, when cabal version is bumped from 3.17 to 3.18. For a proper fix, we probably need to extend the golden test output normalizer.