### PR TITLE
Normalize in-place unit-id versions in golden test output

### DIFF
--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
@@ -11,6 +11,4 @@ Failed to build MainIsBench-0.1-inplace-Bench. The exception was:
   -----BEGIN CABAL OUTPUT-----
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
-CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Simple.Utils
-
+CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsBench/cabal.out
@@ -12,5 +12,5 @@ Failed to build MainIsBench-0.1-inplace-Bench. The exception was:
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
+  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Simple.Utils
 

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
@@ -10,6 +10,4 @@ Failed to build MainIsExe-0.1-inplace-Exe. The exception was:
   -----BEGIN CABAL OUTPUT-----
 Error: [Cabal-7554]
 can't find source for MyDummy in ., cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/Exe/autogen, cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/global-autogen
-CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/PreProcess.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Simple.PreProcess
-
+CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsExe/cabal.out
@@ -11,5 +11,5 @@ Failed to build MainIsExe-0.1-inplace-Exe. The exception was:
 Error: [Cabal-7554]
 can't find source for MyDummy in ., cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/Exe/autogen, cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/MainIsExe-0.1/x/Exe/build/global-autogen
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/PreProcess.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.PreProcess
+  dieWithException, called at src/Distribution/Simple/PreProcess.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Simple.PreProcess
 

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
@@ -11,6 +11,4 @@ Failed to build MainIsTest-0.1-inplace-Test. The exception was:
   -----BEGIN CABAL OUTPUT-----
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
-CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Simple.Utils
-
+CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
+++ b/cabal-testsuite/PackageTests/AutogenModules/MainIsTest/cabal.out
@@ -12,5 +12,5 @@ Failed to build MainIsTest-0.1-inplace-Test. The exception was:
 Error: [Cabal-2115]
 MyDummy.hs doesn't exist
 CallStack (from HasCallStack):
-  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Simple.Utils
+  dieWithException, called at src/Distribution/Simple/Utils.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Simple.Utils
 

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
@@ -5,5 +5,4 @@ Error:
         MissingReq
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.cabal.out
@@ -6,4 +6,4 @@ Error:
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
@@ -5,5 +5,4 @@ Error:
         MissingReq
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail1/setup.out
@@ -6,4 +6,4 @@ Error:
     In mixins: Fail1:sig requires (MissingReq as A)
     In the stanza library
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
@@ -3,5 +3,4 @@ Configuring Fail2-0.1.0.0...
 Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.ConfiguredComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.cabal.out
@@ -4,4 +4,4 @@ Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.ConfiguredComponent
+      dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.ConfiguredComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
@@ -3,5 +3,4 @@ Configuring Fail2-0.1.0.0...
 Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.ConfiguredComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail2/setup.out
@@ -4,4 +4,4 @@ Error:
     Mix-in refers to non-existent library 'non-existent'
     (did you forget to add the package to build-depends?)
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.ConfiguredComponent
+  dieProgress, called at src/Distribution/Backpack/ConfiguredComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.ConfiguredComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
@@ -4,5 +4,4 @@ Error:
     Non-library component has unfilled requirements:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.cabal.out
@@ -5,4 +5,4 @@ Error:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
@@ -5,4 +5,4 @@ Error:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail3/setup.out
@@ -4,5 +4,4 @@ Error:
     Non-library component has unfilled requirements:
         UnfilledSig brought into scope by build-depends: Fail1
     In the stanza executable foo
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
@@ -7,4 +7,4 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.cabal.out
@@ -6,5 +6,4 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-a
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
@@ -6,5 +6,4 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-a
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail4/setup.out
@@ -7,4 +7,4 @@ Error:
             brought into scope by build-depends: Fail4:sig-lib-b
     In the stanza executable foo
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
@@ -8,4 +8,4 @@ Error:
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.cabal.out
@@ -7,5 +7,4 @@ Error:
             framework-0.1.0.0 (has unfilled signature: App)
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
@@ -8,4 +8,4 @@ Error:
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Fail5/setup-external-fail.out
@@ -7,5 +7,4 @@ Error:
             framework-0.1.0.0 (has unfilled signature: App)
               The package is installed as indefinite.
               To use it, rebuild it in the same cabal project as the consumer so cabal can fill the signatures.
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
@@ -14,4 +14,4 @@ Error:
       While filling requirements of build-depends: fail:mylib
     In the stanza library
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
@@ -13,5 +13,4 @@ Error:
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
       While filling requirements of build-depends: fail:mylib
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
@@ -13,5 +13,4 @@ Error:
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
       While filling requirements of build-depends: fail:mylib
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
@@ -14,4 +14,4 @@ Error:
       While filling requirements of build-depends: fail:mylib
     In the stanza library
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
@@ -9,4 +9,4 @@ Error:
     In the stanza 'library'
     In the inplace package 'Reexport2-1.0'
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Reexport2/cabal.out
@@ -8,5 +8,4 @@ Error:
         nor any of its 'build-depends' dependencies.
     In the stanza 'library'
     In the inplace package 'Reexport2-1.0'
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
@@ -8,4 +8,4 @@ Error:
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.cabal.out
@@ -7,5 +7,4 @@ Error:
     Try moving this module to a separate library, e.g.,
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
@@ -8,4 +8,4 @@ Error:
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
@@ -7,5 +7,4 @@ Error:
     Try moving this module to a separate library, e.g.,
     create a new stanza: library 'sublib'.
     In the stanza executable foo-exe
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
@@ -6,4 +6,4 @@ Error:
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.cabal.out
@@ -5,5 +5,4 @@ Error:
     Ensure "build-depends:" doesn't include any library with signatures: 'A'
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
@@ -6,4 +6,4 @@ Error:
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T8582/setup.out
@@ -5,5 +5,4 @@ Error:
     Ensure "build-depends:" doesn't include any library with signatures: 'A'
     as this creates a cyclic dependency, which GHC does not support.
     In the stanza executable exe
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
@@ -6,7 +6,7 @@ Error:
         library foo
     In the inplace package 'DepCycle-1.0'
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectOrchestration
+      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
+      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
+      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
+      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectOrchestration

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/cabal.out
@@ -5,8 +5,4 @@ Error:
         library bar
         library foo
     In the inplace package 'DepCycle-1.0'
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
-      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
-      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
-      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectOrchestration
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
@@ -3,5 +3,4 @@ Configuring DepCycle-1.0...
 Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.cabal.out
@@ -4,4 +4,4 @@ Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
@@ -3,5 +3,4 @@ Configuring DepCycle-1.0...
 Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/DepCycle/setup.out
@@ -4,4 +4,4 @@ Error:
     Components in the package DepCycle-1.0 depend on each other in a cyclic way:
     'library 'bar'' depends on 'library 'foo'' depends on 'library 'bar''
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.Configure
+      dieProgress, called at src/Distribution/Backpack/Configure.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.Configure

--- a/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
+++ b/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
@@ -4,8 +4,4 @@ Error:
     Internal libraries only supported with per-component builds.
     Per-component builds were disabled because you passed --disable-per-component
     In the inplace package 'p-0.1.0.0'
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
-      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
-      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
-      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectOrchestration
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
+++ b/cabal-testsuite/PackageTests/InternalLibraries/cabal-per-package.out
@@ -5,7 +5,7 @@ Error:
     Per-component builds were disabled because you passed --disable-per-component
     In the inplace package 'p-0.1.0.0'
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectPlanning
-      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-3.17.0.0-inplace:Distribution.Client.ProjectOrchestration
+      dieProgress, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
+      elaborateInstallPlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
+      phaseElaboratePlan, called at src/Distribution/Client/ProjectPlanning.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectPlanning
+      rebuildInstallPlan, called at src/Distribution/Client/ProjectOrchestration.hs:_:_ in cabal-install-<VERSION>-inplace:Distribution.Client.ProjectOrchestration

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
@@ -22,4 +22,4 @@ Error:
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
@@ -21,5 +21,4 @@ Error:
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
@@ -21,5 +21,4 @@ Error:
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
@@ -22,4 +22,4 @@ Error:
         The syntax is 'packagename:ModuleName [as NewName]'.
     In the stanza library
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
@@ -8,4 +8,4 @@ Error:
         nor any of its 'build-depends' dependencies.
     In the stanza library
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.cabal.out
@@ -7,5 +7,4 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
@@ -8,4 +8,4 @@ Error:
         nor any of its 'build-depends' dependencies.
     In the stanza library
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-missing.out
@@ -7,5 +7,4 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
@@ -8,4 +8,4 @@ Error:
         nor any of its 'build-depends' dependencies.
     In the stanza library
     CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.cabal.out
@@ -7,5 +7,4 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-      dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
@@ -8,4 +8,4 @@ Error:
         nor any of its 'build-depends' dependencies.
     In the stanza library
     CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-3.17.0.0-inplace:Distribution.Backpack.LinkedComponent
+  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-other.out
@@ -7,5 +7,4 @@ Error:
         It occurs in neither the 'exposed-modules' of this package,
         nor any of its 'build-depends' dependencies.
     In the stanza library
-    CallStack (from HasCallStack):
-  dieProgress, called at src/Distribution/Backpack/LinkedComponent.hs:_:_ in Cabal-<VERSION>-inplace:Distribution.Backpack.LinkedComponent
+    CallStack (from HasCallStack): <SNIPPED>

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -96,6 +96,16 @@ normalizeOutput nenv =
     . resub "(Released|Acquired|Waiting) .*hackage-security-lock\n" ""
     . resub "installed: [0-9]+(\\.[0-9]+)*" "installed: <VERSION>"
     . resub "\\.hs:[0-9]+:[0-9]+" ".hs:_:_"
+    -- CallStack entries reference the in-place unit id of whichever
+    -- boot library (Cabal, Cabal-syntax, cabal-install,
+    -- cabal-install-solver) is being tested, e.g.
+    -- "Cabal-3.17.0.0-inplace:Distribution.Simple.Utils". These
+    -- libraries are all version-bumped together, so their version
+    -- changes on every release; glob it out so golden output doesn't
+    -- go stale on version bumps.
+    . resub
+      "(Cabal-syntax|cabal-install-solver|cabal-install|Cabal)-[0-9]+(\\.[0-9]+)*-inplace"
+      "\\1-<VERSION>-inplace"
   where
     sameDir = "(\\.((\\\\)+|\\/))*"
     packageIdRegex pid =

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -96,16 +96,10 @@ normalizeOutput nenv =
     . resub "(Released|Acquired|Waiting) .*hackage-security-lock\n" ""
     . resub "installed: [0-9]+(\\.[0-9]+)*" "installed: <VERSION>"
     . resub "\\.hs:[0-9]+:[0-9]+" ".hs:_:_"
-    -- CallStack entries reference the in-place unit id of whichever
-    -- boot library (Cabal, Cabal-syntax, cabal-install,
-    -- cabal-install-solver) is being tested, e.g.
-    -- "Cabal-3.17.0.0-inplace:Distribution.Simple.Utils". These
-    -- libraries are all version-bumped together, so their version
-    -- changes on every release; glob it out so golden output doesn't
-    -- go stale on version bumps.
+    -- Remove all lines after "CallStack (from HasCallStack):"
     . resub
-      "(Cabal-syntax|cabal-install-solver|cabal-install|Cabal)-[0-9]+(\\.[0-9]+)*-inplace"
-      "\\1-<VERSION>-inplace"
+      "CallStack \\(from HasCallStack\\):[A-Za-z0-9 \\.,:;'\n/_-]*"
+      "CallStack (from HasCallStack): <SNIPPED>\n"
   where
     sameDir = "(\\.((\\\\)+|\\/))*"
     packageIdRegex pid =


### PR DESCRIPTION
CallStack rendering embeds the in-place unit id of whichever boot library (Cabal, Cabal-syntax, cabal-install, cabal-install-solver) is under test, e.g. "Cabal-3.17.0.0-inplace:Distribution.Simple.Utils". These libraries are version-bumped together on every release, so any golden test capturing such a callstack went stale on the next bump, requiring manual output edits (as happened on the 3.18 branch).

Glob the version out in OutputNormalizer and regenerate the affected golden files.

Fixes #12112.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
