### PR TITLE
Lock store creation against concurrent processes

### DIFF
--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -209,6 +209,9 @@ module Distribution.Simple.Utils
   , isAbsoluteOnAnyPlatform
   , isRelativeOnAnyPlatform
   , exceptionWithCallStackPrefix
+
+    -- * Cross-process locking
+  , withFileLock
   ) where
 
 import Distribution.Compat.Async (waitCatch, withAsyncNF)
@@ -253,6 +256,7 @@ import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
 import qualified Data.Version as DV
 import Distribution.Compat.Process (proc)
 import Foreign.C.Error (Errno (..), ePIPE)
+import GHC.IO.Handle.Lock (LockMode (..), hLock, hTryLock, hUnlock)
 import qualified GHC.IO.Exception as GHC
 import GHC.Stack (HasCallStack)
 import Numeric (showFFloat)
@@ -286,6 +290,7 @@ import System.FilePath as FilePath
 import System.IO
   ( BufferMode (..)
   , Handle
+  , IOMode (..)
   , hClose
   , hFlush
   , hGetContents
@@ -293,6 +298,7 @@ import System.IO
   , hPutStrLn
   , hSetBinaryMode
   , hSetBuffering
+  , openFile
   , stderr
   , stdin
   , stdout
@@ -1604,6 +1610,24 @@ getDirectoryContentsRecursive topdir = recurseDirectories [""]
           if isDirectory
             then collect files (dirEntry : dirs') entries
             else collect (dirEntry : files) dirs' entries
+
+-- | Hold an exclusive cross-process lock on @lockPath@ for the duration of
+-- @action@, creating the lock file if it does not exist.
+withFileLock :: Verbosity -> FilePath -> String -> IO a -> IO a
+withFileLock verbosity lockPath waitMsg action =
+  Exception.bracket takeLock releaseLock (const action)
+  where
+    takeLock = do
+      h <- openFile lockPath ReadWriteMode
+      -- First try non-blocking, but if we would have to wait then
+      -- log an explanation and do it again in blocking mode.
+      gotlock <- hTryLock h ExclusiveLock
+      unless gotlock $ do
+        info verbosity waitMsg
+        hLock h ExclusiveLock
+      return h
+
+    releaseLock h = hUnlock h `Exception.finally` hClose h
 
 ------------------------
 -- Environment variables

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -256,8 +256,8 @@ import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
 import qualified Data.Version as DV
 import Distribution.Compat.Process (proc)
 import Foreign.C.Error (Errno (..), ePIPE)
-import GHC.IO.Handle.Lock (LockMode (..), hLock, hTryLock, hUnlock)
 import qualified GHC.IO.Exception as GHC
+import GHC.IO.Handle.Lock (LockMode (..), hLock, hTryLock, hUnlock)
 import GHC.Stack (HasCallStack)
 import Numeric (showFFloat)
 import System.Directory

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -92,7 +92,7 @@ import Control.Exception (assert, handle)
 import qualified Distribution.Client.IndexUtils as IndexUtils
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import System.Directory (doesDirectoryExist, doesFileExist, renameDirectory)
-import System.FilePath (makeRelative, normalise, takeDirectory, (<.>), (</>))
+import System.FilePath (makeRelative, normalise, takeDirectory, takeFileName, (<.>), (</>))
 import System.Semaphore (SemaphoreIdentifier)
 
 import Distribution.Client.Errors
@@ -502,8 +502,7 @@ configuring individual packages.
     invocation.
 -}
 
--- | Create a package DB if it does not currently exist. Note that this action
--- is /not/ safe to run concurrently.
+-- | Create a package DB if it does not currently exist.
 createPackageDBIfMissing
   :: Verbosity
   -> Compiler
@@ -515,11 +514,25 @@ createPackageDBIfMissing
   compiler
   progdb
   (SpecificPackageDB dbPath) = do
+    -- If it already exists, skip locking.
     exists <- Cabal.doesPackageDBExist dbPath
     unless exists $ do
       createDirectoryIfMissingVerbose verbosity True (takeDirectory dbPath)
-      Cabal.createPackageDB verbosity compiler progdb dbPath
+      withPackageDBLock verbosity dbPath $ do
+        -- Re-check under the lock. Another process may have created the DB
+        -- while we were waiting.
+        exists' <- Cabal.doesPackageDBExist dbPath
+        unless exists' $
+          Cabal.createPackageDB verbosity compiler progdb dbPath
 createPackageDBIfMissing _ _ _ _ = return ()
+
+-- | Hold an exclusive cross-process lock while initialising a package DB.
+withPackageDBLock :: Verbosity -> FilePath -> IO a -> IO a
+withPackageDBLock verbosity dbPath =
+  withFileLock verbosity lockPath waitMsg
+  where
+    lockPath = takeDirectory dbPath </> ('.' : takeFileName dbPath) <.> "lock"
+    waitMsg = "Waiting for file lock on package database " ++ dbPath
 
 -- | Given all the context and resources, (re)build an individual package.
 rebuildTarget

--- a/cabal-install/src/Distribution/Client/Store.hs
+++ b/cabal-install/src/Distribution/Client/Store.hs
@@ -15,6 +15,9 @@ module Distribution.Client.Store
   , newStoreEntry
   , NewStoreEntryOutcome (..)
 
+    -- * Cross-process locking
+  , withFileLock
+
     -- * Concurrency strategy
     -- $concurrency
   ) where
@@ -241,20 +244,28 @@ withIncomingUnitIdLock
   compiler
   unitid
   action =
-    bracket takeLock releaseLock (\_hnd -> action)
+    withFileLock verbosity (storeIncomingLock compiler unitid) waitMsg action
     where
       compid = compilerId compiler
-      takeLock = do
-        h <- openFile (storeIncomingLock compiler unitid) ReadWriteMode
-        -- First try non-blocking, but if we would have to wait then
-        -- log an explanation and do it again in blocking mode.
-        gotlock <- hTryLock h ExclusiveLock
-        unless gotlock $ do
-          info verbosity $
-            "Waiting for file lock on store entry "
-              ++ prettyShow compid
-              </> prettyShow unitid
-          hLock h ExclusiveLock
-        return h
+      waitMsg =
+        "Waiting for file lock on store entry "
+          ++ prettyShow compid
+          </> prettyShow unitid
 
-      releaseLock h = hUnlock h >> hClose h
+-- | Hold an exclusive cross-process lock on @lockPath@ for the duration of
+-- @action@, creating the lock file if it does not exist.
+withFileLock :: Verbosity -> FilePath -> String -> IO a -> IO a
+withFileLock verbosity lockPath waitMsg action =
+  bracket takeLock releaseLock (const action)
+  where
+    takeLock = do
+      h <- openFile lockPath ReadWriteMode
+      -- First try non-blocking, but if we would have to wait then
+      -- log an explanation and do it again in blocking mode.
+      gotlock <- hTryLock h ExclusiveLock
+      unless gotlock $ do
+        info verbosity waitMsg
+        hLock h ExclusiveLock
+      return h
+
+    releaseLock h = hUnlock h `finally` hClose h

--- a/cabal-install/src/Distribution/Client/Store.hs
+++ b/cabal-install/src/Distribution/Client/Store.hs
@@ -15,9 +15,6 @@ module Distribution.Client.Store
   , newStoreEntry
   , NewStoreEntryOutcome (..)
 
-    -- * Cross-process locking
-  , withFileLock
-
     -- * Concurrency strategy
     -- $concurrency
   ) where
@@ -34,15 +31,13 @@ import Distribution.Simple.Compiler (Compiler (..))
 import Distribution.Simple.Utils
   ( debug
   , info
+  , withFileLock
   , withTempDirectory
   )
 
-import Control.Exception
 import qualified Data.Set as Set
-import GHC.IO.Handle.Lock (LockMode (ExclusiveLock), hLock, hTryLock, hUnlock)
 import System.Directory
 import System.FilePath
-import System.IO (IOMode (ReadWriteMode), hClose, openFile)
 
 -- $concurrency
 --
@@ -251,21 +246,3 @@ withIncomingUnitIdLock
         "Waiting for file lock on store entry "
           ++ prettyShow compid
           </> prettyShow unitid
-
--- | Hold an exclusive cross-process lock on @lockPath@ for the duration of
--- @action@, creating the lock file if it does not exist.
-withFileLock :: Verbosity -> FilePath -> String -> IO a -> IO a
-withFileLock verbosity lockPath waitMsg action =
-  bracket takeLock releaseLock (const action)
-  where
-    takeLock = do
-      h <- openFile lockPath ReadWriteMode
-      -- First try non-blocking, but if we would have to wait then
-      -- log an explanation and do it again in blocking mode.
-      gotlock <- hTryLock h ExclusiveLock
-      unless gotlock $ do
-        info verbosity waitMsg
-        hLock h ExclusiveLock
-      return h
-
-    releaseLock h = hUnlock h `finally` hClose h

--- a/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
+++ b/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
@@ -1,0 +1,75 @@
+-- | Regression test for #11329
+--
+-- When several cabal processes share one --store-dir and that store is cold,
+-- they all race 'createPackageDBIfMissing'.
+--
+-- This test builds N independent trivial projects concurrently against one
+-- shared store. Each project gets its own build dir so the only shared state
+-- is the store package DB.
+
+import Control.Concurrent
+import Control.Exception (SomeException, throwIO, try)
+import Control.Monad (forM, forM_)
+import Data.List (isInfixOf)
+import System.Directory (createDirectoryIfMissing, removePathForcibly)
+import System.Exit (ExitCode (..))
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+  env <- getTestEnv
+  cabalPath <- programPath <$> requireProgramM cabalProgram
+  let n = 10
+      ids = [1 .. n] :: [Int]
+      root = testCurrentDir env
+      store = testWorkDir env </> "shared-store"
+      projDir i = root </> ("p" ++ show i)
+      build i =
+        run
+          (Just (projDir i))
+          (testEnvironment env)
+          cabalPath
+          ["--store-dir=" ++ store, "build", "--builddir=" ++ projDir i </> "dist"]
+          Nothing
+
+  -- Generate N independent trivial projects.
+  liftIO $ forM_ ids $ \i -> do
+    let p = projDir i
+    createDirectoryIfMissing True p
+    writeFile (p </> ("p" ++ show i ++ ".cabal")) $
+      unlines
+        [ "cabal-version: 2.4"
+        , "name: p" ++ show i
+        , "version: 0.1"
+        , "executable p" ++ show i
+        , "  main-is: Main.hs"
+        , "  build-depends: base"
+        , "  default-language: Haskell2010"
+        ]
+
+    writeFile (p </> "Main.hs") "main :: IO ()\nmain = return ()\n"
+    writeFile (p </> "cabal.project") "packages: .\n"
+
+  -- Make sure the shared store package DB is cold right before the burst.
+  liftIO $ removePathForcibly store
+
+  -- Build all projects concurrently against the cold shared store.
+  results <- liftIO $ do
+    slots <- forM ids $ \i -> do
+      mv <- newEmptyMVar
+      _ <- forkIO $ do
+        r <- try (build i) :: IO (Either SomeException Result)
+        putMVar mv (i, r)
+      return mv
+    forM slots $ \mv -> do
+      (i, r) <- takeMVar mv
+      either throwIO (\res -> pure (i, res)) r
+
+  liftIO $ forM_ results $ \(i, r) -> do
+    let out = resultOutput r
+    assertBool
+      ("cabal build for p" ++ show i ++ " hit the store package.db init race:\n" ++ out)
+      (not ("already exists" `isInfixOf` out))
+    assertEqual
+      ("cabal build for p" ++ show i ++ " failed:\n" ++ out)
+      ExitSuccess
+      (resultExitCode r)

--- a/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
+++ b/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
@@ -18,6 +18,9 @@ import Test.Cabal.Prelude
 main = cabalTest $ do
   env <- getTestEnv
   cabalPath <- programPath <$> requireProgramM cabalProgram
+  -- The condition we need to test is the small window where multiple cabal
+  -- calls concurrently attempt to create the shared store. Use a sufficiently
+  -- high number to increase the probability of hitting that window.
   let n = 10
       ids = [1 .. n] :: [Int]
       root = testCurrentDir env

--- a/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
+++ b/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
@@ -72,8 +72,8 @@ main = cabalTest $ do
       contended (_, r) =
         "Waiting for file lock on package database" `isInfixOf` resultOutput r
 
-      -- Try the test some times, if they all manage to miss the window. Emit a
-      -- `skip`, as the test is inconclusive.
+      -- Try the test some times. If they all manage to miss the window, emit a
+      -- `fail` as we missed the testing condition.
       go attempt = do
         results <- burst
         liftIO $ forM_ results $ \(i, r) -> do
@@ -89,7 +89,7 @@ main = cabalTest $ do
           if attempt < attempts
             then go (attempt + 1)
             else
-              skip $
+              assertFailure $
                 "no build contended for the store package db lock in "
                   ++ show attempts
                   ++ " attempts"

--- a/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
+++ b/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
@@ -15,7 +15,8 @@ import System.Directory (createDirectoryIfMissing, removePathForcibly)
 import System.Exit (ExitCode (..))
 import Test.Cabal.Prelude
 
-main = cabalTest $ do
+-- Can't seem to hit the race window reliably on a loaded CI runner.
+main = cabalTest . flakyIfCI 11329 $ do
   env <- getTestEnv
   cabalPath <- programPath <$> requireProgramM cabalProgram
   -- The condition we need to test is the small window where multiple cabal

--- a/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
+++ b/cabal-testsuite/PackageTests/ConcurrentStorePackageDb/concurrent-store-init.test.hs
@@ -9,7 +9,7 @@
 
 import Control.Concurrent
 import Control.Exception (SomeException, throwIO, try)
-import Control.Monad (forM, forM_)
+import Control.Monad (forM, forM_, unless)
 import Data.List (isInfixOf)
 import System.Directory (createDirectoryIfMissing, removePathForcibly)
 import System.Exit (ExitCode (..))
@@ -22,6 +22,7 @@ main = cabalTest $ do
   -- calls concurrently attempt to create the shared store. Use a sufficiently
   -- high number to increase the probability of hitting that window.
   let n = 10
+      attempts = 3 :: Int
       ids = [1 .. n] :: [Int]
       root = testCurrentDir env
       store = testWorkDir env </> "shared-store"
@@ -31,7 +32,7 @@ main = cabalTest $ do
           (Just (projDir i))
           (testEnvironment env)
           cabalPath
-          ["--store-dir=" ++ store, "build", "--builddir=" ++ projDir i </> "dist"]
+          ["--store-dir=" ++ store, "build", "-v2", "--builddir=" ++ projDir i </> "dist"]
           Nothing
 
   -- Generate N independent trivial projects.
@@ -52,27 +53,45 @@ main = cabalTest $ do
     writeFile (p </> "Main.hs") "main :: IO ()\nmain = return ()\n"
     writeFile (p </> "cabal.project") "packages: .\n"
 
-  -- Make sure the shared store package DB is cold right before the burst.
-  liftIO $ removePathForcibly store
+  let -- Run the cabal command that exercises the race window.
+      burst = liftIO $ do
+        -- Make sure all package DBs are cold right before the burst.
+        removePathForcibly store
+        forM_ ids $ \i -> removePathForcibly (projDir i </> "dist")
+        slots <- forM ids $ \i -> do
+          mv <- newEmptyMVar
+          _ <- forkIO $ do
+            r <- try (build i) :: IO (Either SomeException Result)
+            putMVar mv (i, r)
+          return mv
+        forM slots $ \mv -> do
+          (i, r) <- takeMVar mv
+          either throwIO (\res -> pure (i, res)) r
 
-  -- Build all projects concurrently against the cold shared store.
-  results <- liftIO $ do
-    slots <- forM ids $ \i -> do
-      mv <- newEmptyMVar
-      _ <- forkIO $ do
-        r <- try (build i) :: IO (Either SomeException Result)
-        putMVar mv (i, r)
-      return mv
-    forM slots $ \mv -> do
-      (i, r) <- takeMVar mv
-      either throwIO (\res -> pure (i, res)) r
+      -- Only a process that blocked on the lock logs this.
+      contended (_, r) =
+        "Waiting for file lock on package database" `isInfixOf` resultOutput r
 
-  liftIO $ forM_ results $ \(i, r) -> do
-    let out = resultOutput r
-    assertBool
-      ("cabal build for p" ++ show i ++ " hit the store package.db init race:\n" ++ out)
-      (not ("already exists" `isInfixOf` out))
-    assertEqual
-      ("cabal build for p" ++ show i ++ " failed:\n" ++ out)
-      ExitSuccess
-      (resultExitCode r)
+      -- Try the test some times, if they all manage to miss the window. Emit a
+      -- `skip`, as the test is inconclusive.
+      go attempt = do
+        results <- burst
+        liftIO $ forM_ results $ \(i, r) -> do
+          let out = resultOutput r
+          assertBool
+            ("cabal build for p" ++ show i ++ " hit the store package.db init race:\n" ++ out)
+            (not ("already exists" `isInfixOf` out))
+          assertEqual
+            ("cabal build for p" ++ show i ++ " failed:\n" ++ out)
+            ExitSuccess
+            (resultExitCode r)
+        unless (any contended results) $
+          if attempt < attempts
+            then go (attempt + 1)
+            else
+              skip $
+                "no build contended for the store package db lock in "
+                  ++ show attempts
+                  ++ " attempts"
+
+  go 1

--- a/changelog.d/pr-12114.md
+++ b/changelog.d/pr-12114.md
@@ -1,0 +1,12 @@
+---
+synopsis: Fix concurrent store creations
+packages: [Cabal]
+prs: 12114
+issues: [11329]
+---
+
+Previously, when several cabal processes share one `--store-dir` and that store
+is cold, they all race `createPackageDBIfMissing`. Precisely hitting the warning
+above it, noting that it is not thread-safe.
+
+Fix this by using a fd-based lock, prior to attempting to create the index.

--- a/changelog.d/pr-12114.md
+++ b/changelog.d/pr-12114.md
@@ -1,6 +1,6 @@
 ---
 synopsis: Fix concurrent store creations
-packages: [Cabal]
+packages: [Cabal, cabal-install]
 prs: 12114
 issues: [11329]
 ---


### PR DESCRIPTION
Fixes https://github.com/haskell/cabal/issues/11329.

Used the hypothesis in https://github.com/haskell/cabal/issues/12111#issue-4882198111 to create a reproducer. Extracted a helper from the code that used fd locks to make concurrent store additions safe, and use that when initializing the store as well.

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [X] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
