### PR TITLE
Exclude testdb/**/AlexTemplate.hs from linting

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -60,11 +60,11 @@
     - --ignore-glob=Cabal-tests/tests/custom-setup/CabalDoctestSetup.hs
     - --ignore-glob=Cabal-tests/tests/custom-setup/IdrisSetup.hs
     - --ignore-glob=cabal-testsuite/PackageTests/BuildWays/q/app/Main.hs
-    - --ignore-glob=cabal-testsuite/PackageTests/CppOptions/CppOpts/Main.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CMain/10168/src/Lib.hs
     - --ignore-glob=cabal-testsuite/PackageTests/Cmm/CmmSources/src/Demo.hs
     - --ignore-glob=cabal-testsuite/PackageTests/Cmm/CmmSourcesDyn/src/Demo.hs
     - --ignore-glob=cabal-testsuite/PackageTests/Cmm/CmmSourcesExe/src/Demo.hs
+    - --ignore-glob=cabal-testsuite/PackageTests/CppOptions/CppOpts/Main.hs
     - --ignore-glob=cabal-testsuite/PackageTests/NewBuild/CmdRun/Script/script.hs
     - --ignore-glob=cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/script.lhs
     - --ignore-glob=cabal-testsuite/PackageTests/Regression/T5309/lib/Bio/Character/Exportable/Class.hs
@@ -80,3 +80,4 @@
     - --ignore-glob=templates/Paths_pkg.template.hs
     - --ignore-glob=templates/SPDX.LicenseExceptionId.template.hs
     - --ignore-glob=templates/SPDX.LicenseId.template.hs
+    - --ignore-glob=testdb/intree/store/**/share/AlexTemplate.hs


### PR DESCRIPTION
Fixes #12115. Excludes `AlexTemplate.hs` from linting and sorts the `--ignore-glob` entries.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
