### PR TITLE
Add appropriate version number for `hooks-exe`

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -250,7 +250,7 @@ library
       , edit-distance >= 0.2.2 && < 0.3
       , exceptions >= 0.10.4   && < 0.11
       , filepath   >= 1.4.0.0  && < 1.6
-      , hooks-exe ^>= 0.1
+      , hooks-exe  >= 3.18     && < 3.19
       , HTTP       >= 4000.1.5 && < 4000.6
       , mtl        >= 2.0      && < 2.4
       , network-uri >= 2.6.2.0 && < 2.7

--- a/hooks-exe/hooks-exe.cabal
+++ b/hooks-exe/hooks-exe.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hooks-exe
-version:       0.1
+version:       3.18
 copyright:     2024, Cabal Development Team
 license:       BSD-3-Clause
 author:        Cabal Development Team <cabal-devel@haskell.org>


### PR DESCRIPTION
We forgot to bump `hooks-exe`, which is now a dependency of `cabal-install`.

Of course `needs-backport master` means “with the appropriate version number”.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* no ~~ [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~
