### PR TITLE
Use parsec parser for project round trip prop tests

### DIFF
--- a/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
@@ -138,6 +138,12 @@ newtype List sep b a = List {_getList :: [a]}
 --
 -- >>> :t alaList' FSep Token
 -- alaList' FSep Token :: [String] -> List FSep Token String
+--
+-- >>> unpack' (alaList' FSep Token) <$> eitherParsec "foo bar foo"
+-- Right ["foo","bar","foo"]
+--
+-- >>> unpack' (alaList' FSep Token) <$> eitherParsec "xL{4,IE-,eK<}fE?e"
+-- Right ["xL{4","IE-","eK<}fE?e"]
 alaList :: sep -> [a] -> List sep (Identity a) a
 alaList _ = List
 

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Module      :  Distribution.Simple.Compiler
@@ -373,8 +374,24 @@ instance Parsec DebugInfoLevel where
 parsecDebugInfoLevel :: CabalParsing m => m DebugInfoLevel
 parsecDebugInfoLevel = flagToDebugInfoLevel . pure <$> parsecToken
 
+-- | Converts a string to a 'DebugInfoLevel'. The string can be either a boolean
+-- or 0-based integer for that enum. Evaluates to the default of 'NoDebugInfo'
+-- when there's no string or when the string is "False".  When the string is
+-- "True", the level is 'NormalDebugInfo'.  These string comparisons are
+-- case-insensitive.
+--
+-- >>> [flagToDebugInfoLevel (Just $ show n) | n <- [0 .. 3]]
+-- [NoDebugInfo,MinimalDebugInfo,NormalDebugInfo,MaximalDebugInfo]
+--
+-- >>> nub $ flagToDebugInfoLevel . Just <$> ["0", "False", "false"]
+-- [NoDebugInfo]
+--
+-- >>> nub $ flagToDebugInfoLevel <$> Nothing : (Just <$> ["2", "True",  "true"])
+-- [NormalDebugInfo]
 flagToDebugInfoLevel :: Maybe String -> DebugInfoLevel
 flagToDebugInfoLevel Nothing = NormalDebugInfo
+flagToDebugInfoLevel (Just (fmap toLower -> "false")) = NoDebugInfo
+flagToDebugInfoLevel (Just (fmap toLower -> "true")) = NormalDebugInfo
 flagToDebugInfoLevel (Just s) = case reads s of
   [(i, "")]
     | i >= fromEnum (minBound :: DebugInfoLevel)

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -359,8 +359,10 @@ intToOptimisationLevel i
 -- level they do support.
 data DebugInfoLevel
   = NoDebugInfo
+  -- ^ The default and disabled level. Disabled by @--disable-debug-info@ or @debug-info: False@.
   | MinimalDebugInfo
   | NormalDebugInfo
+  -- ^ The enabled level when enabled by @--enable-debug-info@ or @debug-info: True@.
   | MaximalDebugInfo
   deriving (Bounded, Enum, Eq, Generic, Read, Show)
 

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -73,6 +73,7 @@ parserTests =
   testGroup
     "project files parsec tests"
     [ testCase "read packages" testPackages
+    , testCase "read packages glob" testPackagesGlob
     , testCase "read packages comma separated" testPackagesCommaSeparated
     , testCase "read optional-packages" testOptionalPackages
     , testCase "read extra-packages" testExtraPackages
@@ -101,6 +102,12 @@ testPackages :: Assertion
 testPackages = do
   let expected = [".", "packages/packages.cabal","a","b"]
   (config, legacy) <- readConfigDefault "packages"
+  assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
+
+testPackagesGlob :: Assertion
+testPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
 
 testPackagesCommaSeparated :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -72,6 +72,7 @@ parserTests =
   testGroup
     "project files parsec tests"
     [ testCase "read packages" testPackages
+    , testCase "read packages comma separated" testPackagesCommaSeparated
     , testCase "read optional-packages" testOptionalPackages
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
@@ -97,8 +98,15 @@ parserTests =
 
 testPackages :: Assertion
 testPackages = do
-  let expected = [".", "packages/packages.cabal"]
+  let expected = [".", "packages/packages.cabal","a","b"]
   (config, legacy) <- readConfigDefault "packages"
+  assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
+
+testPackagesCommaSeparated :: Assertion
+testPackagesCommaSeparated = do
+  let expected = ["xL{4,IE-,eK<}fE?e"]
+  --let expected = ["xL{4","IE-","eK<}fE?e"]
+  (config, legacy) <- readConfig "packages" "cabal.comma-separated.project"
   assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
 
 testOptionalPackages :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -86,6 +86,7 @@ parserTests =
     , testCase "read local-no-index-repos" testLocalNoIndexRepos
     , testCase "set explicit provenance" testProjectConfigProvenance
     , testCase "read project-config-local-packages" testProjectConfigLocalPackages
+    , testCase "read project-config-local-packages-empty-string" testProjectConfigLocalPackagesEmptyString
     , testCase "read project-config-all-packages" testProjectConfigAllPackages
     , testCase "read project-config-specific-packages" testProjectConfigSpecificPackages
     , testCase "test projectConfigAllPackages concatenation" testAllPackagesConcat
@@ -418,6 +419,14 @@ testProjectConfigLocalPackages = do
     packageConfigTestFailWhenNoTestSuites = Flag True
     packageConfigTestTestOptions = [toPathTemplate "--some-option", toPathTemplate "42"]
     packageConfigBenchmarkOptions = [toPathTemplate "--some-benchmark-option", toPathTemplate "--another-option"]
+
+testProjectConfigLocalPackagesEmptyString :: Assertion
+testProjectConfigLocalPackagesEmptyString = do
+  (config, legacy) <- readConfig "project-config-local-packages" "cabal.empty-string.project"
+  assertConfigEquals expected config legacy (field . projectConfigLocalPackages . snd . condTreeData)
+  where
+    field = packageConfigTestHumanLog
+    expected = NoFlag
 
 testProjectConfigAllPackages :: Assertion
 testProjectConfigAllPackages = do

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -85,6 +85,7 @@ parserTests =
     , testCase "read local-no-index-repos" testLocalNoIndexRepos
     , testCase "set explicit provenance" testProjectConfigProvenance
     , testCase "read project-config-local-packages" testProjectConfigLocalPackages
+    , testCase "read project-config-local-packages-empty-string" testProjectConfigLocalPackagesEmptyString
     , testCase "read project-config-all-packages" testProjectConfigAllPackages
     , testCase "read project-config-specific-packages" testProjectConfigSpecificPackages
     , testCase "test projectConfigAllPackages concatenation" testAllPackagesConcat
@@ -417,6 +418,14 @@ testProjectConfigLocalPackages = do
     packageConfigTestFailWhenNoTestSuites = Flag True
     packageConfigTestTestOptions = [toPathTemplate "--some-option", toPathTemplate "42"]
     packageConfigBenchmarkOptions = [toPathTemplate "--some-benchmark-option", toPathTemplate "--another-option"]
+
+testProjectConfigLocalPackagesEmptyString :: Assertion
+testProjectConfigLocalPackagesEmptyString = do
+  (config, legacy) <- readConfig "project-config-local-packages" "cabal.empty-string.project"
+  assertConfigEquals expected config legacy (field . projectConfigLocalPackages . snd . condTreeData)
+  where
+    field = packageConfigTestHumanLog
+    expected = NoFlag
 
 testProjectConfigAllPackages :: Assertion
 testProjectConfigAllPackages = do

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -75,6 +75,7 @@ parserTests =
     , testCase "read packages glob" testPackagesGlob
     , testCase "read packages comma separated" testPackagesCommaSeparated
     , testCase "read optional-packages" testOptionalPackages
+    , testCase "read optional-packages glob" testOptionalPackagesGlob
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
     , testCase "read project-config-build-only" testProjectConfigBuildOnly
@@ -120,6 +121,12 @@ testOptionalPackages :: Assertion
 testOptionalPackages = do
   let expected = [".", "packages/packages.cabal"]
   (config, legacy) <- readConfigDefault "optional-packages"
+  assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
+
+testOptionalPackagesGlob :: Assertion
+testOptionalPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "optional-packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
 
 testSourceRepoList :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -73,6 +73,7 @@ parserTests =
   testGroup
     "project files parsec tests"
     [ testCase "read packages" testPackages
+    , testCase "read packages comma separated" testPackagesCommaSeparated
     , testCase "read optional-packages" testOptionalPackages
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
@@ -98,8 +99,15 @@ parserTests =
 
 testPackages :: Assertion
 testPackages = do
-  let expected = [".", "packages/packages.cabal"]
+  let expected = [".", "packages/packages.cabal","a","b"]
   (config, legacy) <- readConfigDefault "packages"
+  assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
+
+testPackagesCommaSeparated :: Assertion
+testPackagesCommaSeparated = do
+  let expected = ["xL{4,IE-,eK<}fE?e"]
+  --let expected = ["xL{4","IE-","eK<}fE?e"]
+  (config, legacy) <- readConfig "packages" "cabal.comma-separated.project"
   assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
 
 testOptionalPackages :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -76,6 +76,7 @@ parserTests =
     , testCase "read packages glob" testPackagesGlob
     , testCase "read packages comma separated" testPackagesCommaSeparated
     , testCase "read optional-packages" testOptionalPackages
+    , testCase "read optional-packages glob" testOptionalPackagesGlob
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
     , testCase "read project-config-build-only" testProjectConfigBuildOnly
@@ -121,6 +122,12 @@ testOptionalPackages :: Assertion
 testOptionalPackages = do
   let expected = [".", "packages/packages.cabal"]
   (config, legacy) <- readConfigDefault "optional-packages"
+  assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
+
+testOptionalPackagesGlob :: Assertion
+testOptionalPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "optional-packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
 
 testSourceRepoList :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -72,6 +72,7 @@ parserTests =
   testGroup
     "project files parsec tests"
     [ testCase "read packages" testPackages
+    , testCase "read packages glob" testPackagesGlob
     , testCase "read packages comma separated" testPackagesCommaSeparated
     , testCase "read optional-packages" testOptionalPackages
     , testCase "read extra-packages" testExtraPackages
@@ -100,6 +101,12 @@ testPackages :: Assertion
 testPackages = do
   let expected = [".", "packages/packages.cabal","a","b"]
   (config, legacy) <- readConfigDefault "packages"
+  assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
+
+testPackagesGlob :: Assertion
+testPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
 
 testPackagesCommaSeparated :: Assertion

--- a/cabal-install/parser-tests/Tests/files/optional-packages/cabal.glob.project
+++ b/cabal-install/parser-tests/Tests/files/optional-packages/cabal.glob.project
@@ -1,0 +1,3 @@
+-- The glob pattern syntax example from the users guide.
+-- https://github.com/haskell/cabal/blob/d8c1b6f68df0a736c32a15ae85db9ffaf002ecb8/doc/cabal-project-description-file.rst?plain=1#L146
+optional-packages: */*.cabal ../{foo,bar}/

--- a/cabal-install/parser-tests/Tests/files/packages/cabal.comma-separated.project
+++ b/cabal-install/parser-tests/Tests/files/packages/cabal.comma-separated.project
@@ -1,0 +1,5 @@
+-- This example was generated for the property test "round trip packages" and
+-- resulted in this reported difference:
+-- projectPackages = [-"xL{4", -"IE-", -"eK<}fE?e", +"xL{4,IE-,eK<}fE?e"]
+-- projectPackages = [-"7{u", -"{h", -"{=n}}}", +"7{u,{h,{=n}}}"]
+packages: xL{4,IE-,eK<}fE?e

--- a/cabal-install/parser-tests/Tests/files/packages/cabal.glob.project
+++ b/cabal-install/parser-tests/Tests/files/packages/cabal.glob.project
@@ -1,0 +1,3 @@
+-- The glob pattern syntax example from the users guide.
+-- https://github.com/haskell/cabal/blob/d8c1b6f68df0a736c32a15ae85db9ffaf002ecb8/doc/cabal-project-description-file.rst?plain=1#L146
+packages: */*.cabal ../{foo,bar}/

--- a/cabal-install/parser-tests/Tests/files/packages/cabal.project
+++ b/cabal-install/parser-tests/Tests/files/packages/cabal.project
@@ -1,1 +1,2 @@
 packages: . packages/packages.cabal
+packages: a,b

--- a/cabal-install/parser-tests/Tests/files/project-config-local-packages/cabal.empty-string.project
+++ b/cabal-install/parser-tests/Tests/files/project-config-local-packages/cabal.empty-string.project
@@ -1,0 +1,1 @@
+test-log:  

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -16,19 +16,24 @@ import Distribution.Client.CmdInstall.ClientInstallFlags (clientInstallFlagsGram
 import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
+import qualified Distribution.Compat.CharParsing as P
+import Distribution.Compat.Newtype (Newtype)
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
+import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
+import Distribution.Pretty (Pretty (..))
 import Distribution.Simple.Flag
 import Distribution.Simple.InstallDirs
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource (..))
 import Distribution.Solver.Types.ProjectConfigPath
 import Distribution.Solver.Types.Settings (PreferVersion (..))
 import Distribution.Types.PackageVersionConstraint (PackageVersionConstraint (..))
+import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep Token) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep Token) L.projectPackagesOptional
+  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
+  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -38,6 +43,50 @@ projectConfigFieldGrammar source knownPrograms = do
       projectConfigSpecificPackage = mempty
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
+
+newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+
+instance Newtype String PackageLocationToken
+
+instance Parsec PackageLocationToken where
+  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+
+instance Pretty PackageLocationToken where
+  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+
+-- | This matches legacy parsing for @packages@ and @optional-packages@:
+-- supports quoted strings, and for unquoted tokens allows commas only inside
+-- balanced braces (e.g. ../{foo,bar}/).
+parsePackageLocationTokenQ :: CabalParsing m => m String
+parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
+  where
+    parsePackageLocationToken = concat <$> some outerTerm
+    outerTerm = outerToken <|> braces innerTerm
+    innerTerm = concat <$> many (innerToken <|> braces innerTerm)
+    outerToken = P.munch1 outerChar
+    innerToken = P.munch1 innerChar
+    outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
+    innerChar c = not (isSpace c || c == '{' || c == '}')
+    braces p = ("{" <>) . (<> "}") <$> P.between (P.char '{') (P.char '}') p
+
+renderPackageLocationToken :: String -> String
+renderPackageLocationToken s
+  | needsQuoting = show s
+  | otherwise = s
+  where
+    needsQuoting =
+      not (ok 0 s)
+        || s == "." -- . on its own on a line has special meaning
+        || take 2 s == "--" -- on its own line is comment syntax
+    ok :: Int -> String -> Bool
+    ok n [] = n == 0
+    ok _ ('"' : _) = False
+    ok n ('{' : cs) = ok (n + 1) cs
+    ok n ('}' : cs) = ok (n - 1) cs
+    ok n (',' : cs) = (n > 0) && ok n cs
+    ok _ (c : _)
+      | isSpace c = False
+    ok n (_ : cs) = ok n cs
 
 formatPackageVersionConstraints :: [PackageVersionConstraint] -> List CommaVCat (Identity PackageVersionConstraint) PackageVersionConstraint
 formatPackageVersionConstraints = alaList CommaVCat

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -17,7 +17,7 @@ import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
 import qualified Distribution.Compat.CharParsing as P
-import Distribution.Compat.Newtype (Newtype)
+import Distribution.Compat.Lens (Lens')
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
 import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
@@ -32,8 +32,8 @@ import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
+  projectPackages <- getPackageLocationTokens <$> monoidalField "packages" ignoredLens
+  projectPackagesOptional <- getPackageLocationTokens <$> monoidalField "optional-packages" ignoredLens
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -44,15 +44,22 @@ projectConfigFieldGrammar source knownPrograms = do
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
 
-newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+newtype PackageLocationTokens = PackageLocationTokens {getPackageLocationTokens :: [String]}
 
-instance Newtype String PackageLocationToken
+instance Semigroup PackageLocationTokens where
+  PackageLocationTokens a <> PackageLocationTokens b = PackageLocationTokens (a <> b)
 
-instance Parsec PackageLocationToken where
-  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+instance Monoid PackageLocationTokens where
+  mempty = PackageLocationTokens mempty
 
-instance Pretty PackageLocationToken where
-  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+instance Parsec PackageLocationTokens where
+  parsec = PackageLocationTokens <$> parseSep (Proxy :: Proxy FSep) parsePackageLocationTokenQ
+
+instance Pretty PackageLocationTokens where
+  pretty = prettySep (Proxy :: Proxy FSep) . map (PP.text . renderPackageLocationToken) . getPackageLocationTokens
+
+ignoredLens :: Lens' ProjectConfig PackageLocationTokens
+ignoredLens f s = s <$ f mempty
 
 -- | This matches legacy parsing for @packages@ and @optional-packages@:
 -- supports quoted strings, and for unquoted tokens allows commas only inside

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -16,7 +16,7 @@ import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
 import qualified Distribution.Compat.CharParsing as P
-import Distribution.Compat.Newtype (Newtype)
+import Distribution.Compat.Lens (Lens')
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
 import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
@@ -30,8 +30,8 @@ import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
+  projectPackages <- getPackageLocationTokens <$> monoidalField "packages" ignoredLens
+  projectPackagesOptional <- getPackageLocationTokens <$> monoidalField "optional-packages" ignoredLens
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -42,15 +42,22 @@ projectConfigFieldGrammar source knownPrograms = do
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
 
-newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+newtype PackageLocationTokens = PackageLocationTokens {getPackageLocationTokens :: [String]}
 
-instance Newtype String PackageLocationToken
+instance Semigroup PackageLocationTokens where
+  PackageLocationTokens a <> PackageLocationTokens b = PackageLocationTokens (a <> b)
 
-instance Parsec PackageLocationToken where
-  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+instance Monoid PackageLocationTokens where
+  mempty = PackageLocationTokens mempty
 
-instance Pretty PackageLocationToken where
-  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+instance Parsec PackageLocationTokens where
+  parsec = PackageLocationTokens <$> parseSep (Proxy :: Proxy FSep) parsePackageLocationTokenQ
+
+instance Pretty PackageLocationTokens where
+  pretty = prettySep (Proxy :: Proxy FSep) . map (PP.text . renderPackageLocationToken) . getPackageLocationTokens
+
+ignoredLens :: Lens' ProjectConfig PackageLocationTokens
+ignoredLens f s = s <$ f mempty
 
 -- | This matches legacy parsing for @packages@ and @optional-packages@:
 -- supports quoted strings, and for unquoted tokens allows commas only inside

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -15,18 +15,23 @@ import Distribution.Client.CmdInstall.ClientInstallFlags (clientInstallFlagsGram
 import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
+import qualified Distribution.Compat.CharParsing as P
+import Distribution.Compat.Newtype (Newtype)
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
+import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
+import Distribution.Pretty (Pretty (..))
 import Distribution.Simple.Flag
 import Distribution.Simple.InstallDirs
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource (..))
 import Distribution.Solver.Types.ProjectConfigPath
 import Distribution.Types.PackageVersionConstraint (PackageVersionConstraint (..))
+import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep Token) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep Token) L.projectPackagesOptional
+  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
+  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -36,6 +41,50 @@ projectConfigFieldGrammar source knownPrograms = do
       projectConfigSpecificPackage = mempty
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
+
+newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+
+instance Newtype String PackageLocationToken
+
+instance Parsec PackageLocationToken where
+  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+
+instance Pretty PackageLocationToken where
+  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+
+-- | This matches legacy parsing for @packages@ and @optional-packages@:
+-- supports quoted strings, and for unquoted tokens allows commas only inside
+-- balanced braces (e.g. ../{foo,bar}/).
+parsePackageLocationTokenQ :: CabalParsing m => m String
+parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
+  where
+    parsePackageLocationToken = concat <$> some outerTerm
+    outerTerm = outerToken <|> braces innerTerm
+    innerTerm = concat <$> many (innerToken <|> braces innerTerm)
+    outerToken = P.munch1 outerChar
+    innerToken = P.munch1 innerChar
+    outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
+    innerChar c = not (isSpace c || c == '{' || c == '}')
+    braces p = ("{" <>) . (<> "}") <$> P.between (P.char '{') (P.char '}') p
+
+renderPackageLocationToken :: String -> String
+renderPackageLocationToken s
+  | needsQuoting = show s
+  | otherwise = s
+  where
+    needsQuoting =
+      not (ok 0 s)
+        || s == "." -- . on its own on a line has special meaning
+        || take 2 s == "--" -- on its own line is comment syntax
+    ok :: Int -> String -> Bool
+    ok n [] = n == 0
+    ok _ ('"' : _) = False
+    ok n ('{' : cs) = ok (n + 1) cs
+    ok n ('}' : cs) = ok (n - 1) cs
+    ok n (',' : cs) = (n > 0) && ok n cs
+    ok _ (c : _)
+      | isSpace c = False
+    ok n (_ : cs) = ok n cs
 
 formatPackageVersionConstraints :: [PackageVersionConstraint] -> List CommaVCat (Identity PackageVersionConstraint) PackageVersionConstraint
 formatPackageVersionConstraints = alaList CommaVCat

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1240,6 +1240,13 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
 
 parseLegacyProjectConfigFields :: ProjectConfigPath -> [ParseUtils.Field] -> ParseResult LegacyProjectConfig
 parseLegacyProjectConfigFields (ConstraintSourceProjectConfig -> constraintSrc) =
+  parseLegacyProjectConfigFieldsWithConstraintSource constraintSrc
+
+parseLegacyProjectConfigFieldsWithConstraintSource
+  :: ConstraintSource
+  -> [ParseUtils.Field]
+  -> ParseResult LegacyProjectConfig
+parseLegacyProjectConfigFieldsWithConstraintSource constraintSrc =
   parseFieldsAndSections
     (legacyProjectConfigFieldDescrs constraintSrc)
     legacyPackageConfigSectionDescrs
@@ -1266,12 +1273,14 @@ showLegacyProjectConfig config =
     constraintSrc = ConstraintSourceProjectConfig nullProjectConfigPath
 
 -- |
+-- >>> parseLegacyPackages "foo"
+-- ParseOk [] ["foo"]
 --
--- :{
--- fields <- readFields "packages: foo"
--- parseFieldsAndSections (legacyProjectConfigFieldDescrs ConstraintSourceUnknown fields) mempty
--- :}
+-- >>> parseLegacyPackages "xL{4,IE-,eK<}fE?e"
+-- ParseOk [] ["xL{4,IE-,eK<}fE?e"]
 --
+-- >>> parseLegacyPackages "7{u,{h,{=n}}}"
+-- ParseOk [] ["7{u,{h,{=n}}}"]
 legacyProjectConfigFieldDescrs :: ConstraintSource -> [FieldDescr LegacyProjectConfig]
 legacyProjectConfigFieldDescrs constraintSrc =
   [ newLineListField
@@ -2060,3 +2069,11 @@ showTokenQ "" = Disp.empty
 showTokenQ x@('-' : '-' : _) = Disp.text (show x)
 showTokenQ x@['.'] = Disp.text (show x)
 showTokenQ x = showToken x
+
+-- $setup
+-- >>> :{
+-- parseLegacyPackages s = legacyPackages <$>
+--   parseLegacyProjectConfigFieldsWithConstraintSource
+--     ConstraintSourceUnknown
+--     [ParseUtils.F 1 "packages" s]
+-- :}

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1240,6 +1240,13 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
 
 parseLegacyProjectConfigFields :: ProjectConfigPath -> [ParseUtils.Field] -> ParseResult LegacyProjectConfig
 parseLegacyProjectConfigFields (ConstraintSourceProjectConfig -> constraintSrc) =
+  parseLegacyProjectConfigFieldsWithConstraintSource constraintSrc
+
+parseLegacyProjectConfigFieldsWithConstraintSource
+  :: ConstraintSource
+  -> [ParseUtils.Field]
+  -> ParseResult LegacyProjectConfig
+parseLegacyProjectConfigFieldsWithConstraintSource constraintSrc =
   parseFieldsAndSections
     (legacyProjectConfigFieldDescrs constraintSrc)
     legacyPackageConfigSectionDescrs
@@ -1266,12 +1273,14 @@ showLegacyProjectConfig config =
     constraintSrc = ConstraintSourceProjectConfig nullProjectConfigPath
 
 -- |
+-- >>> parseLegacyPackages "foo"
+-- ParseOk [] ["foo"]
 --
--- :{
--- fields <- readFields "packages: foo"
--- parseFieldsAndSections (legacyProjectConfigFieldDescrs ConstraintSourceUnknown fields) mempty
--- :}
+-- >>> parseLegacyPackages "xL{4,IE-,eK<}fE?e"
+-- ParseOk [] ["xL{4,IE-,eK<}fE?e"]
 --
+-- >>> parseLegacyPackages "7{u,{h,{=n}}}"
+-- ParseOk [] ["7{u,{h,{=n}}}"]
 legacyProjectConfigFieldDescrs :: ConstraintSource -> [FieldDescr LegacyProjectConfig]
 legacyProjectConfigFieldDescrs constraintSrc =
   [ newLineListField
@@ -2061,3 +2070,11 @@ showTokenQ "" = Disp.empty
 showTokenQ x@('-' : '-' : _) = Disp.text (show x)
 showTokenQ x@['.'] = Disp.text (show x)
 showTokenQ x = showToken x
+
+-- $setup
+-- >>> :{
+-- parseLegacyPackages s = legacyPackages <$>
+--   parseLegacyProjectConfigFieldsWithConstraintSource
+--     ConstraintSourceUnknown
+--     [ParseUtils.F 1 "packages" s]
+-- :}

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1265,6 +1265,13 @@ showLegacyProjectConfig config =
     -- but requires re-work of how we annotate provenance.
     constraintSrc = ConstraintSourceProjectConfig nullProjectConfigPath
 
+-- |
+--
+-- :{
+-- fields <- readFields "packages: foo"
+-- parseFieldsAndSections (legacyProjectConfigFieldDescrs ConstraintSourceUnknown fields) mempty
+-- :}
+--
 legacyProjectConfigFieldDescrs :: ConstraintSource -> [FieldDescr LegacyProjectConfig]
 legacyProjectConfigFieldDescrs constraintSrc =
   [ newLineListField

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1273,14 +1273,29 @@ showLegacyProjectConfig config =
     constraintSrc = ConstraintSourceProjectConfig nullProjectConfigPath
 
 -- |
--- >>> parseLegacyPackages "foo"
+-- >>> parseLegacyConvert projectPackages "packages" "foo"
 -- ParseOk [] ["foo"]
 --
--- >>> parseLegacyPackages "xL{4,IE-,eK<}fE?e"
+-- >>> parseLegacyConvert projectPackages "packages" "xL{4,IE-,eK<}fE?e"
 -- ParseOk [] ["xL{4,IE-,eK<}fE?e"]
 --
--- >>> parseLegacyPackages "7{u,{h,{=n}}}"
+-- >>> parseLegacyConvert projectPackages "packages" "7{u,{h,{=n}}}"
 -- ParseOk [] ["7{u,{h,{=n}}}"]
+--
+-- >>> parseLegacyConvert (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" ""
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" " "
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" " \n"
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigHaddockHtmlLocation . projectConfigAllPackages) "haddock-html-location" ""
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigHaddockHtmlLocation . projectConfigAllPackages) "haddock-html-location" " "
+-- ParseOk [] (Last {getLast = Nothing})
 legacyProjectConfigFieldDescrs :: ConstraintSource -> [FieldDescr LegacyProjectConfig]
 legacyProjectConfigFieldDescrs constraintSrc =
   [ newLineListField
@@ -2073,8 +2088,17 @@ showTokenQ x = showToken x
 
 -- $setup
 -- >>> :{
--- parseLegacyPackages s = legacyPackages <$>
+-- parseLegacy :: (LegacyProjectConfig -> a) -> String -> String -> ParseResult a
+-- parseLegacy f field s =  f <$>
 --   parseLegacyProjectConfigFieldsWithConstraintSource
 --     ConstraintSourceUnknown
---     [ParseUtils.F 1 "packages" s]
+--     [ParseUtils.F 1 field s]
+-- :}
+--
+-- >>> :{
+-- parseLegacyConvert :: (ProjectConfig -> a) -> String -> String -> ParseResult a
+-- parseLegacyConvert f field s =  (f . convertLegacyProjectConfig) <$>
+--   parseLegacyProjectConfigFieldsWithConstraintSource
+--     ConstraintSourceUnknown
+--     [ParseUtils.F 1 field s]
 -- :}

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1273,14 +1273,29 @@ showLegacyProjectConfig config =
     constraintSrc = ConstraintSourceProjectConfig nullProjectConfigPath
 
 -- |
--- >>> parseLegacyPackages "foo"
+-- >>> parseLegacyConvert projectPackages "packages" "foo"
 -- ParseOk [] ["foo"]
 --
--- >>> parseLegacyPackages "xL{4,IE-,eK<}fE?e"
+-- >>> parseLegacyConvert projectPackages "packages" "xL{4,IE-,eK<}fE?e"
 -- ParseOk [] ["xL{4,IE-,eK<}fE?e"]
 --
--- >>> parseLegacyPackages "7{u,{h,{=n}}}"
+-- >>> parseLegacyConvert projectPackages "packages" "7{u,{h,{=n}}}"
 -- ParseOk [] ["7{u,{h,{=n}}}"]
+--
+-- >>> parseLegacyConvert (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" ""
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" " "
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" " \n"
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigHaddockHtmlLocation . projectConfigAllPackages) "haddock-html-location" ""
+-- ParseOk [] (Last {getLast = Nothing})
+--
+-- >>> parseLegacyConvert (packageConfigHaddockHtmlLocation . projectConfigAllPackages) "haddock-html-location" " "
+-- ParseOk [] (Last {getLast = Nothing})
 legacyProjectConfigFieldDescrs :: ConstraintSource -> [FieldDescr LegacyProjectConfig]
 legacyProjectConfigFieldDescrs constraintSrc =
   [ newLineListField
@@ -2072,8 +2087,17 @@ showTokenQ x = showToken x
 
 -- $setup
 -- >>> :{
--- parseLegacyPackages s = legacyPackages <$>
+-- parseLegacy :: (LegacyProjectConfig -> a) -> String -> String -> ParseResult a
+-- parseLegacy f field s =  f <$>
 --   parseLegacyProjectConfigFieldsWithConstraintSource
 --     ConstraintSourceUnknown
---     [ParseUtils.F 1 "packages" s]
+--     [ParseUtils.F 1 field s]
+-- :}
+--
+-- >>> :{
+-- parseLegacyConvert :: (ProjectConfig -> a) -> String -> String -> ParseResult a
+-- parseLegacyConvert f field s =  (f . convertLegacyProjectConfig) <$>
+--   parseLegacyProjectConfigFieldsWithConstraintSource
+--     ConstraintSourceUnknown
+--     [ParseUtils.F 1 field s]
 -- :}

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
@@ -4,6 +4,7 @@
 module Distribution.Client.ProjectConfig.Parsec
   ( -- * Package configuration
     parseProject
+  , parseProjectConfig
   , ProjectConfig (..)
 
     -- ** Parsing
@@ -174,18 +175,6 @@ parseProjectSkeleton cacheDir httpTransport verbosity projectDir source (Project
     parseImport :: Position -> [FieldLine Position] -> ParseResult ProjectFileSource FilePath
     parseImport pos lines' = runFieldParser pos (P.many P.anyChar) cabalSpec lines'
 
-    -- We want a normalized path for @fieldsToConfig@. This eventually surfaces
-    -- in solver rejection messages and build messages "this build was affected
-    -- by the following (project) config files" so we want all paths shown there
-    -- to be relative to the directory of the project, not relative to the file
-    -- they were imported from.
-    fieldsToConfig :: ProjectConfigPath -> [Field Position] -> ParseResult ProjectFileSource ProjectConfig
-    fieldsToConfig sourceConfigPath xs = do
-      let (fs, sectionGroups) = partitionFields xs
-          sections = concat sectionGroups
-      config <- parseFieldGrammarCheckingStanzas cabalSpec fs (projectConfigFieldGrammar sourceConfigPath (knownProgramNames programDb)) stanzas
-      config' <- view stateConfig <$> execStateT (goSections programDb sections) (SectionS config)
-      return config'
     modifiesCompiler :: ProjectConfig -> Bool
     modifiesCompiler pc = isSet projectConfigHcFlavor || isSet projectConfigHcPath || isSet projectConfigHcPkg
       where
@@ -199,7 +188,24 @@ parseProjectSkeleton cacheDir httpTransport verbosity projectDir source (Project
     sanityWalkBranch :: CondBranch ConfVar ([(Maybe URI, ProjectConfigPath)], ProjectConfig) -> ParseResult ProjectFileSource ()
     sanityWalkBranch (CondBranch _c t f) = traverse_ (sanityWalkPCS True) f >> sanityWalkPCS True t >> pure ()
 
+-- We want a normalized path for @fieldsToConfig@. This eventually surfaces
+-- in solver rejection messages and build messages "this build was affected
+-- by the following (project) config files" so we want all paths shown there
+-- to be relative to the directory of the project, not relative to the file
+-- they were imported from.
+fieldsToConfig :: ProjectConfigPath -> [Field Position] -> ParseResult ProjectFileSource ProjectConfig
+fieldsToConfig sourceConfigPath xs = do
+  let (fs, sectionGroups) = partitionFields xs
+      sections = concat sectionGroups
+  config <- parseFieldGrammarCheckingStanzas cabalSpec fs (projectConfigFieldGrammar sourceConfigPath (knownProgramNames programDb)) stanzas
+  config' <- view stateConfig <$> execStateT (goSections programDb sections) (SectionS config)
+  return config'
+  where
     programDb = defaultProgramDb
+
+parseProjectConfig :: FilePath -> BS.ByteString -> ParseResult ProjectFileSource ProjectConfig
+parseProjectConfig rootConfig bs =
+  fieldsToConfig (ProjectConfigPath $ rootConfig :| []) =<< readPreprocessFields bs
 
 startOfSection :: Position -> [SectionArg Position] -> Position
 -- The case where we have no args is the start of the section

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
@@ -203,6 +203,30 @@ fieldsToConfig sourceConfigPath xs = do
   where
     programDb = defaultProgramDb
 
+-- |
+-- >>> parseParsec projectPackages "packages" "foo"
+-- ([],Right ["foo"])
+--
+-- >>> parseParsec projectPackages "packages" "xL{4,IE-,eK<}fE?e"
+-- ([],Right ["xL{4,IE-,eK<}fE?e"])
+--
+-- >>> parseParsec projectPackages "packages" "7{u,{h,{=n}}}"
+-- ([],Right ["7{u,{h,{=n}}}"])
+--
+-- >>> parseParsec projectPackages "test-log" ""
+-- ([],Right [])
+--
+-- >>> parseParsec (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" " "
+-- ([],Right (Last {getLast = Nothing}))
+--
+-- >>> parseParsec (packageConfigTestHumanLog . projectConfigAllPackages) "test-log" " \n"
+-- ([],Right (Last {getLast = Nothing}))
+
+-- >>> parseParsec (packageConfigHaddockHtmlLocation . projectConfigAllPackages) "haddock-html-location" ""
+-- ([],Right (Last {getLast = Nothing}))
+
+-- >>> parseParsec (packageConfigHaddockHtmlLocation . projectConfigAllPackages) "haddock-html-location" " "
+-- ([],Right (Last {getLast = Nothing}))
 parseProjectConfig :: FilePath -> BS.ByteString -> ParseResult ProjectFileSource ProjectConfig
 parseProjectConfig rootConfig bs =
   fieldsToConfig (ProjectConfigPath $ rootConfig :| []) =<< readPreprocessFields bs
@@ -411,3 +435,15 @@ warnUnknownFields fieldName fieldLines = for_ fieldLines (\field -> parseWarning
 
 cabalSpec :: CabalSpecVersion
 cabalSpec = cabalSpecLatest
+
+-- $setup
+-- >>> :set -XViewPatterns
+-- >>> instance (Show a, Show b) => Show (ParseResult a b) where show = show . runParseResult
+--
+-- >>> :{
+-- parseParsec :: (ProjectConfig -> a) -> String -> String -> ParseResult ProjectFileSource a
+-- parseParsec f (toUTF8BS -> field) (toUTF8BS -> s) = f <$>
+--   fieldsToConfig
+--     nullProjectConfigPath
+--     [Field (Name zeroPos field) [FieldLine zeroPos s]]
+-- :}

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -260,9 +260,11 @@ prop_roundtrip_legacytypes_specific config =
 roundtrip_printparse :: ProjectConfig -> Property
 roundtrip_printparse config =
   case runParseResult $ parseProjectConfig "unused" (toUTF8BS str) of
-    (_, Right x) ->
+    (_, Right result) ->
       counterexample ("shown:\n" ++ str) $
-        x `ediffEq` config{projectConfigProvenance = mempty}
+        ediffEq
+          result{projectConfigProvenance = mempty}
+          config{projectConfigProvenance = mempty}
     (_, Left err) -> counterexample ("shown:\n" ++ str ++ "\nERROR: " ++ show err) False
   where
     str :: String

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -78,12 +78,12 @@ tests =
       ]
   , testGroup
       "ProjectConfig printing/parsing round trip"
-      [ testProperty "packages" prop_roundtrip_printparse_packages
-      , testProperty "buildonly" prop_roundtrip_printparse_buildonly
-      , testProperty "shared" prop_roundtrip_printparse_shared
-      , testProperty "local" prop_roundtrip_printparse_local
-      , testProperty "specific" prop_roundtrip_printparse_specific
-      , testProperty "all" prop_roundtrip_printparse_all
+      [ testProperty "round trip packages" prop_roundtrip_printparse_packages
+      , testProperty "round trip buildonly" prop_roundtrip_printparse_buildonly
+      , testProperty "round trip shared" prop_roundtrip_printparse_shared
+      , testProperty "round trip local" prop_roundtrip_printparse_local
+      , testProperty "round trip specific" prop_roundtrip_printparse_specific
+      , testProperty "round trip all" prop_roundtrip_printparse_all
       ]
   , testGetProjectRootUsability
   , testFindProjectRoot

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -48,6 +48,7 @@ import Distribution.Solver.Types.Settings
 
 import Distribution.Client.ProjectConfig
 import Distribution.Client.ProjectConfig.Legacy
+import Distribution.Client.ProjectConfig.Parsec
 
 import UnitTests.Distribution.Client.ArbitraryInstances
 import UnitTests.Distribution.Client.TreeDiffInstances ()

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -17,7 +17,6 @@ import System.Directory (canonicalizePath, withCurrentDirectory)
 import System.FilePath
 import System.IO.Unsafe (unsafePerformIO)
 
-import Distribution.Deprecated.ParseUtils
 import qualified Distribution.Deprecated.ReadP as Parse
 
 import Distribution.Package
@@ -260,11 +259,11 @@ prop_roundtrip_legacytypes_specific config =
 
 roundtrip_printparse :: ProjectConfig -> Property
 roundtrip_printparse config =
-  case fmap convertLegacyProjectConfig (parseLegacyProjectConfig "unused" (toUTF8BS str)) of
-    ParseOk _ x ->
+  case runParseResult $ parseProjectConfig "unused" (toUTF8BS str) of
+    (_, Right x) ->
       counterexample ("shown:\n" ++ str) $
         x `ediffEq` config{projectConfigProvenance = mempty}
-    ParseFailed err -> counterexample ("shown:\n" ++ str ++ "\nERROR: " ++ show err) False
+    (_, Left err) -> counterexample ("shown:\n" ++ str ++ "\nERROR: " ++ show err) False
   where
     str :: String
     str = showLegacyProjectConfig (convertToLegacyProjectConfig config)

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -258,17 +258,19 @@ prop_roundtrip_legacytypes_specific config =
 --
 
 roundtrip_printparse :: ProjectConfig -> Property
-roundtrip_printparse config =
+roundtrip_printparse config = countering $
   case runParseResult $ parseProjectConfig "unused" (toUTF8BS str) of
     (_, Right result) ->
-      counterexample ("shown:\n" ++ str) $
         ediffEq
           result{projectConfigProvenance = mempty}
           config{projectConfigProvenance = mempty}
-    (_, Left err) -> counterexample ("shown:\n" ++ str ++ "\nERROR: " ++ show err) False
+    (_, Left err) -> counterexample ("ERROR: " ++ show err) False
   where
     str :: String
     str = showLegacyProjectConfig (convertToLegacyProjectConfig config)
+    countering =
+      counterexample ("shown:\n" ++ str) .
+      counterexample ("shown by line:\n" ++ unlines (map (\s -> "'" ++ s ++ "'") (lines str)))
 
 prop_roundtrip_printparse_all :: ProjectConfig -> Property
 prop_roundtrip_printparse_all config =

--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.project
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.project
@@ -1,0 +1,2 @@
+optional-packages: .
+debug-info: True


### PR DESCRIPTION
I've started working on #12138. This changes the property tests for round trip printing and parsing of projects to use the parsec parser from #8889.

Adds `parseProjectConfig` and exports this from `Distribution.Client.ProjectConfig.Parsec`. This is used for testing and is the equivalent of:

https://github.com/haskell/cabal/blob/4907eec7b275aa0e1a31333fc745b3cc9f023f4f/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs#L1250-L1252

The `parseProjectConfig` function could be defined in the test suite but then we'd have to export `fieldsToConfig` and `readPreprocessFields`:

```diff
$ git diff
 module Distribution.Client.ProjectConfig.Parsec
   ( -- * Package configuration
     parseProject
-  , parseProjectConfig
   , ProjectConfig (..)
 
     -- ** Parsing
   , ParseResult
   , runParseResult
+  , readPreprocessFields
+  , fieldsToConfig
   ) where
```

## Differences

There are test failures with commas in the packages field:

```
$ cabal run cabal-install:unit-tests -- -p "round trip packages"
...
Unit Tests
  UnitTests.Distribution.Client.ProjectConfig
    ProjectConfig printing/parsing round trip
      round trip packages: FAIL
        *** Failed! Falsified (after 8 tests and 5 shrinks):
        [PackageLocationString {getPackageLocationString = "Z%{w=g,MZ}"}]
        []
        []
        []
        shown:
        packages: Z%{w=g,MZ}
        
        ProjectConfig {
          projectPackages = [-"Z%{w=g", -"MZ}", +"Z%{w=g,MZ}"],
...
        Use --quickcheck-replay="(SMGen 14836990702317481085 1208827380667102593,7)" to reproduce.
```

There are test failures with commas in the shared test:

```
$ cabal run cabal-install:unit-tests -- -p "round trip shared"
...
Unit Tests
  UnitTests.Distribution.Client.ProjectConfig
    ProjectConfig printing/parsing round trip
      round trip shared: FAIL
        *** Failed! Falsified (after 2 tests and 26 shrinks):
        ProjectConfigShared {projectConfigDistDir = Last {getLast = Nothing}, projectConfigConfigFile = Last {getLast = Nothing}, projectConfigProjectDir = Last {getLast = Nothing}, projectConfigProjectFile = Last {getLast = Nothing}, projectConfigProjectFileParser = Last {getLast = Nothing}, projectConfigIgnoreProject = Last {getLast = Nothing}, projectConfigHcFlavor = Last {getLast = Nothing}, projectConfigHcPath = Last {getLast = Nothing}, projectConfigHcPkg = Last {getLast = Nothing}, projectConfigHaddockIndex = Last {getLast = Nothing}, projectConfigInstallDirs = InstallDirs {prefix = Last {getLast = Just "y"}, bindir = Last {getLast = Nothing}, libdir = Last {getLast = Nothing}, libsubdir = Last {getLast = Just "6"}, dynlibdir = Last {getLast = Just "a"}, bytecodelibdir = Last {getLast = Just "G"}, flibdir = Last {getLast = Nothing}, libexecdir = Last {getLast = Just "f"}, libexecsubdir = Last {getLast = Just "/"}, includedir = Last {getLast = Nothing}, datadir = Last {getLast = Just "r"}, datasubdir = Last {getLast = Just "?"}, docdir = Last {getLast = Just ","}, mandir = Last {getLast = Nothing}, htmldir = Last {getLast = Just "1"}, haddockdir = Last {getLast = Nothing}, sysconfdir = Last {getLast = Just "T"}}, projectConfigPackageDBs = [], projectConfigRemoteRepos = [], projectConfigLocalNoIndexRepos = [], projectConfigActiveRepos = Last {getLast = Nothing}, projectConfigIndexState = Last {getLast = Nothing}, projectConfigStoreDir = Last {getLast = Nothing}, projectConfigConstraints = [], projectConfigPreferences = [], projectConfigCabalVersion = Last {getLast = Nothing}, projectConfigSolver = Last {getLast = Nothing}, projectConfigAllowOlder = Nothing, projectConfigAllowNewer = Nothing, projectConfigWriteGhcEnvironmentFilesPolicy = Last {getLast = Nothing}, projectConfigMaxBackjumps = Last {getLast = Nothing}, projectConfigReorderGoals = Last {getLast = Nothing}, projectConfigCountConflicts = Last {getLast = Nothing}, projectConfigFineGrainedConflicts = Last {getLast = Nothing}, projectConfigMinimizeConflictSet = Last {getLast = Nothing}, projectConfigStrongFlags = Last {getLast = Nothing}, projectConfigAllowBootLibInstalls = Last {getLast = Nothing}, projectConfigOnlyConstrained = Last {getLast = Nothing}, projectConfigPerComponent = Last {getLast = Nothing}, projectConfigIndependentGoals = Last {getLast = Nothing}, projectConfigPreferOldest = Last {getLast = Nothing}, projectConfigProgPathExtra = [], projectConfigMultiRepl = Last {getLast = Nothing}}
        shown:
        prefix: y
        libsubdir: 6
        dynlibdir: a
        bytecodelibdir: G
        libexecdir: f
        libexecsubdir: /
        datadir: r
        datasubdir: ?
        docdir: ,
        htmldir: 1
        sysconfdir: T
        
        ERROR: (Nothing,PErrorWithSource {perrorSource = PUnknownSource, perror = PError {perrorPosition = Position 9 9, perrorMessage = "\nunexpected ','\nexpecting white space, string, identifier or end of input\n"}} :| [])
        Use --quickcheck-replay="(SMGen 4102444156980047325 2848404851119429861,1)" to reproduce.
```

There's a test failure in the local test parsing the debug level:

```
$ cabal run cabal-install:unit-tests -- -p "round trip local"
...
Unit Tests
  UnitTests.Distribution.Client.ProjectConfig
    ProjectConfig printing/parsing round trip
      round trip local: FAIL (0.01s)
        *** Failed! Exception: 'Can't parse debug info level False' (after 2 tests and 41 shrinks):
        PackageConfig {packageConfigProgramPaths = MapLast {getMapLast = fromList []}, packageConfigProgramArgs = MapMappend {getMapMappend = fromList []}, packageConfigProgramPathExtra = [], packageConfigFlagAssignment = fromList [], packageConfigVanillaLib = Last {getLast = Nothing}, packageConfigSharedLib = Last {getLast = Nothing}, packageConfigStaticLib = Last {getLast = Nothing}, packageConfigBytecodeLib = Last {getLast = Nothing}, packageConfigDynExe = Last {getLast = Nothing}, packageConfigFullyStaticExe = Last {getLast = Nothing}, packageConfigProf = Last {getLast = Nothing}, packageConfigProfLib = Last {getLast = Nothing}, packageConfigProfShared = Last {getLast = Nothing}, packageConfigProfExe = Last {getLast = Nothing}, packageConfigProfDetail = Last {getLast = Nothing}, packageConfigProfLibDetail = Last {getLast = Nothing}, packageConfigConfigureArgs = [], packageConfigOptimization = Last {getLast = Nothing}, packageConfigProgPrefix = Last {getLast = Nothing}, packageConfigProgSuffix = Last {getLast = Nothing}, packageConfigExtraLibDirs = [], packageConfigExtraLibDirsStatic = [], packageConfigExtraFrameworkDirs = [], packageConfigExtraIncludeDirs = [], packageConfigGHCiLib = Last {getLast = Nothing}, packageConfigSplitSections = Last {getLast = Nothing}, packageConfigSplitObjs = Last {getLast = Nothing}, packageConfigStripExes = Last {getLast = Nothing}, packageConfigStripLibs = Last {getLast = Nothing}, packageConfigTests = Last {getLast = Nothing}, packageConfigBenchmarks = Last {getLast = Nothing}, packageConfigCoverage = Last {getLast = Nothing}, packageConfigRelocatable = Last {getLast = Nothing}, packageConfigDebugInfo = Last {getLast = Just NoDebugInfo}, packageConfigDumpBuildInfo = Last {getLast = Nothing}, packageConfigRunTests = Last {getLast = Nothing}, packageConfigDocumentation = Last {getLast = Nothing}, packageConfigHaddockHoogle = Last {getLast = Nothing}, packageConfigHaddockHtml = Last {getLast = Nothing}, packageConfigHaddockHtmlLocation = Last {getLast = Nothing}, packageConfigHaddockForeignLibs = Last {getLast = Nothing}, packageConfigHaddockExecutables = Last {getLast = Nothing}, packageConfigHaddockTestSuites = Last {getLast = Nothing}, packageConfigHaddockBenchmarks = Last {getLast = Nothing}, packageConfigHaddockInternal = Last {getLast = Nothing}, packageConfigHaddockCss = Last {getLast = Nothing}, packageConfigHaddockLinkedSource = Last {getLast = Nothing}, packageConfigHaddockQuickJump = Last {getLast = Nothing}, packageConfigHaddockHscolourCss = Last {getLast = Nothing}, packageConfigHaddockContents = Last {getLast = Nothing}, packageConfigHaddockIndex = Last {getLast = Nothing}, packageConfigHaddockBaseUrl = Last {getLast = Nothing}, packageConfigHaddockResourcesDir = Last {getLast = Nothing}, packageConfigHaddockOutputDir = Last {getLast = Nothing}, packageConfigHaddockUseUnicode = Last {getLast = Nothing}, packageConfigHaddockForHackage = Last {getLast = Nothing}, packageConfigTestHumanLog = Last {getLast = Nothing}, packageConfigTestMachineLog = Last {getLast = Nothing}, packageConfigTestShowDetails = Last {getLast = Nothing}, packageConfigTestKeepTix = Last {getLast = Nothing}, packageConfigTestWrapper = Last {getLast = Nothing}, packageConfigTestFailWhenNoTestSuites = Last {getLast = Nothing}, packageConfigTestTestOptions = [], packageConfigBenchmarkOptions = []}
        shown:
        debug-info: False
        
        Exception thrown while showing test case: 'Can't parse debug info level False'
        Use --quickcheck-replay="(SMGen 3113468884534292331 13010642303015172695,1)" to reproduce.
```

There's a test failure in the specific test parsing the debug level (same goes for the all test):

```
$ cabal run cabal-install:unit-tests -- -p "round trip specific"
Warning: this is a debug build of cabal-install with assertions enabled.
Unit Tests
  UnitTests.Distribution.Client.ProjectConfig
    ProjectConfig printing/parsing round trip
      round trip specific: FAIL (0.02s)
        *** Failed! Exception: 'Can't parse debug info level False' (after 3 tests and 43 shrinks):
        fromList [(PackageName "I",NonMEmpty {getNonMEmpty = PackageConfig {packageConfigProgramPaths = MapLast {getMapLast = fromList []}, packageConfigProgramArgs = MapMappend {getMapMappend = fromList []}, packageConfigProgramPathExtra = [], packageConfigFlagAssignment = fromList [], packageConfigVanillaLib = Last {getLast = Nothing}, packageConfigSharedLib = Last {getLast = Nothing}, packageConfigStaticLib = Last {getLast = Nothing}, packageConfigBytecodeLib = Last {getLast = Nothing}, packageConfigDynExe = Last {getLast = Nothing}, packageConfigFullyStaticExe = Last {getLast = Nothing}, packageConfigProf = Last {getLast = Nothing}, packageConfigProfLib = Last {getLast = Nothing}, packageConfigProfShared = Last {getLast = Nothing}, packageConfigProfExe = Last {getLast = Nothing}, packageConfigProfDetail = Last {getLast = Nothing}, packageConfigProfLibDetail = Last {getLast = Nothing}, packageConfigConfigureArgs = [], packageConfigOptimization = Last {getLast = Nothing}, packageConfigProgPrefix = Last {getLast = Nothing}, packageConfigProgSuffix = Last {getLast = Nothing}, packageConfigExtraLibDirs = [], packageConfigExtraLibDirsStatic = [], packageConfigExtraFrameworkDirs = [], packageConfigExtraIncludeDirs = [], packageConfigGHCiLib = Last {getLast = Nothing}, packageConfigSplitSections = Last {getLast = Nothing}, packageConfigSplitObjs = Last {getLast = Nothing}, packageConfigStripExes = Last {getLast = Nothing}, packageConfigStripLibs = Last {getLast = Nothing}, packageConfigTests = Last {getLast = Nothing}, packageConfigBenchmarks = Last {getLast = Nothing}, packageConfigCoverage = Last {getLast = Nothing}, packageConfigRelocatable = Last {getLast = Nothing}, packageConfigDebugInfo = Last {getLast = Just NoDebugInfo}, packageConfigDumpBuildInfo = Last {getLast = Nothing}, packageConfigRunTests = Last {getLast = Nothing}, packageConfigDocumentation = Last {getLast = Nothing}, packageConfigHaddockHoogle = Last {getLast = Nothing}, packageConfigHaddockHtml = Last {getLast = Nothing}, packageConfigHaddockHtmlLocation = Last {getLast = Nothing}, packageConfigHaddockForeignLibs = Last {getLast = Nothing}, packageConfigHaddockExecutables = Last {getLast = Nothing}, packageConfigHaddockTestSuites = Last {getLast = Nothing}, packageConfigHaddockBenchmarks = Last {getLast = Nothing}, packageConfigHaddockInternal = Last {getLast = Nothing}, packageConfigHaddockCss = Last {getLast = Nothing}, packageConfigHaddockLinkedSource = Last {getLast = Nothing}, packageConfigHaddockQuickJump = Last {getLast = Nothing}, packageConfigHaddockHscolourCss = Last {getLast = Nothing}, packageConfigHaddockContents = Last {getLast = Nothing}, packageConfigHaddockIndex = Last {getLast = Nothing}, packageConfigHaddockBaseUrl = Last {getLast = Nothing}, packageConfigHaddockResourcesDir = Last {getLast = Nothing}, packageConfigHaddockOutputDir = Last {getLast = Nothing}, packageConfigHaddockUseUnicode = Last {getLast = Nothing}, packageConfigHaddockForHackage = Last {getLast = Nothing}, packageConfigTestHumanLog = Last {getLast = Nothing}, packageConfigTestMachineLog = Last {getLast = Nothing}, packageConfigTestShowDetails = Last {getLast = Nothing}, packageConfigTestKeepTix = Last {getLast = Nothing}, packageConfigTestWrapper = Last {getLast = Nothing}, packageConfigTestFailWhenNoTestSuites = Last {getLast = Nothing}, packageConfigTestTestOptions = [], packageConfigBenchmarkOptions = []}})]
        shown:
        
        package I
          debug-info: False
        
        Exception thrown while showing test case: 'Can't parse debug info level False'
        Use --quickcheck-replay="(SMGen 18355447672091957642 9032507782252479951,2)" to reproduce.
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
