### PR TITLE
Add parsing debug-info test

### DIFF
--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.boolean.project
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.boolean.project
@@ -1,0 +1,3 @@
+packages: .
+debug-info: False
+debug-info: True

--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.numeric.project
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.numeric.project
@@ -1,0 +1,5 @@
+packages: .
+debug-info: 0
+debug-info: 1
+debug-info: 2
+debug-info: 3

--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.out
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.out
@@ -1,0 +1,10 @@
+# cabal build
+Warnings found while parsing the project file, cabal.numeric.project:
+ - cabal.numeric.project:2:1: The field "debug-info" is specified more than once at positions 2:1, 3:1, 4:1, 5:1
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - debug-info-0 (lib) (first run)
+# cabal build
+Warnings found while parsing the project file, cabal.boolean.project:
+ - cabal.boolean.project:2:1: The field "debug-info" is specified more than once at positions 2:1, 3:1

--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.test.hs
@@ -1,0 +1,12 @@
+import Test.Cabal.Prelude
+
+main = cabalTest . recordMode RecordMarked $ do
+  let errMsg = "Can't parse debug info level"
+
+  numeric <- cabal' "build" ["--project-file=cabal.numeric.project", "--dry-run"]
+  assertOutputDoesNotContain errMsg numeric
+
+  boolean <- fails $ cabal' "build" ["--project-file=cabal.boolean.project", "--dry-run"]
+  -- TODO: When fixed, change this to assertOutputDoesNotContain.
+  assertOutputContains errMsg boolean
+  pure ()

--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/debug-info.cabal
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/debug-info.cabal
@@ -1,0 +1,7 @@
+cabal-version: 3.0
+name: debug-info
+version: 0
+build-type: Simple
+
+library
+  default-language: Haskell2010


### PR DESCRIPTION
Adds a test for the reproduction of #12140 with a TODO describing what to do when the behaviour is fixed.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
