### PR TITLE
doc: replace removed extensions field with default-extensions in examples

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -80,15 +80,16 @@ computer architecture and user-specified configuration flags.
 
 ::
 
-    name:     Foo
-    version:  1.0
+    cabal-version: 3.0
+    name:          Foo
+    version:       1.0
 
     library
-      default-language: Haskell2010
-      build-depends:    base >= 4 && < 5
-      exposed-modules:  Foo
-      extensions:       ForeignFunctionInterface
-      ghc-options:      -Wall
+      default-language:   Haskell2010
+      build-depends:      base >= 4 && < 5
+      exposed-modules:    Foo
+      default-extensions: ForeignFunctionInterface
+      ghc-options:        -Wall
       if os(windows)
         build-depends: Win32 >= 2.1 && < 2.6
 
@@ -3342,7 +3343,7 @@ use different versions of the API?
 
 Haskell lets you preprocess your code using the C preprocessor (either
 the real C preprocessor, or ``cpphs``). To enable this, add
-``extensions: CPP`` to your package description. When using CPP, Cabal
+``default-extensions: CPP`` to your package description. When using CPP, Cabal
 provides some pre-defined macros to let you test the version of
 dependent packages; for example, suppose your package works with either
 version 3 or version 4 of the ``base`` package, you could select the


### PR DESCRIPTION
Fixes #11984.

Two examples in `doc/cabal-package-description-file.rst` still used the `extensions` field, which was deprecated in Cabal 1.10 and removed in 3.0. Replaced both with `default-extensions` and gave the first example a `cabal-version` field.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
