### PR TITLE
Use usageAlternatives with v2-clean

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdClean.hs
+++ b/cabal-install/src/Distribution/Client/CmdClean.hs
@@ -37,6 +37,7 @@ import Distribution.Simple.Command
   , ShowOrParseArgs
   , liftOptionL
   , option
+  , usageAlternatives
   )
 import Distribution.Simple.Setup
   ( Flag
@@ -118,8 +119,7 @@ cleanCommand =
   CommandUI
     { commandName = "v2-clean"
     , commandSynopsis = "Clean the package store and remove temporary files."
-    , commandUsage = \pname ->
-        "Usage: " ++ pname ++ " new-clean [FLAGS]\n"
+    , commandUsage = usageAlternatives "v2-clean" ["[FLAGS]"]
     , commandDescription = Just $ \_ ->
         wrapText $
           "Removes all temporary files created during the building process "


### PR DESCRIPTION
Fixes #12148.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
