### PR TITLE
Filter all commands, leave no other commands

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -100,8 +100,7 @@ outdatedCommand =
           "Checks for outdated dependencies in the package description file "
             ++ "or freeze file"
     , commandNotes = Nothing
-    , commandUsage = \pname ->
-        "Usage: " ++ pname ++ " outdated [FLAGS] [PACKAGES]\n"
+    , commandUsage = usageAlternatives "v2-outdated" ["[FLAGS] [PACKAGES]"]
     , commandDefaultFlags = defaultNixStyleFlags defaultOutdatedFlags
     , commandOptions = nixStyleOptions $ \showOrParseArgs ->
         outdatedOptions showOrParseArgs

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -316,6 +316,8 @@ globalCommand commands =
               , "new-clean"
               , "new-sdist"
               , "new-haddock-project"
+              , "new-gen-bounds"
+              , "new-outdated"
               , "list-bin"
               , -- v1 commands, stateful style
                 "v1-build"
@@ -335,6 +337,7 @@ globalCommand commands =
               , "v1-copy"
               , "v1-register"
               , "v1-reconfigure"
+              , "v1-gen-bounds"
               , -- v2 commands, nix-style
                 "v2-target"
               , "v2-build"
@@ -351,6 +354,8 @@ globalCommand commands =
               , "v2-install"
               , "v2-clean"
               , "v2-sdist"
+              , "v2-gen-bounds"
+              , "v2-outdated"
               ]
           maxlen = maximum $ [length name | (name, _) <- cmdDescs]
           align str = str ++ replicate (maxlen - length str) ' '
@@ -424,6 +429,8 @@ globalCommand commands =
                 , addCmd "v2-install"
                 , addCmd "v2-clean"
                 , addCmd "v2-sdist"
+                , addCmd "v2-outdated"
+                , addCmd "v2-gen-bounds"
                 , par
                 , startGroup "legacy command aliases"
                 , addCmd "v1-build"
@@ -439,6 +446,7 @@ globalCommand commands =
                 , addCmd "v1-copy"
                 , addCmd "v1-register"
                 , addCmd "v1-reconfigure"
+                , addCmd "v1-gen-bounds"
                 ]
                   ++ if null otherCmds
                     then []


### PR DESCRIPTION
Fixes #12150.

```diff
$ cabal run cabal-install:exe:cabal -- --help > before-help.txt

$ cabal run cabal-install:exe:cabal -- --help > after-help.txt

$ diff before-help.txt after-help.txt --unified
...
 Command line interface to the Haskell Cabal infrastructure.
 
 See http://www.haskell.org/cabal/ for more information.
@@ -83,6 +67,8 @@
   v2-install             Install packages.
   v2-clean               Clean the package store and remove temporary files.
   v2-sdist               Generate a source distribution file (.tar.gz).
+  v2-outdated            Check for outdated dependencies.
+  v2-gen-bounds          Generate dependency bounds for packages in the project.
 
  [legacy command aliases]
   v1-build               Compile all/specific components.
@@ -98,12 +84,6 @@
   v1-copy                Copy the files of all/specific components to install locations.
   v1-register            Register this package with the compiler.
   v1-reconfigure         Reconfigure the package if necessary.
-
- [other]
-  new-gen-bounds         Generate dependency bounds for packages in the project.
-  v2-gen-bounds          Generate dependency bounds for packages in the project.
-  new-outdated           Check for outdated dependencies.
-  v2-outdated            Check for outdated dependencies.
   v1-gen-bounds          Generate dependency bounds.
 
 For more information about a command use:
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
