### PR TITLE
Avoid re-validating when decoding from Binary or Read

### DIFF
--- a/Cabal-syntax/src/Distribution/Compat/Graph.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Graph.hs
@@ -123,12 +123,12 @@ data Graph a = Graph
 instance Show a => Show (Graph a) where
   show = show . toList
 
-instance (IsNode a, Read a, Show (Key a)) => Read (Graph a) where
-  readsPrec d s = map (first fromDistinctList) (readsPrec d s)
+instance (IsNode a, Read a) => Read (Graph a) where
+  readsPrec d s = map (first fromDistinctListTrusted) (readsPrec d s)
 
-instance (IsNode a, Binary a, Show (Key a)) => Binary (Graph a) where
+instance (IsNode a, Binary a) => Binary (Graph a) where
   put x = put (toList x)
-  get = fmap fromDistinctList get
+  get = fmap fromDistinctListTrusted get
 
 instance Structured a => Structured (Graph a) where
   structure p = Nominal (typeRep p) 0 "Graph" [structure (Proxy :: Proxy a)]
@@ -391,6 +391,15 @@ fromDistinctList =
       error $
         "Graph.fromDistinctList: duplicate key: "
           ++ show (nodeKey n)
+
+-- | Like 'fromDistinctList', but for reconstructing a graph whose keys are
+-- already known to be distinct — in particular a graph produced by 'toList'
+-- and round-tripped through the 'Binary'/'Read' instances. It performs no
+-- duplicate-key check, and so (unlike 'fromDistinctList') does not require
+-- @Show (Key a)@.
+fromDistinctListTrusted :: IsNode a => [a] -> Graph a
+fromDistinctListTrusted =
+  fromMap . Map.fromList . map (\n -> n `seq` (nodeKey n, n))
 
 -- Map-like operations
 

--- a/cabal-install/src/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/src/Distribution/Client/InstallPlan.hs
@@ -314,10 +314,14 @@ instance
       , planIndepGoals = indepGoals
       } = put graph >> put indepGoals
 
+  -- Reconstruct the plan directly rather than routing through 'mkInstallPlan':
+  -- the bytes were serialised from a valid plan, so re-running the invariant
+  -- check on decode is redundant (and would 'error' rather than fail the
+  -- decode). This keeps 'get' the inverse of 'put'.
   get = do
     graph <- get
     indepGoals <- get
-    return $! mkInstallPlan "(instance Binary)" graph indepGoals
+    pure $! GenericInstallPlan graph indepGoals
 
 data ShowPlanNode = ShowPlanNode
   { showPlanHerald :: Doc

--- a/changelog.d/decode-no-revalidate.md
+++ b/changelog.d/decode-no-revalidate.md
@@ -1,0 +1,16 @@
+---
+synopsis: Don't re-validate serialised graphs and install plans on decode
+packages: [Cabal-syntax, cabal-install]
+prs: 12169
+significance:
+---
+
+- The `Binary` and `Read` instances of `Distribution.Compat.Graph.Graph` no
+  longer re-check key uniqueness when decoding, and consequently no longer
+  require `Show (Key a)`. Decoding now simply inverts encoding, trusting that
+  serialised data was produced from a valid graph. This is a backwards-compatible
+  widening of the instance contexts.
+- `Binary (GenericInstallPlan …)` likewise reconstructs the plan directly
+  instead of routing through `mkInstallPlan`, so it no longer re-runs the
+  plan-validity check (which `error`ed rather than failing the decode) on cached
+  data.


### PR DESCRIPTION
The Binary and Read instances rebuilt the graph with fromDistinctList, which re-checks key uniqueness and calls 'error' (stringifying the key with 'show') on a duplicate. That check is pointless on data we serialised ourselves from an already-valid graph, yet it forced a Show (Key a) constraint onto both instances purely to format that panic. Decode now reconstructs directly or via a non-validating helper, dropping the Show (Key a) constraint.

`Binary (GenericInstallPlan …)` had the same shape one layer up: its `get` routed
through `mkInstallPlan`, re-running the plan-validity check (which `error`s rather
than failing the decode) on cached data. It now reconstructs the plan directly.

This is an interface change to `Cabal-syntax` — the `Binary`/`Read (Graph a)`
instances require fewer constraints — but a **backwards-compatible widening**: no
existing caller breaks.

- [x] Patches conform to the coding conventions. (fourmolu + hlint clean.)
- [x] Changes recorded in the changelog (`changelog.d/decode-no-revalidate.md`).
  - [ ] Not significant — backwards-compatible, no user-visible behaviour change.
- [x] Documentation updated, if necessary. (N/A — internal.)
- [x] QA notes: cache serialisation round-trips are unaffected; `Distribution.Compat.Graph` (4 props) and `InstallPlan` (5 props) unit suites pass.
- [ ] Tests: covered by the existing Graph/InstallPlan round-trip & consistency suites; no new test added since this is a constraint relaxation exercised by existing coverage.
