### PR TITLE
Grant write permissions for contents in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   pull-requests: read
+  contents: write
 
 env:
   BUILD_LABEL: "run release build"


### PR DESCRIPTION
avoid

> GitHub release failed with status: 403
> Resource not accessible by integration
> Skip retry — your GitHub token/PAT does not have the required permission to create a release

in the release workflow

e.g. https://github.com/haskell/cabal/actions/runs/30353923781

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
