### PR TITLE
Fix project packages glob parsing

### DIFF
--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -73,6 +73,7 @@ parserTests =
   testGroup
     "project files parsec tests"
     [ testCase "read packages" testPackages
+    , testCase "read packages glob" testPackagesGlob
     , testCase "read optional-packages" testOptionalPackages
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
@@ -100,6 +101,12 @@ testPackages :: Assertion
 testPackages = do
   let expected = [".", "packages/packages.cabal"]
   (config, legacy) <- readConfigDefault "packages"
+  assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
+
+testPackagesGlob :: Assertion
+testPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
 
 testOptionalPackages :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -75,6 +75,7 @@ parserTests =
     [ testCase "read packages" testPackages
     , testCase "read packages glob" testPackagesGlob
     , testCase "read optional-packages" testOptionalPackages
+    , testCase "read optional-packages glob" testOptionalPackagesGlob
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
     , testCase "read project-config-build-only" testProjectConfigBuildOnly
@@ -113,6 +114,12 @@ testOptionalPackages :: Assertion
 testOptionalPackages = do
   let expected = [".", "packages/packages.cabal"]
   (config, legacy) <- readConfigDefault "optional-packages"
+  assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
+
+testOptionalPackagesGlob :: Assertion
+testOptionalPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "optional-packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
 
 testSourceRepoList :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -74,6 +74,7 @@ parserTests =
     [ testCase "read packages" testPackages
     , testCase "read packages glob" testPackagesGlob
     , testCase "read optional-packages" testOptionalPackages
+    , testCase "read optional-packages glob" testOptionalPackagesGlob
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
     , testCase "read project-config-build-only" testProjectConfigBuildOnly
@@ -112,6 +113,12 @@ testOptionalPackages :: Assertion
 testOptionalPackages = do
   let expected = [".", "packages/packages.cabal"]
   (config, legacy) <- readConfigDefault "optional-packages"
+  assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
+
+testOptionalPackagesGlob :: Assertion
+testOptionalPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "optional-packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackagesOptional . snd . condTreeData)
 
 testSourceRepoList :: Assertion

--- a/cabal-install/parser-tests/Tests/ParserTests.hs
+++ b/cabal-install/parser-tests/Tests/ParserTests.hs
@@ -72,6 +72,7 @@ parserTests =
   testGroup
     "project files parsec tests"
     [ testCase "read packages" testPackages
+    , testCase "read packages glob" testPackagesGlob
     , testCase "read optional-packages" testOptionalPackages
     , testCase "read extra-packages" testExtraPackages
     , testCase "read source-repository-package" testSourceRepoList
@@ -99,6 +100,12 @@ testPackages :: Assertion
 testPackages = do
   let expected = [".", "packages/packages.cabal"]
   (config, legacy) <- readConfigDefault "packages"
+  assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
+
+testPackagesGlob :: Assertion
+testPackagesGlob = do
+  let expected = ["*/*.cabal", "../{foo,bar}/"]
+  (config, legacy) <- readConfig "packages" "cabal.glob.project"
   assertConfigEquals expected config legacy (projectPackages . snd . condTreeData)
 
 testOptionalPackages :: Assertion

--- a/cabal-install/parser-tests/Tests/files/optional-packages/cabal.glob.project
+++ b/cabal-install/parser-tests/Tests/files/optional-packages/cabal.glob.project
@@ -1,0 +1,3 @@
+-- The glob pattern syntax example from the users guide.
+-- https://github.com/haskell/cabal/blob/d8c1b6f68df0a736c32a15ae85db9ffaf002ecb8/doc/cabal-project-description-file.rst?plain=1#L146
+optional-packages: */*.cabal ../{foo,bar}/

--- a/cabal-install/parser-tests/Tests/files/packages/cabal.glob.project
+++ b/cabal-install/parser-tests/Tests/files/packages/cabal.glob.project
@@ -1,0 +1,3 @@
+-- The glob pattern syntax example from the users guide.
+-- https://github.com/haskell/cabal/blob/d8c1b6f68df0a736c32a15ae85db9ffaf002ecb8/doc/cabal-project-description-file.rst?plain=1#L146
+packages: */*.cabal ../{foo,bar}/

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -13,6 +13,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.Set as Set
 import Distribution.CabalSpecVersion (CabalSpecVersion (..))
 import Distribution.Client.CmdInstall.ClientInstallFlags (clientInstallFlagsGrammar)
+import Distribution.Client.ProjectConfig.Legacy (renderPackageLocationToken)
 import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
@@ -75,25 +76,6 @@ parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
     outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
     innerChar c = not (isSpace c || c == '{' || c == '}')
     braces p = ("{" <>) . (<> "}") <$> P.between (P.char '{') (P.char '}') p
-
-renderPackageLocationToken :: String -> String
-renderPackageLocationToken s
-  | needsQuoting = show s
-  | otherwise = s
-  where
-    needsQuoting =
-      not (ok 0 s)
-        || s == "." -- . on its own on a line has special meaning
-        || take 2 s == "--" -- on its own line is comment syntax
-    ok :: Int -> String -> Bool
-    ok n [] = n == 0
-    ok _ ('"' : _) = False
-    ok n ('{' : cs) = ok (n + 1) cs
-    ok n ('}' : cs) = ok (n - 1) cs
-    ok n (',' : cs) = (n > 0) && ok n cs
-    ok _ (c : _)
-      | isSpace c = False
-    ok n (_ : cs) = ok n cs
 
 formatPackageVersionConstraints :: [PackageVersionConstraint] -> List CommaVCat (Identity PackageVersionConstraint) PackageVersionConstraint
 formatPackageVersionConstraints = alaList CommaVCat

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -16,19 +16,24 @@ import Distribution.Client.CmdInstall.ClientInstallFlags (clientInstallFlagsGram
 import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
+import qualified Distribution.Compat.CharParsing as P
+import Distribution.Compat.Newtype (Newtype)
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
+import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
+import Distribution.Pretty (Pretty (..))
 import Distribution.Simple.Flag
 import Distribution.Simple.InstallDirs
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource (..))
 import Distribution.Solver.Types.ProjectConfigPath
 import Distribution.Solver.Types.Settings (PreferVersion (..))
 import Distribution.Types.PackageVersionConstraint (PackageVersionConstraint (..))
+import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep Token) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep Token) L.projectPackagesOptional
+  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
+  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -38,6 +43,50 @@ projectConfigFieldGrammar source knownPrograms = do
       projectConfigSpecificPackage = mempty
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
+
+newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+
+instance Newtype String PackageLocationToken
+
+instance Parsec PackageLocationToken where
+  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+
+instance Pretty PackageLocationToken where
+  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+
+-- | This matches legacy parsing for @packages@ and @optional-packages@:
+-- supports quoted strings, and for unquoted tokens allows commas only inside
+-- balanced braces (e.g. ../{foo,bar}/).
+parsePackageLocationTokenQ :: CabalParsing m => m String
+parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
+  where
+    parsePackageLocationToken = concat <$> some outerTerm
+    outerTerm = outerToken <|> braces innerTerm
+    innerTerm = concat <$> many (innerToken <|> braces innerTerm)
+    outerToken = P.munch1 outerChar
+    innerToken = P.munch1 innerChar
+    outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
+    innerChar c = not (isSpace c || c == '{' || c == '}')
+    braces p = ("{" <>) . (<> "}") <$> P.between (P.char '{') (P.char '}') p
+
+renderPackageLocationToken :: String -> String
+renderPackageLocationToken s
+  | needsQuoting = show s
+  | otherwise = s
+  where
+    needsQuoting =
+      not (ok 0 s)
+        || s == "." -- . on its own on a line has special meaning
+        || take 2 s == "--" -- on its own line is comment syntax
+    ok :: Int -> String -> Bool
+    ok n [] = n == 0
+    ok _ ('"' : _) = False
+    ok n ('{' : cs) = ok (n + 1) cs
+    ok n ('}' : cs) = ok (n - 1) cs
+    ok n (',' : cs) = (n > 0) && ok n cs
+    ok _ (c : _)
+      | isSpace c = False
+    ok n (_ : cs) = ok n cs
 
 formatPackageVersionConstraints :: [PackageVersionConstraint] -> List CommaVCat (Identity PackageVersionConstraint) PackageVersionConstraint
 formatPackageVersionConstraints = alaList CommaVCat

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -66,8 +66,8 @@ ignoredLens f s = s <$ f mempty
 -- supports quoted strings, and for unquoted tokens allows commas only inside
 -- balanced braces (e.g. ../{foo,bar}/).
 --
--- >>> prettyShow <$> (simpleParsec "packages: */*.cabal ../{foo,bar}/" :: Maybe PackageLocationTokens)
--- Just "packages: */*.cabal ../{foo,bar}/"
+-- >>> getPackageLocationTokens <$> (simpleParsec "*/*.cabal ../{foo,bar}/" :: Maybe PackageLocationTokens)
+-- Just ["*/*.cabal","../{foo,bar}/"]
 parsePackageLocationTokenQ :: CabalParsing m => m String
 parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
   where
@@ -251,4 +251,3 @@ packageConfigPreferVersion =
 
 -- $setup
 -- >>> import Distribution.Parsec (simpleParsec)
--- >>> import Distribution.Pretty (prettyShow)

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -17,7 +17,7 @@ import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
 import qualified Distribution.Compat.CharParsing as P
-import Distribution.Compat.Newtype (Newtype)
+import Distribution.Compat.Lens (Lens')
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
 import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
@@ -32,8 +32,8 @@ import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
+  projectPackages <- getPackageLocationTokens <$> monoidalField "packages" ignoredLens
+  projectPackagesOptional <- getPackageLocationTokens <$> monoidalField "optional-packages" ignoredLens
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -44,15 +44,22 @@ projectConfigFieldGrammar source knownPrograms = do
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
 
-newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+newtype PackageLocationTokens = PackageLocationTokens {getPackageLocationTokens :: [String]}
 
-instance Newtype String PackageLocationToken
+instance Semigroup PackageLocationTokens where
+  PackageLocationTokens a <> PackageLocationTokens b = PackageLocationTokens (a <> b)
 
-instance Parsec PackageLocationToken where
-  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+instance Monoid PackageLocationTokens where
+  mempty = PackageLocationTokens mempty
 
-instance Pretty PackageLocationToken where
-  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+instance Parsec PackageLocationTokens where
+  parsec = PackageLocationTokens <$> parseSep (Proxy :: Proxy FSep) parsePackageLocationTokenQ
+
+instance Pretty PackageLocationTokens where
+  pretty = prettySep (Proxy :: Proxy FSep) . map (PP.text . renderPackageLocationToken) . getPackageLocationTokens
+
+ignoredLens :: Lens' ProjectConfig PackageLocationTokens
+ignoredLens f s = s <$ f mempty
 
 -- | This matches legacy parsing for @packages@ and @optional-packages@:
 -- supports quoted strings, and for unquoted tokens allows commas only inside

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -65,6 +65,9 @@ ignoredLens f s = s <$ f mempty
 -- | This matches legacy parsing for @packages@ and @optional-packages@:
 -- supports quoted strings, and for unquoted tokens allows commas only inside
 -- balanced braces (e.g. ../{foo,bar}/).
+--
+-- >>> prettyShow <$> (simpleParsec "packages: */*.cabal ../{foo,bar}/" :: Maybe PackageLocationTokens)
+-- Just "packages: */*.cabal ../{foo,bar}/"
 parsePackageLocationTokenQ :: CabalParsing m => m String
 parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
   where
@@ -245,3 +248,7 @@ packageConfigPreferVersion =
     <$> optionalFieldDef "prefer-oldest" L.projectConfigPreferOldest mempty
       ^^^ deprecatedSince CabalSpecV3_20 "Please use 'prefer-version' field instead."
     <*> optionalFieldDef "prefer-version" L.projectConfigPreferVersion mempty
+
+-- $setup
+-- >>> import Distribution.Parsec (simpleParsec)
+-- >>> import Distribution.Pretty (prettyShow)

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -16,7 +16,7 @@ import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
 import qualified Distribution.Compat.CharParsing as P
-import Distribution.Compat.Newtype (Newtype)
+import Distribution.Compat.Lens (Lens')
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
 import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
@@ -30,8 +30,8 @@ import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
+  projectPackages <- getPackageLocationTokens <$> monoidalField "packages" ignoredLens
+  projectPackagesOptional <- getPackageLocationTokens <$> monoidalField "optional-packages" ignoredLens
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -42,15 +42,22 @@ projectConfigFieldGrammar source knownPrograms = do
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
 
-newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+newtype PackageLocationTokens = PackageLocationTokens {getPackageLocationTokens :: [String]}
 
-instance Newtype String PackageLocationToken
+instance Semigroup PackageLocationTokens where
+  PackageLocationTokens a <> PackageLocationTokens b = PackageLocationTokens (a <> b)
 
-instance Parsec PackageLocationToken where
-  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+instance Monoid PackageLocationTokens where
+  mempty = PackageLocationTokens mempty
 
-instance Pretty PackageLocationToken where
-  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+instance Parsec PackageLocationTokens where
+  parsec = PackageLocationTokens <$> parseSep (Proxy :: Proxy FSep) parsePackageLocationTokenQ
+
+instance Pretty PackageLocationTokens where
+  pretty = prettySep (Proxy :: Proxy FSep) . map (PP.text . renderPackageLocationToken) . getPackageLocationTokens
+
+ignoredLens :: Lens' ProjectConfig PackageLocationTokens
+ignoredLens f s = s <$ f mempty
 
 -- | This matches legacy parsing for @packages@ and @optional-packages@:
 -- supports quoted strings, and for unquoted tokens allows commas only inside

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -15,18 +15,23 @@ import Distribution.Client.CmdInstall.ClientInstallFlags (clientInstallFlagsGram
 import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
+import qualified Distribution.Compat.CharParsing as P
+import Distribution.Compat.Newtype (Newtype)
 import Distribution.Compat.Prelude
 import Distribution.FieldGrammar
+import Distribution.Parsec (CabalParsing, Parsec (..), parsecHaskellString)
+import Distribution.Pretty (Pretty (..))
 import Distribution.Simple.Flag
 import Distribution.Simple.InstallDirs
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource (..))
 import Distribution.Solver.Types.ProjectConfigPath
 import Distribution.Types.PackageVersionConstraint (PackageVersionConstraint (..))
+import qualified Text.PrettyPrint as PP
 
 projectConfigFieldGrammar :: ProjectConfigPath -> [String] -> ParsecFieldGrammar' ProjectConfig
 projectConfigFieldGrammar source knownPrograms = do
-  projectPackages <- monoidalFieldAla "packages" (alaList' FSep Token) L.projectPackages
-  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep Token) L.projectPackagesOptional
+  projectPackages <- monoidalFieldAla "packages" (alaList' FSep PackageLocationToken) L.projectPackages
+  projectPackagesOptional <- monoidalFieldAla "optional-packages" (alaList' FSep PackageLocationToken) L.projectPackagesOptional
   let projectPackagesRepo = mempty
   projectPackagesNamed <- monoidalFieldAla "extra-packages" formatPackageVersionConstraints L.projectPackagesNamed
   projectConfigBuildOnly <- blurFieldGrammar L.projectConfigBuildOnly projectConfigBuildOnlyFieldGrammar
@@ -36,6 +41,50 @@ projectConfigFieldGrammar source knownPrograms = do
       projectConfigSpecificPackage = mempty
   projectConfigLocalPackages <- blurFieldGrammar L.projectConfigLocalPackages (packageConfigFieldGrammar knownPrograms)
   pure ProjectConfig{..}
+
+newtype PackageLocationToken = PackageLocationToken {getPackageLocationToken :: String}
+
+instance Newtype String PackageLocationToken
+
+instance Parsec PackageLocationToken where
+  parsec = PackageLocationToken <$> parsePackageLocationTokenQ
+
+instance Pretty PackageLocationToken where
+  pretty = PP.text . renderPackageLocationToken . getPackageLocationToken
+
+-- | This matches legacy parsing for @packages@ and @optional-packages@:
+-- supports quoted strings, and for unquoted tokens allows commas only inside
+-- balanced braces (e.g. ../{foo,bar}/).
+parsePackageLocationTokenQ :: CabalParsing m => m String
+parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
+  where
+    parsePackageLocationToken = concat <$> some outerTerm
+    outerTerm = outerToken <|> braces innerTerm
+    innerTerm = concat <$> many (innerToken <|> braces innerTerm)
+    outerToken = P.munch1 outerChar
+    innerToken = P.munch1 innerChar
+    outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
+    innerChar c = not (isSpace c || c == '{' || c == '}')
+    braces p = ("{" <>) . (<> "}") <$> P.between (P.char '{') (P.char '}') p
+
+renderPackageLocationToken :: String -> String
+renderPackageLocationToken s
+  | needsQuoting = show s
+  | otherwise = s
+  where
+    needsQuoting =
+      not (ok 0 s)
+        || s == "." -- . on its own on a line has special meaning
+        || take 2 s == "--" -- on its own line is comment syntax
+    ok :: Int -> String -> Bool
+    ok n [] = n == 0
+    ok _ ('"' : _) = False
+    ok n ('{' : cs) = ok (n + 1) cs
+    ok n ('}' : cs) = ok (n - 1) cs
+    ok n (',' : cs) = (n > 0) && ok n cs
+    ok _ (c : _)
+      | isSpace c = False
+    ok n (_ : cs) = ok n cs
 
 formatPackageVersionConstraints :: [PackageVersionConstraint] -> List CommaVCat (Identity PackageVersionConstraint) PackageVersionConstraint
 formatPackageVersionConstraints = alaList CommaVCat

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.Set as Set
 import Distribution.CabalSpecVersion (CabalSpecVersion (..))
 import Distribution.Client.CmdInstall.ClientInstallFlags (clientInstallFlagsGrammar)
+import Distribution.Client.ProjectConfig.Legacy (renderPackageLocationToken)
 import qualified Distribution.Client.ProjectConfig.Lens as L
 import Distribution.Client.ProjectConfig.Types (PackageConfig (..), ProjectConfig (..), ProjectConfigBuildOnly (..), ProjectConfigProvenance (..), ProjectConfigShared (..))
 import Distribution.Client.Utils.Parsec
@@ -73,25 +74,6 @@ parsePackageLocationTokenQ = parsecHaskellString <|> parsePackageLocationToken
     outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
     innerChar c = not (isSpace c || c == '{' || c == '}')
     braces p = ("{" <>) . (<> "}") <$> P.between (P.char '{') (P.char '}') p
-
-renderPackageLocationToken :: String -> String
-renderPackageLocationToken s
-  | needsQuoting = show s
-  | otherwise = s
-  where
-    needsQuoting =
-      not (ok 0 s)
-        || s == "." -- . on its own on a line has special meaning
-        || take 2 s == "--" -- on its own line is comment syntax
-    ok :: Int -> String -> Bool
-    ok n [] = n == 0
-    ok _ ('"' : _) = False
-    ok n ('{' : cs) = ok (n + 1) cs
-    ok n ('}' : cs) = ok (n - 1) cs
-    ok n (',' : cs) = (n > 0) && ok n cs
-    ok _ (c : _)
-      | isSpace c = False
-    ok n (_ : cs) = ok n cs
 
 formatPackageVersionConstraints :: [PackageVersionConstraint] -> List CommaVCat (Identity PackageVersionConstraint) PackageVersionConstraint
 formatPackageVersionConstraints = alaList CommaVCat

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1304,6 +1304,9 @@ legacyProjectConfigFieldDescrs constraintSrc =
 -- allow http urls which don't parse as globs, and possibly some
 -- system-dependent file paths. So we parse fairly liberally as a token, but
 -- we allow @,@ inside matched @{}@ braces.
+--
+-- >>> readP_to_S parsePackageLocationTokenQ "*/*.cabal ../{foo,bar}/"
+-- [("*/*.cabal"," ../{foo,bar}/")]
 parsePackageLocationTokenQ :: ReadP String
 parsePackageLocationTokenQ =
   parseHaskellString
@@ -2054,3 +2057,6 @@ showTokenQ "" = Disp.empty
 showTokenQ x@('-' : '-' : _) = Disp.text (show x)
 showTokenQ x@['.'] = Disp.text (show x)
 showTokenQ x = showToken x
+
+-- $setup
+-- >>> import Distribution.Deprecated.ReadP (readP_to_S)

--- a/changelog.d/12172.md
+++ b/changelog.d/12172.md
@@ -1,0 +1,10 @@
+---
+synopsis: Fix project packages glob parsing
+packages: [cabal-install]
+prs: 12172
+issues: 12171
+---
+
+Fixes a deficiency with `--project-file-parser=parsec`, the default parser, when
+compared to the `--project-file-parser=legacy`.  It can now parse globs in the
+packages field.


### PR DESCRIPTION
The failing test for #12171 and its fix.

```
$ cabal test cabal-install:parser-tests
...
Build profile: -w ghc-9.10.3 -O1
...
Running 1 test suites...
Test suite parser-tests: RUNNING...
project files parsec tests                                                                                                                                                                                                                            
  read packages:                                    OK
  read packages glob:                               FAIL
    Exception: Error: [Cabal-7167]
    Error parsing project file cabal.glob.project:
    
    cabal.glob.project:3:28: error:
      unexpected ','
      expecting white space, string, identifier or end of input
          3 | packages: */*.cabal ../{foo,bar}/
            |                            ^    
    
    Use -p '/read packages glob/' to rerun this test only.
```

I'll squash commits before applying the merge label if this pull request is approved.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.
