### PR TITLE
Move phase control to cabal commands docs

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -834,6 +834,37 @@ and fully-qualified.
 
 .. _command-group-build:
 
+Build action phase control
+--------------------------
+
+The following settings apply to commands that result in build actions
+(``build``, ``run``, ``repl``, ``test``...), and control which phases of the
+build are executed.
+
+.. option:: --dry-run
+
+    Do not download, build, or install anything, only print what would happen.
+
+.. option:: --only-configure
+
+    Instead of performing a full build just run the configure step.
+    Only accepted by the ``build`` command.
+
+.. option:: --only-download
+
+    Do not build anything, only fetch the packages.
+
+.. option:: --only-dependencies
+            --dependencies-only
+
+    Install only the dependencies necessary to build the given packages.
+    Not accepted by the ``repl`` command.
+
+.. tip::
+
+    ``--dependencies-only`` is a synonym for ``--only-dependencies`` but the
+    latter is preferred as it follows the pattern of other ``--only-*`` flags.
+
 Project building and installing
 -------------------------------
 

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -519,31 +519,6 @@ package, and thus apply globally:
         [build-timings] build     aeson-2.2.3.0 3.284s
         [build-timings] install   aeson-2.2.3.0 0.123s
 
-Phase control
--------------
-
-The following settings apply to commands that result in build actions
-(``build``, ``run``, ``repl``, ``test``...), and control which phases of the
-build are executed.
-
-.. option:: --dry-run
-
-    Do not download, build, or install anything, only print what would happen.
-
-.. option:: --only-configure
-
-    Instead of performing a full build just run the configure step.
-    Only accepted by the ``build`` command.
-
-.. option:: --only-download
-
-    Do not build anything, only fetch the packages.
-
-.. option:: --only-dependencies
-
-    Install only the dependencies necessary to build the given packages.
-    Not accepted by the ``repl`` command.
-
 Solver configuration options
 ----------------------------
 


### PR DESCRIPTION
Fixes #12175 

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
