### PR TITLE
Use newer warning flag format

### DIFF
--- a/hooks-exe/hooks-exe.cabal
+++ b/hooks-exe/hooks-exe.cabal
@@ -22,7 +22,7 @@ common warnings
     -Wcompat
     -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
     -Wincomplete-record-updates
-    -fno-warn-unticked-promoted-constructors
+    -Wno-unticked-promoted-constructors
   if impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
   if impl(ghc >=9.0)


### PR DESCRIPTION
Reviewing the 3.18 release I found a use of an `-fno-warn-` flag in one of the released packages. This minor change switches that up to the newer syntax.

> In GHC < 8 the syntax for -W⟨wflag⟩ was -fwarn-⟨wflag⟩
> -- [GHC Users Guide - Warnings and sanity-checking](https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#warnings-and-sanity-checking)

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
