### PR TITLE
fix(Cabal, cabal-install): default debug-info level to NoDebugInfo

### DIFF
--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -374,7 +374,7 @@ parsecDebugInfoLevel :: CabalParsing m => m DebugInfoLevel
 parsecDebugInfoLevel = flagToDebugInfoLevel . pure <$> parsecToken
 
 flagToDebugInfoLevel :: Maybe String -> DebugInfoLevel
-flagToDebugInfoLevel Nothing = NormalDebugInfo
+flagToDebugInfoLevel Nothing = NoDebugInfo
 flagToDebugInfoLevel (Just s) = case reads s of
   [(i, "")]
     | i >= fromEnum (minBound :: DebugInfoLevel)

--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -324,7 +324,7 @@ renderPackageHashInputs
           , opt "split-sections" False prettyShow pkgHashSplitSections
           , opt "stripped-lib" False prettyShow pkgHashStripLibs
           , opt "stripped-exe" True prettyShow pkgHashStripExes
-          , opt "debug-info" NormalDebugInfo (show . fromEnum) pkgHashDebugInfo
+          , opt "debug-info" NoDebugInfo (show . fromEnum) pkgHashDebugInfo
           , opt "extra-lib-dirs" [] unwords pkgHashExtraLibDirs
           , opt "extra-lib-dirs-static" [] unwords pkgHashExtraLibDirsStatic
           , opt "extra-framework-dirs" [] unwords pkgHashExtraFrameworkDirs

--- a/cabal-testsuite/PackageTests/DebugInfoDefault/app/Main.hs
+++ b/cabal-testsuite/PackageTests/DebugInfoDefault/app/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "hello"

--- a/cabal-testsuite/PackageTests/DebugInfoDefault/cabal.project
+++ b/cabal-testsuite/PackageTests/DebugInfoDefault/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/DebugInfoDefault/debug-info-default.cabal
+++ b/cabal-testsuite/PackageTests/DebugInfoDefault/debug-info-default.cabal
@@ -1,0 +1,16 @@
+cabal-version: 3.0
+name:          debug-info-default
+version:       0.1.0.0
+license:       BSD-3-Clause
+
+library
+  exposed-modules:  MyLib
+  build-depends:    base
+  hs-source-dirs:   src
+  default-language: Haskell2010
+
+executable debug-info-default
+  main-is:          Main.hs
+  build-depends:    base
+  hs-source-dirs:   app
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/DebugInfoDefault/enable-debug-info.test.hs
+++ b/cabal-testsuite/PackageTests/DebugInfoDefault/enable-debug-info.test.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Test.Cabal.DecodeShowBuildInfo
+import Test.Cabal.Prelude
+
+-- Regression test for the default debug-info level being NoDebugInfo.
+--
+-- The GHC command line must only carry a debug-info flag (-g2) when a
+-- level is explicitly requested, not by default nor via a bare
+-- --enable-debug-info.
+main = cabalTest $ do
+  recordMode DoNotRecord $ do
+    -- Default: NoDebugInfo, no -g2.
+    runShowBuildInfo ["lib:debug-info-default"]
+      >> withPlan
+        ( assertComponent "debug-info-default" mainLib $
+            defCompAssertion
+              { modules = ["MyLib"]
+              , sourceDirs = ["src"]
+              , compilerArgsPred = notElem "-g2"
+              }
+        )
+
+    -- --enable-debug-info without a level maps to NoDebugInfo.
+    runShowBuildInfo ["--enable-debug-info", "lib:debug-info-default"]
+      >> withPlan
+        ( assertComponent "debug-info-default" mainLib $
+            defCompAssertion
+              { modules = ["MyLib"]
+              , sourceDirs = ["src"]
+              , compilerArgsPred = notElem "-g2"
+              }
+        )
+
+    -- --enable-debug-info=2 selects NormalDebugInfo, which emits -g2.
+    runShowBuildInfo ["--enable-debug-info=2", "lib:debug-info-default"]
+      >> withPlan
+        ( assertComponent "debug-info-default" mainLib $
+            defCompAssertion
+              { modules = ["MyLib"]
+              , sourceDirs = ["src"]
+              , compilerArgsPred = elem "-g2"
+              }
+        )

--- a/cabal-testsuite/PackageTests/DebugInfoDefault/hash-inputs.test.hs
+++ b/cabal-testsuite/PackageTests/DebugInfoDefault/hash-inputs.test.hs
@@ -1,0 +1,15 @@
+import Test.Cabal.Prelude
+
+-- Regression test for the default debug-info level being NoDebugInfo in
+-- the inputs used to compute the package hash.
+--
+-- By default the "debug-info" entry is omitted from the hash inputs, and
+-- requesting NormalDebugInfo adds "debug-info: 2".
+main = cabalTest $ do
+  res <- recordMode DoNotRecord $ cabal' "v2-install" ["--overwrite-policy=always", "-v3"]
+  assertOutputContains "creating file with the inputs used to compute the package hash:" res
+  assertOutputDoesNotContain "debug-info:" res
+
+  res2 <- recordMode DoNotRecord $ cabal' "v2-install" ["--overwrite-policy=always", "--enable-debug-info=2", "-v3"]
+  assertOutputContains "creating file with the inputs used to compute the package hash:" res2
+  assertOutputContains "debug-info: 2" res2

--- a/cabal-testsuite/PackageTests/DebugInfoDefault/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/DebugInfoDefault/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib where
+
+x :: Int
+x = 42

--- a/changelog.d/12200.md
+++ b/changelog.d/12200.md
@@ -1,0 +1,7 @@
+---
+synopsis: Change default debug-info level from NormalDebugInfo to NoDebugInfo
+packages: [Cabal, cabal-install]
+prs: 12200
+---
+
+Change the default value of debug-info from NormalDebugInfo to NoDebugInfo.


### PR DESCRIPTION
In some cases we will display the wrong debug level flag.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
