### PR TITLE
fix(Cabal): Removes the short -g option for the --ghc flag

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -40,6 +40,7 @@ test-suite unit-tests
     UnitTests.Distribution.Simple.Glob
     UnitTests.Distribution.Simple.Program.GHC
     UnitTests.Distribution.Simple.Program.Internal
+    UnitTests.Distribution.Simple.Setup.Config
     UnitTests.Distribution.Simple.Utils
     UnitTests.Distribution.SPDX
     UnitTests.Distribution.System

--- a/Cabal-tests/tests/UnitTests.hs
+++ b/Cabal-tests/tests/UnitTests.hs
@@ -14,6 +14,7 @@ import qualified UnitTests.Distribution.Simple.Command
 import qualified UnitTests.Distribution.Simple.Glob
 import qualified UnitTests.Distribution.Simple.Program.GHC
 import qualified UnitTests.Distribution.Simple.Program.Internal
+import qualified UnitTests.Distribution.Simple.Setup.Config
 import qualified UnitTests.Distribution.Simple.Utils
 import qualified UnitTests.Distribution.System
 import qualified UnitTests.Distribution.Utils.CharSet
@@ -46,6 +47,7 @@ tests =
     , UnitTests.Distribution.Simple.Program.GHC.tests
     , testGroup "Distribution.Simple.Program.Internal"
         UnitTests.Distribution.Simple.Program.Internal.tests
+    , UnitTests.Distribution.Simple.Setup.Config.tests
     , testGroup "Distribution.Simple.Utils" $
         UnitTests.Distribution.Simple.Utils.tests ghcPath
     , testGroup "Distribution.Utils.Generic"

--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Setup/Config.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Setup/Config.hs
@@ -1,0 +1,65 @@
+module UnitTests.Distribution.Simple.Setup.Config
+  ( tests
+  ) where
+
+import Distribution.Compiler (CompilerFlavor (..))
+import Distribution.Simple.Command (CommandParse (..), commandParseArgs)
+import Distribution.Simple.Compiler (DebugInfoLevel (..))
+import Distribution.Simple.Flag qualified as Flag
+import Distribution.Simple.Program.Db (emptyProgramDb)
+import Distribution.Simple.Setup
+  ( ConfigFlags (..)
+  , configureCommand
+  , emptyConfigFlags
+  )
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup
+    "Distribution.Simple.Setup.Config"
+    [ testGroup
+        "--ghc / -g compiler selection"
+        [ testCase "--ghc selects GHC" $
+            configHcFlavor (parse ["--ghc"]) @?= Flag.Flag GHC
+        , testCase "--ghcjs selects GHCJS" $
+            configHcFlavor (parse ["--ghcjs"]) @?= Flag.Flag GHCJS
+        , testCase "-g no longer selects GHC" $
+            configHcFlavor (parse ["-g"]) @?= Flag.NoFlag
+        , testCase "--ghc -g selects GHC and does not conflict" $
+            configHcFlavor (parse ["--ghc", "-g"]) @?= Flag.Flag GHC
+        , testCase "-g --ghcjs selects GHCJS and does not conflict" $
+            configHcFlavor (parse ["-g", "--ghcjs"]) @?= Flag.Flag GHCJS
+        ]
+    , testGroup
+        "--enable-debug-info / -g debug info"
+        [ testCase "-g sets NormalDebugInfo" $
+            configDebugInfo (parse ["-g"]) @?= Flag.Flag NormalDebugInfo
+        , testCase "--enable-debug-info sets NormalDebugInfo" $
+            configDebugInfo (parse ["--enable-debug-info"]) @?= Flag.Flag NormalDebugInfo
+        , testCase "-g1 sets MinimalDebugInfo" $
+            configDebugInfo (parse ["-g1"]) @?= Flag.Flag MinimalDebugInfo
+        , testCase "-g3 sets MaximalDebugInfo" $
+            configDebugInfo (parse ["-g3"]) @?= Flag.Flag MaximalDebugInfo
+        , testCase "--enable-debug-info=2 sets NormalDebugInfo" $
+            configDebugInfo (parse ["--enable-debug-info=2"]) @?= Flag.Flag NormalDebugInfo
+        , testCase "--disable-debug-info sets NoDebugInfo" $
+            configDebugInfo (parse ["--disable-debug-info"]) @?= Flag.Flag NoDebugInfo
+        ]
+    ]
+
+-- | Parse the given @configure@ command line arguments starting from
+-- 'emptyConfigFlags', so that only the options actually given are set.
+-- Parsing failures are reported as test failures.
+parse :: [String] -> ConfigFlags
+parse args =
+  case commandParseArgs (configureCommand emptyProgramDb) False args of
+    CommandReadyToGo (f, _) -> f emptyConfigFlags
+    CommandErrors errs ->
+      error $ "unexpected parse errors: " ++ show errs
+    CommandHelp _ ->
+      error "unexpected help"
+    CommandList _ ->
+      error "unexpected list"

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -434,7 +434,7 @@ configureOptions showOrParseArgs =
         configHcFlavor
         (\v flags -> flags{configHcFlavor = v})
         ( choiceOpt
-            [ (Flag GHC, ("g", ["ghc"]), "compile with GHC")
+            [ (Flag GHC, ([], ["ghc"]), "compile with GHC")
             , (Flag GHCJS, ([], ["ghcjs"]), "compile with GHCJS")
             , (Flag UHC, ([], ["uhc"]), "compile with UHC")
             ]
@@ -599,7 +599,7 @@ configureOptions showOrParseArgs =
                   Flag MaximalDebugInfo -> [Just "3"]
                   _ -> []
               )
-              ""
+              "g"
               ["enable-debug-info"]
               "Emit debug info (n is 0--3, default is 0)"
           , noArg

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -434,7 +434,7 @@ configureOptions showOrParseArgs =
         configHcFlavor
         (\v flags -> flags{configHcFlavor = v})
         ( choiceOpt
-            [ (Flag GHC, ("g", ["ghc"]), "Compile with GHC")
+            [ (Flag GHC, ([], ["ghc"]), "Compile with GHC")
             , (Flag GHCJS, ([], ["ghcjs"]), "Compile with GHCJS")
             , (Flag UHC, ([], ["uhc"]), "Compile with UHC")
             ]
@@ -599,7 +599,7 @@ configureOptions showOrParseArgs =
                   Flag MaximalDebugInfo -> [Just "3"]
                   _ -> []
               )
-              ""
+              "g"
               ["enable-debug-info"]
               "Emit debug info (n is 0--3, default is 0)"
           , noArg

--- a/changelog.d/12201.md
+++ b/changelog.d/12201.md
@@ -8,10 +8,10 @@ prs: 12201
 ```diff
   $ cabal build --help
 ...
-- -g, --ghc                      compile with GHC
-+ --ghc                          compile with GHC
+- -g, --ghc                    # Compile with GHC
++ --ghc                        # Compile with GHC
 ...
-- --enable-debug-info[=n]        Emit debug info (n is 0--3, default is 0)
-+ -g n or -gn, --enable-debug-info[=n]
-+                                Emit debug info (n is 0--3, default is 0)
+- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
++ -g[n], --enable-debug-info[=n]
++                              # Emit debug info (n is 0--3, default is 0)
 ```

--- a/changelog.d/12201.md
+++ b/changelog.d/12201.md
@@ -1,0 +1,17 @@
+---
+synopsis: Removes the short `-g` option for the `--ghc` flag
+packages: [Cabal]
+prs: 12201
+---
+
+- Removes the short `-g` option for the `--ghc` flag. This is now used as the short option for `--enable-debug-info`.
+```diff
+  $ cabal build --help
+...
+- -g, --ghc                      compile with GHC
++ --ghc                          compile with GHC
+...
+- --enable-debug-info[=n]        Emit debug info (n is 0--3, default is 0)
++ -g n or -gn, --enable-debug-info[=n]
++                                Emit debug info (n is 0--3, default is 0)
+```

--- a/doc/cmd-v1-help/configure.txt
+++ b/doc/cmd-v1-help/configure.txt
@@ -15,7 +15,7 @@ Flags for v1-configure:
                                 files (default dist)
  --cabal-file=PATH            # use this Cabal file
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -73,7 +73,8 @@ Flags for v1-configure:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v1-help/install.txt
+++ b/doc/cmd-v1-help/install.txt
@@ -26,7 +26,7 @@ Flags for v1-install:
                                 files (default dist)
  --cabal-file=PATH            # use this Cabal file
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -84,7 +84,8 @@ Flags for v1-install:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v1-help/reconfigure.txt
+++ b/doc/cmd-v1-help/reconfigure.txt
@@ -14,7 +14,7 @@ Flags for v1-reconfigure:
                                 files (default dist)
  --cabal-file=PATH            # use this Cabal file
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -72,7 +72,8 @@ Flags for v1-reconfigure:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/bench.txt
+++ b/doc/cmd-v2-help/bench.txt
@@ -19,7 +19,7 @@ Flags for bench:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -77,7 +77,8 @@ Flags for bench:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/build.txt
+++ b/doc/cmd-v2-help/build.txt
@@ -19,7 +19,7 @@ Flags for build:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -77,7 +77,8 @@ Flags for build:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/configure.txt
+++ b/doc/cmd-v2-help/configure.txt
@@ -32,7 +32,7 @@ Flags for configure:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -90,7 +90,8 @@ Flags for configure:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/exec.txt
+++ b/doc/cmd-v2-help/exec.txt
@@ -21,7 +21,7 @@ Flags for exec:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -79,7 +79,8 @@ Flags for exec:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/freeze.txt
+++ b/doc/cmd-v2-help/freeze.txt
@@ -24,7 +24,7 @@ Flags for freeze:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -82,7 +82,8 @@ Flags for freeze:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/gen-bounds.txt
+++ b/doc/cmd-v2-help/gen-bounds.txt
@@ -10,7 +10,7 @@ Flags for gen-bounds:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -68,7 +68,8 @@ Flags for gen-bounds:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/haddock.txt
+++ b/doc/cmd-v2-help/haddock.txt
@@ -24,7 +24,7 @@ Flags for haddock:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -82,7 +82,8 @@ Flags for haddock:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/install.txt
+++ b/doc/cmd-v2-help/install.txt
@@ -20,7 +20,7 @@ Flags for install:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -60,7 +60,8 @@ Flags for install:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/list-bin.txt
+++ b/doc/cmd-v2-help/list-bin.txt
@@ -11,7 +11,7 @@ Flags for list-bin:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -69,7 +69,8 @@ Flags for list-bin:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/outdated.txt
+++ b/doc/cmd-v2-help/outdated.txt
@@ -12,7 +12,7 @@ Flags for outdated:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -70,7 +70,8 @@ Flags for outdated:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/path.txt
+++ b/doc/cmd-v2-help/path.txt
@@ -13,7 +13,7 @@ Flags for path:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -71,7 +71,8 @@ Flags for path:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/repl.txt
+++ b/doc/cmd-v2-help/repl.txt
@@ -22,7 +22,7 @@ Flags for repl:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -80,7 +80,8 @@ Flags for repl:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/run.txt
+++ b/doc/cmd-v2-help/run.txt
@@ -25,7 +25,7 @@ Flags for run:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -83,7 +83,8 @@ Flags for run:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/target.txt
+++ b/doc/cmd-v2-help/target.txt
@@ -41,7 +41,7 @@ Flags for target:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -99,7 +99,8 @@ Flags for target:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/test.txt
+++ b/doc/cmd-v2-help/test.txt
@@ -21,7 +21,7 @@ Flags for test:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -79,7 +79,8 @@ Flags for test:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/cmd-v2-help/update.txt
+++ b/doc/cmd-v2-help/update.txt
@@ -11,7 +11,7 @@ Flags for update:
  --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -69,7 +69,8 @@ Flags for update:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building

--- a/doc/setup-help/configure.txt
+++ b/doc/setup-help/configure.txt
@@ -15,7 +15,7 @@ Flags for configure:
                                 files (default dist)
  --cabal-file=PATH            # use this Cabal file
  --keep-temp-files            # Keep temporary files.
- -g, --ghc                    # Compile with GHC
+ --ghc                        # Compile with GHC
  --ghcjs                      # Compile with GHCJS
  --uhc                        # Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
@@ -73,7 +73,8 @@ Flags for configure:
                               # Build with optimization (n is 0--2, default is
                                 1)
  --disable-optimization       # Build without optimization
- --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ -g[n], --enable-debug-info[=n]
+                              # Emit debug info (n is 0--3, default is 0)
  --disable-debug-info         # Don't emit debug info
  --enable-build-info          # Enable build information generation during
                                 project building


### PR DESCRIPTION
fix: https://github.com/haskell/cabal/issues/2056

I think we can simply redefine the flag, and few people will notice, since it doesn't appear in libraries or executables.

Those who do notice will now use the full flag. As I understand it, these are the people who manually enter flags in the console.

Currently, this is mostly LLM, which makes this change even more valuable for them.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
