### PR TITLE
fix(Cabal): Accept boolean values for `debug-info` and `optimization` levels

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -37,6 +37,7 @@ test-suite unit-tests
     UnitTests.Distribution.PackageDescription.Check
     UnitTests.Distribution.PkgconfigVersion
     UnitTests.Distribution.Simple.Command
+    UnitTests.Distribution.Simple.Compiler
     UnitTests.Distribution.Simple.Glob
     UnitTests.Distribution.Simple.Program.GHC
     UnitTests.Distribution.Simple.Program.Internal

--- a/Cabal-tests/tests/UnitTests.hs
+++ b/Cabal-tests/tests/UnitTests.hs
@@ -11,6 +11,7 @@ import qualified UnitTests.Distribution.Compat.Time
 import qualified UnitTests.Distribution.Compat.Graph
 import qualified UnitTests.Distribution.PackageDescription.Check
 import qualified UnitTests.Distribution.Simple.Command
+import qualified UnitTests.Distribution.Simple.Compiler
 import qualified UnitTests.Distribution.Simple.Glob
 import qualified UnitTests.Distribution.Simple.Program.GHC
 import qualified UnitTests.Distribution.Simple.Program.Internal
@@ -41,6 +42,8 @@ tests =
         UnitTests.Distribution.Compat.Graph.tests
     , testGroup "Distribution.Simple.Command"
         UnitTests.Distribution.Simple.Command.tests
+    , testGroup "Distribution.Simple.Compiler"
+        UnitTests.Distribution.Simple.Compiler.tests
     , testGroup "Distribution.Simple.Glob"
         UnitTests.Distribution.Simple.Glob.tests
     , UnitTests.Distribution.Simple.Program.GHC.tests

--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Compiler.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Compiler.hs
@@ -1,0 +1,105 @@
+module UnitTests.Distribution.Simple.Compiler
+    ( tests
+    ) where
+
+import Distribution.Parsec (eitherParsec)
+import Distribution.Simple.Compiler
+  ( DebugInfoLevel (..)
+  , OptimisationLevel (..)
+  , flagToDebugInfoLevel
+  , flagToOptimisationLevel
+  )
+
+import qualified Control.Exception as C
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: [TestTree]
+tests =
+  [ testGroup "flagToDebugInfoLevel" flagToDebugInfoLevelTests
+  , testGroup "flagToOptimisationLevel" flagToOptimisationLevelTests
+  , testGroup "DebugInfoLevel Parsec" debugInfoLevelParsecTests
+  , testGroup "OptimisationLevel Parsec" optimisationLevelParsecTests
+  ]
+
+flagToDebugInfoLevelTests :: [TestTree]
+flagToDebugInfoLevelTests =
+  [ testCase "defaults to NormalDebugInfo" $
+      flagToDebugInfoLevel Nothing @?= NormalDebugInfo
+  , testCase "--enable-debug-info=True" $
+      flagToDebugInfoLevel (Just "True") @?= NormalDebugInfo
+  , testCase "--enable-debug-info=False" $
+      flagToDebugInfoLevel (Just "False") @?= NoDebugInfo
+  , testCase "--enable-debug-info=0" $
+      flagToDebugInfoLevel (Just "0") @?= NoDebugInfo
+  , testCase "--enable-debug-info=1" $
+      flagToDebugInfoLevel (Just "1") @?= MinimalDebugInfo
+  , testCase "--enable-debug-info=2" $
+      flagToDebugInfoLevel (Just "2") @?= NormalDebugInfo
+  , testCase "--enable-debug-info=3" $
+      flagToDebugInfoLevel (Just "3") @?= MaximalDebugInfo
+  , testCase "--enable-debug-info=4 is out of range" $
+      assertError "expected an error for out-of-range debug info level" $
+        flagToDebugInfoLevel (Just "4")
+  , testCase "--enable-debug-info=foo is unparsable" $
+      assertError "expected an error for unparsable debug info level" $
+        flagToDebugInfoLevel (Just "foo")
+  ]
+
+flagToOptimisationLevelTests :: [TestTree]
+flagToOptimisationLevelTests =
+  [ testCase "defaults to NormalOptimisation" $
+      flagToOptimisationLevel Nothing @?= NormalOptimisation
+  , testCase "--enable-optimization=True" $
+      flagToOptimisationLevel (Just "True") @?= NormalOptimisation
+  , testCase "--enable-optimization=False" $
+      flagToOptimisationLevel (Just "False") @?= NoOptimisation
+  , testCase "--enable-optimization=0" $
+      flagToOptimisationLevel (Just "0") @?= NoOptimisation
+  , testCase "--enable-optimization=1" $
+      flagToOptimisationLevel (Just "1") @?= NormalOptimisation
+  , testCase "--enable-optimization=2" $
+      flagToOptimisationLevel (Just "2") @?= MaximumOptimisation
+  , testCase "--enable-optimization=3 is out of range" $
+      assertError "expected an error for out-of-range optimisation level" $
+        flagToOptimisationLevel (Just "3")
+  , testCase "--enable-optimization=foo is unparsable" $
+      assertError "expected an error for unparsable optimisation level" $
+        flagToOptimisationLevel (Just "foo")
+  ]
+
+debugInfoLevelParsecTests :: [TestTree]
+debugInfoLevelParsecTests =
+  [ testCase "parses True" $
+      eitherParsec "True" @?= (Right NormalDebugInfo :: Either String DebugInfoLevel)
+  , testCase "parses False" $
+      eitherParsec "False" @?= (Right NoDebugInfo :: Either String DebugInfoLevel)
+  , testCase "parses 0" $
+      eitherParsec "0" @?= (Right NoDebugInfo :: Either String DebugInfoLevel)
+  , testCase "parses 1" $
+      eitherParsec "1" @?= (Right MinimalDebugInfo :: Either String DebugInfoLevel)
+  , testCase "parses 2" $
+      eitherParsec "2" @?= (Right NormalDebugInfo :: Either String DebugInfoLevel)
+  , testCase "parses 3" $
+      eitherParsec "3" @?= (Right MaximalDebugInfo :: Either String DebugInfoLevel)
+  ]
+
+optimisationLevelParsecTests :: [TestTree]
+optimisationLevelParsecTests =
+  [ testCase "parses True" $
+      eitherParsec "True" @?= (Right NormalOptimisation :: Either String OptimisationLevel)
+  , testCase "parses False" $
+      eitherParsec "False" @?= (Right NoOptimisation :: Either String OptimisationLevel)
+  , testCase "parses 0" $
+      eitherParsec "0" @?= (Right NoOptimisation :: Either String OptimisationLevel)
+  , testCase "parses 1" $
+      eitherParsec "1" @?= (Right NormalOptimisation :: Either String OptimisationLevel)
+  , testCase "parses 2" $
+      eitherParsec "2" @?= (Right MaximumOptimisation :: Either String OptimisationLevel)
+  ]
+
+assertError :: String -> a -> Assertion
+assertError msg x =
+  C.catch
+    (C.evaluate x >> assertFailure msg)
+    (\(C.ErrorCall _) -> return ())

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -330,7 +330,9 @@ flagToOptimisationLevel :: Maybe String -> OptimisationLevel
 flagToOptimisationLevel Nothing = NormalOptimisation
 flagToOptimisationLevel (Just s) = case reads s of
   [(i, "")] -> intToEnum "optimisation level" i
-  _ -> error $ "Can't parse optimisation level " ++ s
+  _ -> case reads s of
+    [(b, "")] -> if b then NormalOptimisation else NoOptimisation
+    _ -> error $ "Can't parse optimisation level " ++ s
 
 -- ------------------------------------------------------------
 
@@ -365,7 +367,9 @@ flagToDebugInfoLevel :: Maybe String -> DebugInfoLevel
 flagToDebugInfoLevel Nothing = NormalDebugInfo
 flagToDebugInfoLevel (Just s) = case reads s of
   [(i, "")] -> intToEnum "debug info level" i
-  _ -> error $ "Can't parse debug info level " ++ s
+  _ -> case reads s of
+    [(b, "")] -> if b then NormalDebugInfo else NoDebugInfo
+    _ -> error $ "Can't parse debug info level " ++ s
 
 -- ------------------------------------------------------------
 

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -371,21 +371,31 @@ instance Parsec DebugInfoLevel where
   parsec = parsecDebugInfoLevel
 
 parsecDebugInfoLevel :: CabalParsing m => m DebugInfoLevel
-parsecDebugInfoLevel = flagToDebugInfoLevel . pure <$> parsecToken
+parsecDebugInfoLevel = boolParser <|> intParser
+  where
+    boolParser = bool NoDebugInfo NormalDebugInfo <$> parsec
+    intParser = intToDebugInfoLevel <$> integral
 
 flagToDebugInfoLevel :: Maybe String -> DebugInfoLevel
 flagToDebugInfoLevel Nothing = NormalDebugInfo
 flagToDebugInfoLevel (Just s) = case reads s of
-  [(i, "")]
-    | i >= fromEnum (minBound :: DebugInfoLevel)
-        && i <= fromEnum (maxBound :: DebugInfoLevel) ->
-        toEnum i
-    | otherwise ->
-        error $
-          "Bad debug info level: "
-            ++ show i
-            ++ ". Valid values are 0..3"
+  [(i, "")] -> intToDebugInfoLevel i
   _ -> error $ "Can't parse debug info level " ++ s
+
+intToDebugInfoLevel :: Int -> DebugInfoLevel
+intToDebugInfoLevel i
+  | i >= minLevel && i <= maxLevel = toEnum i
+  | otherwise =
+      error $
+        "Bad debug info level: "
+          ++ show i
+          ++ ". Valid values are "
+          ++ show minLevel
+          ++ ".."
+          ++ show maxLevel
+  where
+    minLevel = fromEnum (minBound :: DebugInfoLevel)
+    maxLevel = fromEnum (maxBound :: DebugInfoLevel)
 
 -- ------------------------------------------------------------
 

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -324,28 +324,13 @@ parsecOptimisationLevel :: CabalParsing m => m OptimisationLevel
 parsecOptimisationLevel = boolParser <|> intParser
   where
     boolParser = bool NoOptimisation NormalOptimisation <$> parsec
-    intParser = intToOptimisationLevel <$> integral
+    intParser = intToEnum "optimisation level" <$> integral
 
 flagToOptimisationLevel :: Maybe String -> OptimisationLevel
 flagToOptimisationLevel Nothing = NormalOptimisation
 flagToOptimisationLevel (Just s) = case reads s of
-  [(i, "")] -> intToOptimisationLevel i
+  [(i, "")] -> intToEnum "optimisation level" i
   _ -> error $ "Can't parse optimisation level " ++ s
-
-intToOptimisationLevel :: Int -> OptimisationLevel
-intToOptimisationLevel i
-  | i >= minLevel && i <= maxLevel = toEnum i
-  | otherwise =
-      error $
-        "Bad optimisation level: "
-          ++ show i
-          ++ ". Valid values are "
-          ++ show minLevel
-          ++ ".."
-          ++ show maxLevel
-  where
-    minLevel = fromEnum (minBound :: OptimisationLevel)
-    maxLevel = fromEnum (maxBound :: OptimisationLevel)
 
 -- ------------------------------------------------------------
 
@@ -374,28 +359,13 @@ parsecDebugInfoLevel :: CabalParsing m => m DebugInfoLevel
 parsecDebugInfoLevel = boolParser <|> intParser
   where
     boolParser = bool NoDebugInfo NormalDebugInfo <$> parsec
-    intParser = intToDebugInfoLevel <$> integral
+    intParser = intToEnum "debug info level" <$> integral
 
 flagToDebugInfoLevel :: Maybe String -> DebugInfoLevel
 flagToDebugInfoLevel Nothing = NormalDebugInfo
 flagToDebugInfoLevel (Just s) = case reads s of
-  [(i, "")] -> intToDebugInfoLevel i
+  [(i, "")] -> intToEnum "debug info level" i
   _ -> error $ "Can't parse debug info level " ++ s
-
-intToDebugInfoLevel :: Int -> DebugInfoLevel
-intToDebugInfoLevel i
-  | i >= minLevel && i <= maxLevel = toEnum i
-  | otherwise =
-      error $
-        "Bad debug info level: "
-          ++ show i
-          ++ ". Valid values are "
-          ++ show minLevel
-          ++ ".."
-          ++ show maxLevel
-  where
-    minLevel = fromEnum (minBound :: DebugInfoLevel)
-    maxLevel = fromEnum (maxBound :: DebugInfoLevel)
 
 -- ------------------------------------------------------------
 

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -328,11 +328,10 @@ parsecOptimisationLevel = boolParser <|> intParser
 
 flagToOptimisationLevel :: Maybe String -> OptimisationLevel
 flagToOptimisationLevel Nothing = NormalOptimisation
-flagToOptimisationLevel (Just s) = case reads s of
-  [(i, "")] -> intToEnum "optimisation level" i
-  _ -> case reads s of
-    [(b, "")] -> if b then NormalOptimisation else NoOptimisation
-    _ -> error $ "Can't parse optimisation level " ++ s
+flagToOptimisationLevel (Just s)
+  | Just i <- readMaybe s = intToEnum "optimisation level" i
+  | Just b <- readMaybe s = if b then NormalOptimisation else NoOptimisation
+  | otherwise = error $ "Can't parse optimisation level: " ++ s
 
 -- ------------------------------------------------------------
 
@@ -365,11 +364,10 @@ parsecDebugInfoLevel = boolParser <|> intParser
 
 flagToDebugInfoLevel :: Maybe String -> DebugInfoLevel
 flagToDebugInfoLevel Nothing = NormalDebugInfo
-flagToDebugInfoLevel (Just s) = case reads s of
-  [(i, "")] -> intToEnum "debug info level" i
-  _ -> case reads s of
-    [(b, "")] -> if b then NormalDebugInfo else NoDebugInfo
-    _ -> error $ "Can't parse debug info level " ++ s
+flagToDebugInfoLevel (Just s)
+  | Just i <- readMaybe s = intToEnum "debug info level" i
+  | Just b <- readMaybe s = if b then NormalDebugInfo else NoDebugInfo
+  | otherwise = error $ "Can't parse debug info level " ++ s
 
 -- ------------------------------------------------------------
 

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -201,6 +201,7 @@ module Distribution.Simple.Utils
   , wrapText
   , wrapLine
   , stripCommonPrefix
+  , intToEnum
 
     -- * FilePath stuff
   , isAbsoluteOnAnyPlatform
@@ -2171,3 +2172,21 @@ stripCommonPrefix (x : xs) (y : ys)
   | x == y = stripCommonPrefix xs ys
   | otherwise = y : ys
 stripCommonPrefix _ ys = ys
+
+intToEnum :: (Show a, Enum a, Bounded a) => String -> Int -> a
+intToEnum str i =
+  let res = toEnum i
+      maxLevel = maxBound `asTypeOf` res
+      minLevel = minBound `asTypeOf` res
+   in if i >= fromEnum minLevel && i <= fromEnum maxLevel
+        then res
+        else
+          error $
+            "Bad "
+              ++ str
+              ++ ": "
+              ++ show i
+              ++ ". Valid values are "
+              ++ show minLevel
+              ++ ".."
+              ++ show maxLevel

--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.out
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.out
@@ -8,3 +8,6 @@ In order, the following would be built:
 # cabal build
 Warnings found while parsing the project file, cabal.boolean.project:
  - cabal.boolean.project:2:1: The field "debug-info" is specified more than once at positions 2:1, 3:1
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - debug-info-0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectConfig/DebugInfo/cabal.test.hs
@@ -6,7 +6,5 @@ main = cabalTest . recordMode RecordMarked $ do
   numeric <- cabal' "build" ["--project-file=cabal.numeric.project", "--dry-run"]
   assertOutputDoesNotContain errMsg numeric
 
-  boolean <- fails $ cabal' "build" ["--project-file=cabal.boolean.project", "--dry-run"]
-  -- TODO: When fixed, change this to assertOutputDoesNotContain.
-  assertOutputContains errMsg boolean
-  pure ()
+  boolean <- cabal' "build" ["--project-file=cabal.boolean.project", "--dry-run"]
+  assertOutputDoesNotContain errMsg boolean

--- a/changelog.d/12202.md
+++ b/changelog.d/12202.md
@@ -1,8 +1,48 @@
 ---
-synopsis: Fix parsing of boolean values to debug-info
+synopsis: Accept boolean values for `debug-info` and `optimization` levels
 packages: [Cabal]
 prs: 12202
 issues: 12140
 ---
 
-`False` values are treated as `NoDebugInfo`, and `True` values are treated as `NormalDebugInfo`.
+The `debug-info` and `optimization`/`optimisation` options now accept boolean
+values in addition to numeric levels, both in project files
+(`debug-info: True`) and on the command line (`--enable-debug-info=True`,
+`--enable-optimization=True`).
+
+`True` is parsed as the normal level and `False` as the disabled level.
+Previously the parsec project-file parser rejected `debug-info: True` with
+"Can't parse debug info level True" (the legacy parser already accepted it),
+and the corresponding command-line options only accepted numeric arguments.
+
+In a project file:
+
+```diff
+- debug-info: True
+- # Can't parse debug info level True
++ debug-info: True
++ # OK, treated as NormalDebugInfo
+```
+
+On the command line:
+
+```diff
+- $ cabal build all --dry-run --enable-debug-info=True
+- Can't parse debug info level True
++ $ cabal build all --dry-run --enable-debug-info=True
++ Resolving dependencies...
++ Build profile: -w ghc-<GHCVER> -O1
++ In order, the following would be built:
++  - debug-info-0 (lib) (first run)
+```
+
+```diff
+- $ cabal build all --dry-run --enable-optimization=True
+- Can't parse optimisation level True
++ $ cabal build all --dry-run --enable-optimization=True
++ Build profile: -w ghc-<GHCVER> -O1
+- $ cabal build all --dry-run --enable-optimization=False
+- Can't parse optimisation level False
++ $ cabal build all --dry-run --enable-optimization=False
++ Build profile: -w ghc-<GHCVER> -O0
+```

--- a/changelog.d/12202.md
+++ b/changelog.d/12202.md
@@ -1,8 +1,8 @@
 ---
-synopsis: Fix parsing of boolean values ​​to debug-info
+synopsis: Fix parsing of boolean values to debug-info
 packages: [Cabal]
 prs: 12202
 issues: 12140
 ---
 
-`False` values ​​are treated as `NoDebugInfo`, and `True` values ​​are treated as `NormalDebugInfo`.
+`False` values are treated as `NoDebugInfo`, and `True` values are treated as `NormalDebugInfo`.

--- a/changelog.d/12202.md
+++ b/changelog.d/12202.md
@@ -1,0 +1,8 @@
+---
+synopsis: Fix parsing of boolean values ​​to debug-info
+packages: [Cabal]
+prs: 12202
+issues: 12140
+---
+
+`False` values ​​are treated as `NoDebugInfo`, and `True` values ​​are treated as `NormalDebugInfo`.


### PR DESCRIPTION
fix: https://github.com/haskell/cabal/issues/12140

`debug-info: False` ​​are treated as `NoDebugInfo`, and `debug-info: True` ​​are treated as `NormalDebugInfo`

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)