### PR TITLE
Guard base>=4.22 wired-in constraint on wired-in unit ids

### DIFF
--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -457,9 +457,19 @@ dependOnWiredIns compiler params = addConstraints extraConstraints params
         -- Old versions of `base` must be excluded from build plans still as they do not depend on any version of a wired-in unit.
         -- If we do not do this then we will get confusing error messages about old versions of `base` being unbuildable.
         -- Newer versions of `base` will be handled gracefully as they were designed to be reinstallable.
+        --
+        -- This only makes sense when the wired-in unit ids above are actually
+        -- in force: it is those constraints that pin the new, reinstallable
+        -- `base`, leaving old `base` to be excluded explicitly. A compiler
+        -- that reports no wired-in unit ids (e.g. GHC < 9.14) has no
+        -- installed `base` satisfying this bound, so adding it
+        -- unconditionally makes such a compiler's plans unsolvable whenever
+        -- this branch is taken (which `allow-boot-library-installs` alone is
+        -- enough to do).
         [ LabeledPackageConstraint
-            (PackageConstraint (ScopeAnyQualifier $ mkPackageName "base") (PackagePropertyVersion (orLaterVersion (mkVersion [4, 22]))))
-            ConstraintSourceNonReinstallablePackage
+          (PackageConstraint (ScopeAnyQualifier $ mkPackageName "base") (PackagePropertyVersion (orLaterVersion (mkVersion [4, 22]))))
+          ConstraintSourceNonReinstallablePackage
+        | isJust (compilerInfoWiredInUnitIds compiler)
         ]
 
 -- | Some packages are specific to a given compiler version and should never be

--- a/changelog.d/base-422-wired-in-guard.md
+++ b/changelog.d/base-422-wired-in-guard.md
@@ -1,0 +1,14 @@
+---
+synopsis: Fix unsolvable plans on compilers without wired-in unit ids
+packages: [cabal-install]
+prs: 12206
+significance: normal
+---
+
+`dependOnWiredIns` added a `base >= 4.22` lower-bound constraint
+unconditionally, even for compilers that report no wired-in unit ids at all
+(GHC < 9.14). Such a compiler's installed `base` never satisfies that bound,
+so any plan reaching this code path — which `allow-boot-library-installs`
+alone is enough to trigger — became unsolvable. The constraint is now guarded
+on the compiler actually reporting wired-in unit ids, matching the intent of
+the surrounding comment.


### PR DESCRIPTION
## Summary

`dependOnWiredIns` (in `cabal-install/src/Distribution/Client/Dependency.hs`) appends a `base >= 4.22` lower-bound constraint outside the wired-in-unit-ids list comprehension it's meant to complement. The comment above it explains the intent: old `base` must be excluded because it doesn't depend on any wired-in unit, while newer `base` is reinstallable and covered by the wired-in-unit-id constraints instead.

The constraint was unconditional, so a compiler that reports **no** wired-in unit ids at all (GHC < 9.14) still gets the `>=4.22` lower bound on `base`, with nothing in that compiler's install to satisfy it. Any plan that reaches this branch — which `allow-boot-library-installs: True` alone is enough to trigger — becomes unsolvable.

This was introduced by 20f0f906add ("cabal-install: base <4.22 is still non-reinstallable").

Fix: guard the constraint on `isJust (compilerInfoWiredInUnitIds compiler)`, so it only fires when the wired-in unit ids it depends on are actually present.

## Test plan

- Found while building GHC (`stable-haskell/ghc`, whose `cabal.project.common` sets `allow-boot-library-installs: True` with a GHC0 bootstrap compiler in the 9.8/9.10 range) — before this fix, cabal's plan computation failed with an unsatisfiable `base` constraint on that bootstrap compiler; after the fix, planning succeeds.
- `mise run format` / `mise run lint` / `mise run whitespace` clean
- `cabal build cabal-install:exe:cabal` succeeds
