### PR TITLE
Capitalise first letter of option help

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Benchmark.hs
@@ -116,7 +116,7 @@ benchmarkOptions' showOrParseArgs =
     [ option
         []
         ["benchmark-options"]
-        ( "give extra options to benchmark executables "
+        ( "Give extra options to benchmark executables "
             ++ "(split on spaces, use \"\" to prevent splitting; "
             ++ "name templates can use $pkgid, $compiler, "
             ++ "$os, $arch, $benchmark)"
@@ -131,7 +131,7 @@ benchmarkOptions' showOrParseArgs =
     , option
         []
         ["benchmark-option"]
-        ( "give extra option to benchmark executables "
+        ( "Give extra option to benchmark executables "
             ++ "(passed directly as a single argument; "
             ++ "name template can use $pkgid, $compiler, "
             ++ "$os, $arch, $benchmark)"

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -237,7 +237,7 @@ programDbPaths' mkName progDb showOrParseArgs get set =
       option
         ""
         [mkName prog]
-        ("give the path to " ++ prog)
+        ("Give the path to " ++ prog)
         get
         set
         ( reqArg'
@@ -267,7 +267,7 @@ programDbOption progDb showOrParseArgs get set =
       option
         ""
         [prog ++ "-option"]
-        ( "give an extra option to "
+        ( "Give an extra option to "
             ++ prog
             ++ " (passed directly to "
             ++ prog
@@ -308,7 +308,7 @@ programDbOptions progDb showOrParseArgs get set =
       option
         ""
         [prog ++ "-options"]
-        ( "give extra options to "
+        ( "Give extra options to "
             ++ prog
             ++ " (split on spaces, use \"\" to prevent splitting)"
         )

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -434,22 +434,22 @@ configureOptions showOrParseArgs =
         configHcFlavor
         (\v flags -> flags{configHcFlavor = v})
         ( choiceOpt
-            [ (Flag GHC, ("g", ["ghc"]), "compile with GHC")
-            , (Flag GHCJS, ([], ["ghcjs"]), "compile with GHCJS")
-            , (Flag UHC, ([], ["uhc"]), "compile with UHC")
+            [ (Flag GHC, ("g", ["ghc"]), "Compile with GHC")
+            , (Flag GHCJS, ([], ["ghcjs"]), "Compile with GHCJS")
+            , (Flag UHC, ([], ["uhc"]), "Compile with UHC")
             ]
         )
     , option
         "w"
         ["with-compiler"]
-        "give the path to a particular compiler"
+        "Give the path to a particular compiler"
         configHcPath
         (\v flags -> flags{configHcPath = v})
         (reqArgFlag "PATH")
     , option
         ""
         ["with-hc-pkg"]
-        "give the path to the package tool"
+        "Give the path to the package tool"
         configHcPkg
         (\v flags -> flags{configHcPkg = v})
         (reqArgFlag "PATH")
@@ -458,14 +458,14 @@ configureOptions showOrParseArgs =
     ++ [ option
           ""
           ["program-prefix"]
-          "prefix to be applied to installed executables"
+          "Prefix to be applied to installed executables"
           configProgPrefix
           (\v flags -> flags{configProgPrefix = v})
           (reqPathTemplateArgFlag "PREFIX")
        , option
           ""
           ["program-suffix"]
-          "suffix to be applied to installed executables"
+          "Suffix to be applied to installed executables"
           configProgSuffix
           (\v flags -> flags{configProgSuffix = v})
           (reqPathTemplateArgFlag "SUFFIX")
@@ -841,7 +841,7 @@ configureOptions showOrParseArgs =
        , option
           ""
           ["response-files"]
-          "enable workaround for old versions of programs like \"ar\" that do not support @file arguments"
+          "Enable workaround for old versions of programs like \"ar\" that do not support @file arguments"
           configUseResponseFiles
           (\v flags -> flags{configUseResponseFiles = v})
           (boolOpt' ([], ["disable-response-files"]) ([], []))
@@ -963,98 +963,98 @@ installDirsOptions =
   [ option
       ""
       ["prefix"]
-      "bake this prefix in preparation of installation"
+      "Bake this prefix in preparation of installation"
       prefix
       (\v flags -> flags{prefix = v})
       installDirArg
   , option
       ""
       ["bindir"]
-      "installation directory for executables"
+      "Installation directory for executables"
       bindir
       (\v flags -> flags{bindir = v})
       installDirArg
   , option
       ""
       ["libdir"]
-      "installation directory for libraries"
+      "Installation directory for libraries"
       libdir
       (\v flags -> flags{libdir = v})
       installDirArg
   , option
       ""
       ["libsubdir"]
-      "subdirectory of libdir in which libs are installed"
+      "Subdirectory of libdir in which libs are installed"
       libsubdir
       (\v flags -> flags{libsubdir = v})
       installDirArg
   , option
       ""
       ["dynlibdir"]
-      "installation directory for dynamic libraries"
+      "Installation directory for dynamic libraries"
       dynlibdir
       (\v flags -> flags{dynlibdir = v})
       installDirArg
   , option
       ""
       ["bytecodelibdir"]
-      "installation directory for bytecode libraries"
+      "Installation directory for bytecode libraries"
       bytecodelibdir
       (\v flags -> flags{bytecodelibdir = v})
       installDirArg
   , option
       ""
       ["libexecdir"]
-      "installation directory for program executables"
+      "Installation directory for program executables"
       libexecdir
       (\v flags -> flags{libexecdir = v})
       installDirArg
   , option
       ""
       ["libexecsubdir"]
-      "subdirectory of libexecdir in which private executables are installed"
+      "Subdirectory of libexecdir in which private executables are installed"
       libexecsubdir
       (\v flags -> flags{libexecsubdir = v})
       installDirArg
   , option
       ""
       ["datadir"]
-      "installation directory for read-only data"
+      "Installation directory for read-only data"
       datadir
       (\v flags -> flags{datadir = v})
       installDirArg
   , option
       ""
       ["datasubdir"]
-      "subdirectory of datadir in which data files are installed"
+      "Subdirectory of datadir in which data files are installed"
       datasubdir
       (\v flags -> flags{datasubdir = v})
       installDirArg
   , option
       ""
       ["docdir"]
-      "installation directory for documentation"
+      "Installation directory for documentation"
       docdir
       (\v flags -> flags{docdir = v})
       installDirArg
   , option
       ""
       ["htmldir"]
-      "installation directory for HTML documentation"
+      "Installation directory for HTML documentation"
       htmldir
       (\v flags -> flags{htmldir = v})
       installDirArg
   , option
       ""
       ["haddockdir"]
-      "installation directory for haddock interfaces"
+      "Installation directory for haddock interfaces"
       haddockdir
       (\v flags -> flags{haddockdir = v})
       installDirArg
   , option
       ""
       ["sysconfdir"]
-      "installation directory for configuration files"
+      "Installation directory for configuration files"
       sysconfdir
       (\v flags -> flags{sysconfdir = v})
       installDirArg

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -356,7 +356,7 @@ haddockOptions showOrParseArgs =
     , option
         ""
         ["resources-dir"]
-        "location of Haddocks static / auxiliary files"
+        "Location of Haddocks static / auxiliary files"
         haddockResourcesDir
         (\v flags -> flags{haddockResourcesDir = v})
         (reqArgFlag "DIR")
@@ -609,7 +609,7 @@ haddockProjectOptions showOrParseArgs =
     , option
         ""
         ["resources-dir"]
-        "location of Haddocks static / auxiliary files"
+        "Location of Haddocks static / auxiliary files"
         haddockProjectResourcesDir
         (\v flags -> flags{haddockProjectResourcesDir = v})
         (reqArgFlag "DIR")

--- a/Cabal/src/Distribution/Simple/Setup/Test.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Test.hs
@@ -218,7 +218,7 @@ testOptions' showOrParseArgs =
     , option
         []
         ["keep-tix-files"]
-        "keep .tix files for HPC between test runs"
+        "Keep .tix files for HPC between test runs"
         testKeepTix
         (\v flags -> flags{testKeepTix = v})
         trueArg
@@ -243,7 +243,7 @@ testOptions' showOrParseArgs =
     , option
         []
         ["test-options"]
-        ( "give extra options to test executables "
+        ( "Give extra options to test executables "
             ++ "(split on spaces, use \"\" to prevent splitting; "
             ++ "name templates can use $pkgid, $compiler, "
             ++ "$os, $arch, $test-suite)"
@@ -258,7 +258,7 @@ testOptions' showOrParseArgs =
     , option
         []
         ["test-option"]
-        ( "give extra option to test executables "
+        ( "Give extra option to test executables "
             ++ "(passed directly as a single argument; "
             ++ "name template can use $pkgid, $compiler, "
             ++ "$os, $arch, $test-suite)"

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1962,7 +1962,7 @@ programDbOptions progDb showOrParseArgs get' set =
       option
         ""
         [prog ++ "-options"]
-        ("give extra options to " ++ prog)
+        ("Give extra options to " ++ prog)
         get'
         set
         ( reqArg'

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -2143,7 +2143,7 @@ listOptions =
   , option
       "w"
       ["with-compiler"]
-      "give the path to a particular compiler"
+      "Give the path to a particular compiler"
       listHcPath
       (\v flags -> flags{listHcPath = v})
       (reqArgFlag "PATH")
@@ -3333,7 +3333,7 @@ initOptions _ =
   , option
       "w"
       ["with-compiler"]
-      "give the path to a particular compiler. For 'init', this flag is used \
+      "Give the path to a particular compiler. For 'init', this flag is used \
       \to set the bounds inferred for the 'base' package."
       IT.initHcPath
       (\v flags -> flags{IT.initHcPath = v})

--- a/changelog.d/12219.md
+++ b/changelog.d/12219.md
@@ -1,0 +1,9 @@
+---
+synopsis: Capitalise first letter of command line flag help
+packages: [cabal-install]
+prs: 12219
+issues: 12218
+---
+
+Ensures that each command line flag's help description starts with a capital
+letter.


### PR DESCRIPTION
Fixes #12218. Something of a typo fix.

I'll squash commits before applying the merge label if this pull request is approved.

## Manual QA Notes

Compare the `cabal build --help` output to master.

```
$ git checkout master

$ cabal run cabal-install:cabal -- build --help
$ cabal run cabal-install:cabal -- build --help > help-1.txt

$ gh pr checkout 12219
$ cabal run cabal-install:cabal -- build --help
$ cabal run cabal-install:cabal -- build --help > help-2.txt
```

```diff
$ diff help-1.txt help-2.txt --unified
--- help-1.txt	2026-08-07 09:28:39.796672965 -0400
+++ help-2.txt	2026-08-07 09:24:12.562175313 -0400
@@ -19,32 +19,32 @@
  --builddir=DIR                 The directory where Cabal puts generated build
                                 files (default dist)
  --keep-temp-files              Keep temporary files.
- -g, --ghc                      compile with GHC
- --ghcjs                        compile with GHCJS
- --uhc                          compile with UHC
+ -g, --ghc                      Compile with GHC
+ --ghcjs                        Compile with GHCJS
+ --uhc                          Compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
-                                give the path to a particular compiler
- --with-hc-pkg=PATH             give the path to the package tool
- --prefix=DIR                   bake this prefix in preparation of
+                                Give the path to a particular compiler
+ --with-hc-pkg=PATH             Give the path to the package tool
+ --prefix=DIR                   Bake this prefix in preparation of
                                 installation
- --bindir=DIR                   installation directory for executables
- --libdir=DIR                   installation directory for libraries
- --libsubdir=DIR                subdirectory of libdir in which libs are
+ --bindir=DIR                   Installation directory for executables
+ --libdir=DIR                   Installation directory for libraries
+ --libsubdir=DIR                Subdirectory of libdir in which libs are
                                 installed
- --dynlibdir=DIR                installation directory for dynamic libraries
- --bytecodelibdir=DIR           installation directory for bytecode libraries
- --libexecdir=DIR               installation directory for program executables
- --libexecsubdir=DIR            subdirectory of libexecdir in which private
+ --dynlibdir=DIR                Installation directory for dynamic libraries
+ --bytecodelibdir=DIR           Installation directory for bytecode libraries
+ --libexecdir=DIR               Installation directory for program executables
+ --libexecsubdir=DIR            Subdirectory of libexecdir in which private
                                 executables are installed
- --datadir=DIR                  installation directory for read-only data
- --datasubdir=DIR               subdirectory of datadir in which data files
+ --datadir=DIR                  Installation directory for read-only data
+ --datasubdir=DIR               Subdirectory of datadir in which data files
                                 are installed
- --docdir=DIR                   installation directory for documentation
- --htmldir=DIR                  installation directory for HTML documentation
- --haddockdir=DIR               installation directory for haddock interfaces
- --sysconfdir=DIR               installation directory for configuration files
- --program-prefix=PREFIX        prefix to be applied to installed executables
- --program-suffix=SUFFIX        suffix to be applied to installed executables
+ --docdir=DIR                   Installation directory for documentation
+ --htmldir=DIR                  Installation directory for HTML documentation
+ --haddockdir=DIR               Installation directory for haddock interfaces
+ --sysconfdir=DIR               Installation directory for configuration files
+ --program-prefix=PREFIX        Prefix to be applied to installed executables
+ --program-suffix=SUFFIX        Suffix to be applied to installed executables
  --enable-library-vanilla       Enable Vanilla libraries
  --disable-library-vanilla      Disable Vanilla libraries
  -p, --enable-library-profiling
@@ -166,7 +166,7 @@
                                 (GHC only)
  --disable-relocatable          Disable building a package that is
                                 relocatable. (GHC only)
- --disable-response-files       enable workaround for old versions of programs
+ --disable-response-files       Enable workaround for old versions of programs
                                 like "ar" that do not support @file arguments
  --allow-depending-on-private-libs
                                 Allow depending on private libraries. If set,
@@ -177,10 +177,10 @@
  --ignore-build-tools           Ignore build tool dependencies. If set,
                                 declared build tools needn't be found for
                                 compilation to proceed.
- --with-PROG=PATH               give the path to PROG
- --PROG-option=OPT              give an extra option to PROG (passed directly
+ --with-PROG=PATH               Give the path to PROG
+ --PROG-option=OPT              Give an extra option to PROG (passed directly
                                 to PROG as a single argument)
- --PROG-options=OPTS            give extra options to PROG (split on spaces,
+ --PROG-options=OPTS            Give extra options to PROG (split on spaces,
                                 use "" to prevent splitting)
  --cabal-lib-version=VERSION    Select which version of the Cabal lib to use
                                 to build packages (useful for testing).
@@ -320,7 +320,7 @@
                                 Bake URL in as the location for the contents
                                 page
  --haddock-base-url=URL         Base URL for static files.
- --haddock-resources-dir=DIR    location of Haddocks static / auxiliary files
+ --haddock-resources-dir=DIR    Location of Haddocks static / auxiliary files
  --haddock-output-dir=DIR       Generate haddock documentation into this
                                 directory. This flag is provided as a
                                 technology preview and is subject to change in
@@ -339,24 +339,24 @@
                                 show results of test cases in real
                                 time.'direct': send results of test cases in
                                 real time; no log file.
- --test-keep-tix-files          keep .tix files for HPC between test runs
+ --test-keep-tix-files          Keep .tix files for HPC between test runs
  --test-wrapper=FILE            Run test through a wrapper.
  --test-fail-when-no-test-suites
                                 Exit with failure when no test suites are
                                 found.
- --test-options=TEMPLATES       give extra options to test executables (split
+ --test-options=TEMPLATES       Give extra options to test executables (split
                                 on spaces, use "" to prevent splitting; name
                                 templates can use $pkgid, $compiler, $os,
                                 $arch, $test-suite)
- --test-option=TEMPLATE         give extra option to test executables (passed
+ --test-option=TEMPLATE         Give extra option to test executables (passed
                                 directly as a single argument; name template
                                 can use $pkgid, $compiler, $os, $arch,
                                 $test-suite)
- --benchmark-options=TEMPLATES  give extra options to benchmark executables
+ --benchmark-options=TEMPLATES  Give extra options to benchmark executables
                                 (split on spaces, use "" to prevent splitting;
                                 name templates can use $pkgid, $compiler, $os,
                                 $arch, $benchmark)
- --benchmark-option=TEMPLATE    give extra option to benchmark executables
+ --benchmark-option=TEMPLATE    Give extra option to benchmark executables
                                 (passed directly as a single argument; name
                                 template can use $pkgid, $compiler, $os,
                                 $arch, $benchmark)
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
