### PR TITLE
Add help text marker

### DIFF
--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ViewPatterns #-}
+
 -- |
 -- Module      :  Distribution.GetOpt
 -- Copyright   :  (c) Sven Panne 2002-2005
@@ -82,49 +84,55 @@ data OptHelp = OptHelp
   , optHelp :: String
   }
 
--- | Return a string describing the usage of a command, derived from
--- the header (first argument) and the options described by the
--- second argument.
-usageInfo
-  :: String -- header
-  -> [OptDescr a] -- option descriptors
-  -> String -- nicely formatted description of options
-usageInfo header optDescr = unlines (header : table)
+-- | Lays out the header followed with a formatted table of options.
+--
+-- An item in the table consists of the option and its help.  The option line is
+-- a comma-separated list with all of the short options followed by only the
+-- first long option.  No attempt is made to wrap this option line.
+--
+-- If space allows, the option help text is placed on the same line as the
+-- option line.  If the option line is too long, the help text is placed on the
+-- next line.  The help text is wrapped to fit within 80 columns and always
+-- starts at the same column, column 33. Its first line is prefixed with a @#@
+-- herald.
+usageInfo :: String -> [OptDescr a] -> String
+usageInfo header (map flattenNames -> options) = unlines (header : table)
   where
-    options = flip map optDescr $ \(Option sos los ad d) ->
-      OptHelp
-        { optNames =
-            intercalate ", " $
-              map (fmtShort ad) sos
-                ++ map (fmtLong ad) (take 1 los)
-        , optHelp = d
-        }
+    (nameWidth, helpWidth) = let w = 30 in (w, 80 - (w + 3))
+    indent = ' '
 
-    maxOptNameWidth = 30
-    descolWidth = 80 - (maxOptNameWidth + 3)
-
-    table :: [String]
     table = do
       OptHelp{optNames, optHelp} <- options
-      let wrappedHelp = wrapText descolWidth optHelp
-      if length optNames >= maxOptNameWidth
-        then
-          [" " ++ optNames]
-            ++ renderColumns [] wrappedHelp
-        else renderColumns [optNames] wrappedHelp
+      let wrappedHelp = wrapText helpWidth optHelp
+      if length optNames >= nameWidth - 1
+        then rows optNames [] ++ rows "" wrappedHelp
+        else rows optNames wrappedHelp
 
-    renderColumns :: [String] -> [String] -> [String]
-    renderColumns xs ys = do
-      (x, y) <- zipDefault "" "" xs ys
-      return $ " " ++ padTo maxOptNameWidth x ++ " " ++ y
+    rows x [] = [indent : x]
+    rows x (y : ys) = markedRow x y : map unmarkedRow ys
 
-    padTo n x = take n (x ++ repeat ' ')
+    markedRow name help = rowOption name ++ ' ' : '#' : ' ' : help
+    unmarkedRow help = rowOption "" ++ "   " ++ help
 
-zipDefault :: a -> b -> [a] -> [b] -> [(a, b)]
-zipDefault _ _ [] [] = []
-zipDefault _ bd (a : as) [] = (a, bd) : map (,bd) as
-zipDefault ad _ [] (b : bs) = (ad, b) : map (ad,) bs
-zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
+    rowOption name = indent : padTo (nameWidth - 2) name
+
+-- | Pad a string to a given length with spaces.
+-- >>> padTo 5 "123"
+-- "123  "
+--
+-- If the string is longer than the given length, it is not truncated.
+-- >>> padTo 3 "12345"
+-- "12345"
+padTo :: Int -> String -> String
+padTo = flip $ foldr (\ch rest n -> ch : rest (n - 1)) (`replicate` ' ')
+
+-- | Flatten the short and long option names into a single string for display.
+flattenNames :: OptDescr a -> OptHelp
+flattenNames (Option sos los ad help) =
+  OptHelp
+    { optNames = intercalate ", " $ map (fmtShort ad) sos ++ map (fmtLong ad) (take 1 los)
+    , optHelp = help
+    }
 
 -- | Pretty printing of short options.
 -- * With required arguments can be given as:

--- a/changelog.d/12221.md
+++ b/changelog.d/12221.md
@@ -1,0 +1,47 @@
+---
+synopsis: Command option help \# herald
+packages: [Cabal]
+prs: 12221
+issues: 1220
+---
+
+When laying out the table of options, `Distribution.GetOpt.usageInfo` marks the
+first line of each help description with a preceding `#` to herald the
+description. Longer descriptions wrap and this herald helps to itemize or
+separate descriptions, like bullet points in a list.
+
+The options may overflow the columns reserved for them. If they do the
+description of that option starts at its normal column but on the next line
+down. This leads to these combinations;
+
+- short option, short description,
+
+    ```pre
+    -h, --help                   # Show this help text.
+    ```
+
+- short option, long description,
+
+    ```pre
+    --enable-tests               # Enable dependency checking and compilation for
+                                   test suites listed in the package description
+                                   file.
+    ```
+
+- long option, short description,
+
+    ```pre
+    -w PATH or -wPATH, --with-compiler=PATH
+                                 # Give the path to a particular compiler.
+    ```
+
+- long option, long description.
+
+    ```pre
+    -f FLAGS or -fFLAGS, --flags=FLAGS
+                                 # Force values for the given flags in Cabal
+                                   conditionals in the .cabal file. E.g.,
+                                   --flags="debug -usebytestrings" forces the
+                                   flag "debug" to true and "usebytestrings" to
+                                   false.
+    ```


### PR DESCRIPTION
Fixes #12220. Uses an ASCII `#` as the marker. Rewrote the haddocks for `usageInfo`. Replaced the implementation of `padTo` adding haddocks and doctests.

I'll squash commits before applying the merge label if this pull request is approved.

## Manual QA Notes

Compare the `cabal build --help` output to master.

```
$ git checkout master

$ cabal run cabal-install:cabal -- build --help
$ cabal run cabal-install:cabal -- build --help > help-1.txt

$ gh pr checkout 12219
$ cabal run cabal-install:cabal -- build --help
$ cabal run cabal-install:cabal -- build --help > help-2.txt
```

```diff
$ diff help-1.txt help-2.txt --unified
--- help-1.txt	2026-08-12 15:36:40.176840646 -0400
+++ help-2.txt	2026-08-12 15:37:43.405366780 -0400
@@ -13,100 +13,102 @@
 configuration from the 'cabal.project', 'cabal.project.local' and other files.
 
 Flags for build:
- -h, --help                     Show this help text
- -v[n], --verbose[=n]           Control verbosity (n is 0--3, default
+ -h, --help                   # Show this help text
+ -v[n], --verbose[=n]         # Control verbosity (n is 0--3, default
                                 verbosity level is 1)
- --builddir=DIR                 The directory where Cabal puts generated build
+ --builddir=DIR               # The directory where Cabal puts generated build
                                 files (default dist)
- --keep-temp-files              Keep temporary files.
- -g, --ghc                      compile with GHC
- --ghcjs                        compile with GHCJS
- --uhc                          compile with UHC
+ --keep-temp-files            # Keep temporary files.
+ -g, --ghc                    # compile with GHC
+ --ghcjs                      # compile with GHCJS
+ --uhc                        # compile with UHC
  -w PATH or -wPATH, --with-compiler=PATH
-                                give the path to a particular compiler
- --with-hc-pkg=PATH             give the path to the package tool
- --prefix=DIR                   bake this prefix in preparation of
+                              # give the path to a particular compiler
+ --with-hc-pkg=PATH           # give the path to the package tool
+ --prefix=DIR                 # bake this prefix in preparation of
                                 installation
- --bindir=DIR                   installation directory for executables
- --libdir=DIR                   installation directory for libraries
- --libsubdir=DIR                subdirectory of libdir in which libs are
+ --bindir=DIR                 # installation directory for executables
+ --libdir=DIR                 # installation directory for libraries
+ --libsubdir=DIR              # subdirectory of libdir in which libs are
                                 installed
- --dynlibdir=DIR                installation directory for dynamic libraries
- --bytecodelibdir=DIR           installation directory for bytecode libraries
- --libexecdir=DIR               installation directory for program executables
- --libexecsubdir=DIR            subdirectory of libexecdir in which private
+ --dynlibdir=DIR              # installation directory for dynamic libraries
+ --bytecodelibdir=DIR         # installation directory for bytecode libraries
+ --libexecdir=DIR             # installation directory for program executables
+ --libexecsubdir=DIR          # subdirectory of libexecdir in which private
                                 executables are installed
- --datadir=DIR                  installation directory for read-only data
- --datasubdir=DIR               subdirectory of datadir in which data files
+ --datadir=DIR                # installation directory for read-only data
+ --datasubdir=DIR             # subdirectory of datadir in which data files
                                 are installed
- --docdir=DIR                   installation directory for documentation
- --htmldir=DIR                  installation directory for HTML documentation
- --haddockdir=DIR               installation directory for haddock interfaces
- --sysconfdir=DIR               installation directory for configuration files
- --program-prefix=PREFIX        prefix to be applied to installed executables
- --program-suffix=SUFFIX        suffix to be applied to installed executables
- --enable-library-vanilla       Enable Vanilla libraries
- --disable-library-vanilla      Disable Vanilla libraries
+ --docdir=DIR                 # installation directory for documentation
+ --htmldir=DIR                # installation directory for HTML documentation
+ --haddockdir=DIR             # installation directory for haddock interfaces
+ --sysconfdir=DIR             # installation directory for configuration files
+ --program-prefix=PREFIX      # prefix to be applied to installed executables
+ --program-suffix=SUFFIX      # suffix to be applied to installed executables
+ --enable-library-vanilla     # Enable Vanilla libraries
+ --disable-library-vanilla    # Disable Vanilla libraries
  -p, --enable-library-profiling
-                                Enable Library profiling
- --disable-library-profiling    Disable Library profiling
- --enable-shared                Enable Shared library
- --disable-shared               Disable Shared library
- --enable-static                Enable Static library
- --disable-static               Disable Static library
- --enable-library-bytecode      Enable Bytecode library
- --disable-library-bytecode     Disable Bytecode library
- --enable-executable-dynamic    Enable Executable dynamic linking
- --disable-executable-dynamic   Disable Executable dynamic linking
- --enable-executable-static     Enable Executable fully static linking
- --disable-executable-static    Disable Executable fully static linking
- --enable-profiling             Enable Executable and library profiling
- --disable-profiling            Disable Executable and library profiling
- --enable-profiling-shared      Enable Build profiling shared libraries
- --disable-profiling-shared     Disable Build profiling shared libraries
- --enable-executable-profiling  Enable Executable profiling (DEPRECATED)
+                              # Enable Library profiling
+ --disable-library-profiling  # Disable Library profiling
+ --enable-shared              # Enable Shared library
+ --disable-shared             # Disable Shared library
+ --enable-static              # Enable Static library
+ --disable-static             # Disable Static library
+ --enable-library-bytecode    # Enable Bytecode library
+ --disable-library-bytecode   # Disable Bytecode library
+ --enable-executable-dynamic  # Enable Executable dynamic linking
+ --disable-executable-dynamic # Disable Executable dynamic linking
+ --enable-executable-static   # Enable Executable fully static linking
+ --disable-executable-static  # Disable Executable fully static linking
+ --enable-profiling           # Enable Executable and library profiling
+ --disable-profiling          # Disable Executable and library profiling
+ --enable-profiling-shared    # Enable Build profiling shared libraries
+ --disable-profiling-shared   # Disable Build profiling shared libraries
+ --enable-executable-profiling
+                              # Enable Executable profiling (DEPRECATED)
  --disable-executable-profiling
-                                Disable Executable profiling (DEPRECATED)
- --profiling-detail=level       Profiling detail level for executable and
+                              # Disable Executable profiling (DEPRECATED)
+ --profiling-detail=level     # Profiling detail level for executable and
                                 library (default, none, exported-functions,
                                 toplevel-functions, all-functions, late).
  --library-profiling-detail=level
-                                Profiling detail level for libraries only.
+                              # Profiling detail level for libraries only.
  -O[n], --enable-optimization[=n]
-                                Build with optimization (n is 0--2, default is
+                              # Build with optimization (n is 0--2, default is
                                 1)
- --disable-optimization         Build without optimization
- --enable-debug-info[=n]        Emit debug info (n is 0--3, default is 0)
- --disable-debug-info           Don't emit debug info
- --enable-build-info            Enable build information generation during
+ --disable-optimization       # Build without optimization
+ --enable-debug-info[=n]      # Emit debug info (n is 0--3, default is 0)
+ --disable-debug-info         # Don't emit debug info
+ --enable-build-info          # Enable build information generation during
                                 project building
- --disable-build-info           Disable build information generation during
+ --disable-build-info         # Disable build information generation during
                                 project building
- --enable-library-for-ghci      Enable compile library for use with GHCi
- --disable-library-for-ghci     Disable compile library for use with GHCi
- --enable-split-sections        Enable compile library code such that unneeded
+ --enable-library-for-ghci    # Enable compile library for use with GHCi
+ --disable-library-for-ghci   # Disable compile library for use with GHCi
+ --enable-split-sections      # Enable compile library code such that unneeded
                                 definitions can be dropped from the final
                                 executable (GHC 7.8+)
- --disable-split-sections       Disable compile library code such that
+ --disable-split-sections     # Disable compile library code such that
                                 unneeded definitions can be dropped from the
                                 final executable (GHC 7.8+)
- --enable-split-objs            Enable split library into smaller objects to
+ --enable-split-objs          # Enable split library into smaller objects to
                                 reduce binary sizes (GHC 6.6+)
- --disable-split-objs           Disable split library into smaller objects to
+ --disable-split-objs         # Disable split library into smaller objects to
                                 reduce binary sizes (GHC 6.6+)
- --enable-executable-stripping  Enable strip executables upon installation to
+ --enable-executable-stripping
+                              # Enable strip executables upon installation to
                                 reduce binary sizes
  --disable-executable-stripping
-                                Disable strip executables upon installation to
+                              # Disable strip executables upon installation to
                                 reduce binary sizes
- --enable-library-stripping     Enable strip libraries upon installation to
+ --enable-library-stripping   # Enable strip libraries upon installation to
                                 reduce binary sizes
- --disable-library-stripping    Disable strip libraries upon installation to
+ --disable-library-stripping  # Disable strip libraries upon installation to
                                 reduce binary sizes
- --configure-option=OPT         Extra option for configure
- --user                         Enable doing a per-user installation
- --global                       Disable doing a per-user installation
- --package-db=DB                Append the given package database to the list
+ --configure-option=OPT       # Extra option for configure
+ --user                       # Enable doing a per-user installation
+ --global                     # Disable doing a per-user installation
+ --package-db=DB              # Append the given package database to the list
                                 of package databases used (to satisfy
                                 dependencies and register into). May be a
                                 specific file, 'global' or 'user'. The initial
@@ -115,257 +117,259 @@
                                 Use 'clear' to reset the list to empty. See
                                 the user guide for details.
  -f FLAGS or -fFLAGS, --flags=FLAGS
-                                Force values for the given flags in Cabal
+                              # Force values for the given flags in Cabal
                                 conditionals in the .cabal file. E.g.,
                                 --flags="debug -usebytestrings" forces the
                                 flag "debug" to true and "usebytestrings" to
                                 false.
- --extra-include-dirs=PATH      A list of directories to search for header
+ --extra-include-dirs=PATH    # A list of directories to search for header
                                 files
- --enable-deterministic         Enable Try to be as deterministic as possible
+ --enable-deterministic       # Enable Try to be as deterministic as possible
                                 (used by the test suite)
- --disable-deterministic        Disable Try to be as deterministic as possible
+ --disable-deterministic      # Disable Try to be as deterministic as possible
                                 (used by the test suite)
- --ipid=IPID                    Installed package ID to compile this package
+ --ipid=IPID                  # Installed package ID to compile this package
                                 as
- --cid=CID                      Installed component ID to compile this
+ --cid=CID                    # Installed component ID to compile this
                                 component as
- --extra-lib-dirs=PATH          A list of directories to search for external
+ --extra-lib-dirs=PATH        # A list of directories to search for external
                                 libraries
- --extra-lib-dirs-static=PATH   A list of directories to search for external
+ --extra-lib-dirs-static=PATH # A list of directories to search for external
                                 libraries when linking fully static
                                 executables
- --extra-framework-dirs=PATH    A list of directories to search for external
+ --extra-framework-dirs=PATH  # A list of directories to search for external
                                 frameworks (OS X only)
- --extra-prog-path=PATH         A list of directories to search for required
+ --extra-prog-path=PATH       # A list of directories to search for required
                                 programs (in addition to the normal search
                                 locations)
- --instantiate-with=NAME=MOD    A mapping of signature names to concrete
+ --instantiate-with=NAME=MOD  # A mapping of signature names to concrete
                                 module instantiations.
- --enable-tests                 Enable dependency checking and compilation for
+ --enable-tests               # Enable dependency checking and compilation for
                                 test suites listed in the package description
                                 file.
- --disable-tests                Disable dependency checking and compilation
+ --disable-tests              # Disable dependency checking and compilation
                                 for test suites listed in the package
                                 description file.
- --enable-coverage              Enable build package with Haskell Program
+ --enable-coverage            # Enable build package with Haskell Program
                                 Coverage. (GHC only)
- --disable-coverage             Disable build package with Haskell Program
+ --disable-coverage           # Disable build package with Haskell Program
                                 Coverage. (GHC only)
- --enable-library-coverage      Enable build package with Haskell Program
+ --enable-library-coverage    # Enable build package with Haskell Program
                                 Coverage. (GHC only) (DEPRECATED)
- --disable-library-coverage     Disable build package with Haskell Program
+ --disable-library-coverage   # Disable build package with Haskell Program
                                 Coverage. (GHC only) (DEPRECATED)
- --enable-benchmarks            Enable dependency checking and compilation for
+ --enable-benchmarks          # Enable dependency checking and compilation for
                                 benchmarks listed in the package description
                                 file.
- --disable-benchmarks           Disable dependency checking and compilation
+ --disable-benchmarks         # Disable dependency checking and compilation
                                 for benchmarks listed in the package
                                 description file.
- --enable-relocatable           Enable building a package that is relocatable.
+ --enable-relocatable         # Enable building a package that is relocatable.
                                 (GHC only)
- --disable-relocatable          Disable building a package that is
+ --disable-relocatable        # Disable building a package that is
                                 relocatable. (GHC only)
- --disable-response-files       enable workaround for old versions of programs
+ --disable-response-files     # enable workaround for old versions of programs
                                 like "ar" that do not support @file arguments
  --allow-depending-on-private-libs
-                                Allow depending on private libraries. If set,
+                              # Allow depending on private libraries. If set,
                                 the library visibility check MUST be done
                                 externally.
- --coverage-for=UNITID          A list of unit-ids of libraries to include in
+ --coverage-for=UNITID        # A list of unit-ids of libraries to include in
                                 the Haskell Program Coverage report.
- --ignore-build-tools           Ignore build tool dependencies. If set,
+ --ignore-build-tools         # Ignore build tool dependencies. If set,
                                 declared build tools needn't be found for
                                 compilation to proceed.
- --with-PROG=PATH               give the path to PROG
- --PROG-option=OPT              give an extra option to PROG (passed directly
+ --with-PROG=PATH             # give the path to PROG
+ --PROG-option=OPT            # give an extra option to PROG (passed directly
                                 to PROG as a single argument)
- --PROG-options=OPTS            give extra options to PROG (split on spaces,
+ --PROG-options=OPTS          # give extra options to PROG (split on spaces,
                                 use "" to prevent splitting)
- --cabal-lib-version=VERSION    Select which version of the Cabal lib to use
+ --cabal-lib-version=VERSION  # Select which version of the Cabal lib to use
                                 to build packages (useful for testing).
- --enable-append                Enable appending the new config to the old
+ --enable-append              # Enable appending the new config to the old
                                 config file
- --disable-append               Disable appending the new config to the old
+ --disable-append             # Disable appending the new config to the old
                                 config file
- --enable-backup                Enable the backup of the config file before
+ --enable-backup              # Enable the backup of the config file before
                                 any alterations
- --disable-backup               Disable the backup of the config file before
+ --disable-backup             # Disable the backup of the config file before
                                 any alterations
  -c CONSTRAINT or -cCONSTRAINT, --constraint=CONSTRAINT
-                                Specify constraints on a package (version,
+                              # Specify constraints on a package (version,
                                 installed/source, flags)
- --preference=CONSTRAINT        Specify preferences (soft constraints) on the
+ --preference=CONSTRAINT      # Specify preferences (soft constraints) on the
                                 version of a package
- --solver=SOLVER                Select dependency solver to use (default:
+ --solver=SOLVER              # Select dependency solver to use (default:
                                 modular). Choices: modular.
- --allow-older[=DEPS]           Ignore lower bounds in all dependencies or
+ --allow-older[=DEPS]         # Ignore lower bounds in all dependencies or
                                 DEPS
- --allow-newer[=DEPS]           Ignore upper bounds in all dependencies or
+ --allow-newer[=DEPS]         # Ignore upper bounds in all dependencies or
                                 DEPS
  --write-ghc-environment-files=always|never|ghc8.4.4+
-                                Whether to create a .ghc.environment file
+                              # Whether to create a .ghc.environment file
                                 after a successful build (v2-build only)
- --enable-documentation         Enable building of documentation
- --disable-documentation        Disable building of documentation
- --doc-index-file=TEMPLATE      A central index of haddock API documentation
+ --enable-documentation       # Enable building of documentation
+ --disable-documentation      # Disable building of documentation
+ --doc-index-file=TEMPLATE    # A central index of haddock API documentation
                                 (template cannot use $pkgid)
- --dry-run                      Do not install anything, only print what would
+ --dry-run                    # Do not install anything, only print what would
                                 be installed.
- --only-download                Do not build anything, only fetch the
+ --only-download              # Do not build anything, only fetch the
                                 packages.
- --max-backjumps=NUM            Maximum number of backjumps allowed while
+ --max-backjumps=NUM          # Maximum number of backjumps allowed while
                                 solving (default: 4000). Use a negative number
                                 to enable unlimited backtracking. Use 0 to
                                 disable backtracking completely.
- --reorder-goals                Try to reorder goals according to certain
+ --reorder-goals              # Try to reorder goals according to certain
                                 heuristics. Slows things down on average, but
                                 may make backtracking faster for some
                                 packages.
- --count-conflicts              Try to speed up solving by preferring goals
+ --count-conflicts            # Try to speed up solving by preferring goals
                                 that are involved in a lot of conflicts
                                 (default).
- --fine-grained-conflicts       Skip a version of a package if it does not
+ --fine-grained-conflicts     # Skip a version of a package if it does not
                                 resolve the conflicts encountered in the last
                                 version, as a solver optimization (default).
- --minimize-conflict-set        When there is no solution, try to improve the
+ --minimize-conflict-set      # When there is no solution, try to improve the
                                 error message by finding a minimal conflict
                                 set (default: false). May increase run time
                                 significantly.
- --independent-goals            Treat several goals on the command line as
+ --independent-goals          # Treat several goals on the command line as
                                 independent. If several goals depend on the
                                 same package, different versions can be
                                 chosen.
- --prefer-oldest                Prefer the oldest (instead of the latest)
+ --prefer-oldest              # Prefer the oldest (instead of the latest)
                                 versions of packages available. Useful to
                                 determine lower bounds in the build-depends
                                 section.
  --prefer-version=oldest|latest|installed-or-latest
-                                Select which version of a package that the
+                              # Select which version of a package that the
                                 solver should prefer. Oldest is useful to
                                 determine lower bounds in build-depends
                                 section. Latest will prefer the latest
                                 version. Installed-or-latest will prefer
                                 installed versions and the latest version
                                 otherwise.
- --shadow-installed-packages    If multiple package instances of the same
+ --shadow-installed-packages  # If multiple package instances of the same
                                 version are installed, treat all but one as
                                 shadowed.
- --strong-flags                 Do not defer flag choices (this used to be the
+ --strong-flags               # Do not defer flag choices (this used to be the
                                 default in cabal-install <= 1.20).
- --allow-boot-library-installs  Allow cabal to install base, ghc-prim,
+ --allow-boot-library-installs
+                              # Allow cabal to install base, ghc-prim,
                                 integer-simple, integer-gmp, and
                                 template-haskell.
  --reject-unconstrained-dependencies=none|all
-                                Require these packages to have constraints on
+                              # Require these packages to have constraints on
                                 them if they are to be selected (default:
                                 none).
- --reinstall                    Install even if it means installing the same
+ --reinstall                  # Install even if it means installing the same
                                 version again.
- --avoid-reinstalls             Do not select versions that would
+ --avoid-reinstalls           # Do not select versions that would
                                 destructively overwrite installed packages.
- --force-reinstalls             Reinstall packages even if they will most
+ --force-reinstalls           # Reinstall packages even if they will most
                                 likely break other installed packages.
- --upgrade-dependencies         Pick the latest version for all dependencies,
+ --upgrade-dependencies       # Pick the latest version for all dependencies,
                                 rather than trying to pick an installed
                                 version.
- --only-dependencies            Install only the dependencies necessary to
+ --only-dependencies          # Install only the dependencies necessary to
                                 build the given packages
- --dependencies-only            A synonym for --only-dependencies
- --index-state=STATE            Use source package index state as it existed
+ --dependencies-only          # A synonym for --only-dependencies
+ --index-state=STATE          # Use source package index state as it existed
                                 at a previous time. Accepts unix-timestamps
                                 (e.g. '@1474732068'), ISO8601 UTC timestamps
                                 (e.g. '2016-09-24T17:47:48Z'), or 'HEAD'
                                 (default: 'HEAD').
- --root-cmd=COMMAND             (No longer supported, do not use.)
- --build-summary=TEMPLATE       Save build summaries to file (name template
+ --root-cmd=COMMAND           # (No longer supported, do not use.)
+ --build-summary=TEMPLATE     # Save build summaries to file (name template
                                 can use $pkgid, $compiler, $os, $arch)
- --build-log=TEMPLATE           Log all builds to file (name template can use
+ --build-log=TEMPLATE         # Log all builds to file (name template can use
                                 $pkgid, $compiler, $os, $arch)
  --remote-build-reporting=LEVEL
-                                Generate build reports to send to a remote
+                              # Generate build reports to send to a remote
                                 server (none, anonymous or detailed).
- --report-planning-failure      Generate build reports when the dependency
+ --report-planning-failure    # Generate build reports when the dependency
                                 solver fails. This is used by the Hackage
                                 build bot.
- --enable-per-component         Enable Per-component builds when possible
- --disable-per-component        Disable Per-component builds when possible
- --run-tests                    Run package test suites during installation.
- --semaphore                    Use a semaphore so GHC can compile components
+ --enable-per-component       # Enable Per-component builds when possible
+ --disable-per-component      # Disable Per-component builds when possible
+ --run-tests                  # Run package test suites during installation.
+ --semaphore                  # Use a semaphore so GHC can compile components
                                 in parallel
- -j[NUM], --jobs[=NUM]          Run NUM jobs simultaneously (or '$ncpus' if no
+ -j[NUM], --jobs[=NUM]        # Run NUM jobs simultaneously (or '$ncpus' if no
                                 NUM is given).
- --keep-going                   After a build failure, continue to build other
+ --keep-going                 # After a build failure, continue to build other
                                 unaffected packages.
- --offline                      Don't download packages from the Internet.
- --build-timings                Print elapsed time for each build phase.
- --haddock-hoogle               Generate a hoogle database
- --haddock-html                 Generate HTML documentation (the default)
- --haddock-html-location=URL    Location of HTML documentation for
+ --offline                    # Don't download packages from the Internet.
+ --build-timings              # Print elapsed time for each build phase.
+ --haddock-hoogle             # Generate a hoogle database
+ --haddock-html               # Generate HTML documentation (the default)
+ --haddock-html-location=URL  # Location of HTML documentation for
                                 pre-requisite packages
- --haddock-for-hackage          Collection of flags to generate documentation
+ --haddock-for-hackage        # Collection of flags to generate documentation
                                 suitable for upload to hackage
- --haddock-executables          Run haddock for Executables targets
- --haddock-tests                Run haddock for Test Suite targets
- --haddock-benchmarks           Run haddock for Benchmark targets
- --haddock-all                  Run haddock for all targets
- --haddock-internal             Run haddock for internal modules and include
+ --haddock-executables        # Run haddock for Executables targets
+ --haddock-tests              # Run haddock for Test Suite targets
+ --haddock-benchmarks         # Run haddock for Benchmark targets
+ --haddock-all                # Run haddock for all targets
+ --haddock-internal           # Run haddock for internal modules and include
                                 all symbols
- --haddock-css=PATH             Use PATH as the haddock stylesheet
- --haddock-hyperlink-source     Hyperlink the documentation to the source code
- --haddock-quickjump            Generate an index for interactive
+ --haddock-css=PATH           # Use PATH as the haddock stylesheet
+ --haddock-hyperlink-source   # Hyperlink the documentation to the source code
+ --haddock-quickjump          # Generate an index for interactive
                                 documentation navigation
- --haddock-hscolour-css=PATH    Use PATH as the HsColour stylesheet
+ --haddock-hscolour-css=PATH  # Use PATH as the HsColour stylesheet
  --haddock-contents-location=URL
-                                Bake URL in as the location for the contents
+                              # Bake URL in as the location for the contents
                                 page
- --haddock-base-url=URL         Base URL for static files.
- --haddock-resources-dir=DIR    location of Haddocks static / auxiliary files
- --haddock-output-dir=DIR       Generate haddock documentation into this
+ --haddock-base-url=URL       # Base URL for static files.
+ --haddock-resources-dir=DIR  # location of Haddocks static / auxiliary files
+ --haddock-output-dir=DIR     # Generate haddock documentation into this
                                 directory. This flag is provided as a
                                 technology preview and is subject to change in
                                 the next releases.
- --haddock-use-unicode          Pass --use-unicode option to haddock
- --test-log=TEMPLATE            Log all test suite results to file (name
+ --haddock-use-unicode        # Pass --use-unicode option to haddock
+ --test-log=TEMPLATE          # Log all test suite results to file (name
                                 template can use $pkgid, $compiler, $os,
                                 $arch, $test-suite, $result)
- --test-machine-log=TEMPLATE    Produce a machine-readable log file (name
+ --test-machine-log=TEMPLATE  # Produce a machine-readable log file (name
                                 template can use $pkgid, $compiler, $os,
                                 $arch, $result)
- --test-show-details=FILTER     'always': always show results of individual
+ --test-show-details=FILTER   # 'always': always show results of individual
                                 test cases. 'never': never show results of
                                 individual test cases. 'failures': show
                                 results of failing test cases. 'streaming':
                                 show results of test cases in real
                                 time.'direct': send results of test cases in
                                 real time; no log file.
- --test-keep-tix-files          keep .tix files for HPC between test runs
- --test-wrapper=FILE            Run test through a wrapper.
+ --test-keep-tix-files        # keep .tix files for HPC between test runs
+ --test-wrapper=FILE          # Run test through a wrapper.
  --test-fail-when-no-test-suites
-                                Exit with failure when no test suites are
+                              # Exit with failure when no test suites are
                                 found.
- --test-options=TEMPLATES       give extra options to test executables (split
+ --test-options=TEMPLATES     # give extra options to test executables (split
                                 on spaces, use "" to prevent splitting; name
                                 templates can use $pkgid, $compiler, $os,
                                 $arch, $test-suite)
- --test-option=TEMPLATE         give extra option to test executables (passed
+ --test-option=TEMPLATE       # give extra option to test executables (passed
                                 directly as a single argument; name template
                                 can use $pkgid, $compiler, $os, $arch,
                                 $test-suite)
- --benchmark-options=TEMPLATES  give extra options to benchmark executables
+ --benchmark-options=TEMPLATES
+                              # give extra options to benchmark executables
                                 (split on spaces, use "" to prevent splitting;
                                 name templates can use $pkgid, $compiler, $os,
                                 $arch, $benchmark)
- --benchmark-option=TEMPLATE    give extra option to benchmark executables
+ --benchmark-option=TEMPLATE  # give extra option to benchmark executables
                                 (passed directly as a single argument; name
                                 template can use $pkgid, $compiler, $os,
                                 $arch, $benchmark)
- --project-dir=DIR              Set the path of the project directory
- --project-file=FILE            Set the path of the cabal.project file
+ --project-dir=DIR            # Set the path of the project directory
+ --project-file=FILE          # Set the path of the cabal.project file
                                 (relative to the project directory when
                                 relative)
- --project-file-parser=PARSER   Set the parser to use for the project file
- --only-configure               Instead of performing a full build just run
+ --project-file-parser=PARSER # Set the parser to use for the project file
+ --only-configure             # Instead of performing a full build just run
                                 the configure step
 
 Examples:
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
