### PR TITLE
Don't re-run the solver unnecessarily (#12119)

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
@@ -65,7 +65,10 @@ import Distribution.Types.UnqualComponentName
 -- | Constrained instance. It represents the allowed instances for a package,
 -- which can be either a fixed instance or a version range.
 data CI = Fixed I | Constrained VR
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured CI
+instance Binary CI
 
 {-------------------------------------------------------------------------------
   Flagged dependencies
@@ -92,6 +95,10 @@ data FlaggedDep qpn =
   | Stanza  (SN qpn)       (TrueFlaggedDeps qpn)
     -- | Dependencies which are always enabled, for the component 'comp'.
   | Simple (LDep qpn) Component
+  deriving (Eq, Generic)
+
+instance Structured qpn => Structured (FlaggedDep qpn)
+instance Binary qpn => Binary (FlaggedDep qpn)
 
 -- | Conservatively flatten out flagged dependencies
 --
@@ -114,6 +121,10 @@ type FalseFlaggedDeps qpn = FlaggedDeps qpn
 -- depending; having a 'Functor' instance makes bugs where we don't distinguish
 -- these two far too likely. (By rights 'LDep' ought to have two type variables.)
 data LDep qpn = LDep (DependencyReason qpn) (Dep qpn)
+  deriving (Eq, Generic)
+
+instance Structured qpn => Structured (LDep qpn)
+instance Binary qpn => Binary (LDep qpn)
 
 -- | A dependency (constraint) associates a package name with a constrained
 -- instance. It can also represent other types of dependencies, such as
@@ -122,26 +133,38 @@ data Dep qpn = Dep (PkgComponent qpn) CI  -- ^ dependency on a package component
              | Ext Extension              -- ^ dependency on a language extension
              | Lang Language              -- ^ dependency on a language version
              | Pkg PkgconfigName PkgconfigVersionRange  -- ^ dependency on a pkg-config package
-  deriving Functor
+  deriving (Functor, Eq, Generic)
+
+instance Structured qpn => Structured (Dep qpn)
+instance Binary qpn => Binary (Dep qpn)
 
 -- | An exposed component within a package. This type is used to represent
 -- build-depends and build-tool-depends dependencies.
 data PkgComponent qpn = PkgComponent qpn ExposedComponent
-  deriving (Eq, Ord, Functor, Show)
+  deriving (Eq, Ord, Functor, Show, Generic)
+
+instance Structured qpn => Structured (PkgComponent qpn)
+instance Binary qpn => Binary (PkgComponent qpn)
 
 -- | A component that can be depended upon by another package, i.e., a library
 -- or an executable.
 data ExposedComponent =
     ExposedLib LibraryName
   | ExposedExe UnqualComponentName
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured ExposedComponent
+instance Binary ExposedComponent
 
 -- | The reason that a dependency is active. It identifies the package and any
 -- flag and stanza choices that introduced the dependency. It contains
 -- everything needed for creating ConflictSets or describing conflicts in solver
 -- log messages.
 data DependencyReason qpn = DependencyReason qpn (Map Flag FlagValue) (S.Set Stanza)
-  deriving (Functor, Eq, Show)
+  deriving (Functor, Eq, Show, Generic)
+
+instance Structured qpn => Structured (DependencyReason qpn)
+instance Binary qpn => Binary (DependencyReason qpn)
 
 -- | Print the reason that a dependency was introduced.
 showDependencyReason :: DependencyReason QPN -> String

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Flag.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Flag.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Distribution.Solver.Modular.Flag
     ( FInfo(..)
     , Flag
@@ -20,16 +22,22 @@ module Distribution.Solver.Modular.Flag
 
 import Data.Map as M
 import Prelude hiding (pi)
+import GHC.Generics
 
 import qualified Distribution.PackageDescription as P -- from Cabal
 
 import Distribution.Solver.Types.Flag
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackagePath
+import Distribution.Utils.Structured (Structured (..))
+import Distribution.Compat.Binary (Binary)
 
 -- | Flag name. Consists of a package instance and the flag identifier itself.
 data FN qpn = FN qpn Flag
-  deriving (Eq, Ord, Show, Functor)
+  deriving (Eq, Ord, Show, Functor, Generic)
+
+instance Structured qpn => Structured (FN qpn)
+instance Binary qpn => Binary (FN qpn)
 
 -- | Flag identifier. Just a string.
 type Flag = P.FlagName
@@ -47,7 +55,10 @@ mkFlag = P.mkFlagName
 -- whether the flag is weak. Manual flags can only be set explicitly.
 -- Weak flags are typically deferred by the solver.
 data FInfo = FInfo { fdefault :: Bool, fmanual :: FlagType, fweak :: WeakOrTrivial }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured FInfo
+instance Binary FInfo
 
 -- | Flag defaults.
 type FlagInfo = Map Flag FInfo
@@ -57,7 +68,10 @@ type QFN = FN QPN
 
 -- | Stanza name. Paired with a package name, much like a flag.
 data SN qpn = SN qpn Stanza
-  deriving (Eq, Ord, Show, Functor)
+  deriving (Eq, Ord, Show, Functor, Generic)
+
+instance Structured qpn => Structured (SN qpn)
+instance Binary qpn => Binary (SN qpn)
 
 -- | Qualified stanza name.
 type QSN = SN QPN
@@ -74,12 +88,18 @@ type QSN = SN QPN
 -- special case of triviality we actually consider is if there are no new
 -- dependencies introduced by the choice.
 newtype WeakOrTrivial = WeakOrTrivial { unWeakOrTrivial :: Bool }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured WeakOrTrivial
+instance Binary WeakOrTrivial
 
 -- | Value shown for a flag in a solver log message. The message can refer to
 -- only the true choice, only the false choice, or both choices.
 data FlagValue = FlagTrue | FlagFalse | FlagBoth
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured FlagValue
+instance Binary FlagValue
 
 showQFNBool :: QFN -> Bool -> String
 showQFNBool qfn@(FN qpn _f) b = showQPN qpn ++ ":" ++ showFBool qfn b

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Index.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Index.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Distribution.Solver.Modular.Index
     ( Index
     , PInfo(..)
@@ -13,11 +15,14 @@ import Prelude hiding (pi)
 import Data.Map (Map)
 import qualified Data.List as L
 import qualified Data.Map as M
+import GHC.Generics
 
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
 import Distribution.Solver.Modular.Package
 import Distribution.Solver.Modular.Tree
+import Distribution.Utils.Structured (Structured (..))
+import Distribution.Compat.Binary (Binary)
 
 -- | An index contains information about package instances. This is a nested
 -- dictionary. Package names are mapped to instances, which in turn is mapped
@@ -36,21 +41,34 @@ data PInfo = PInfo (FlaggedDeps PN)
                    (Map ExposedComponent ComponentInfo)
                    FlagInfo
                    (Maybe FailReason)
+  deriving (Eq, Generic)
+
+instance Structured PInfo
+instance Binary PInfo
 
 -- | Info associated with each library and executable in a package instance.
 data ComponentInfo = ComponentInfo {
     compIsVisible   :: IsVisible
   , compIsBuildable :: IsBuildable
   }
-  deriving Show
+  deriving (Show, Eq, Generic)
+
+instance Structured ComponentInfo
+instance Binary ComponentInfo
 
 -- | Whether a component is visible in the current environment.
 newtype IsVisible = IsVisible Bool
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured IsVisible
+instance Binary IsVisible
 
 -- | Whether a component is made unbuildable by a "buildable: False" field.
 newtype IsBuildable = IsBuildable Bool
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured IsBuildable
+instance Binary IsBuildable
 
 mkIndex :: [(PN, I, PInfo)] -> Index
 mkIndex xs = M.map M.fromList (groupMap (L.map (\ (pn, i, pi) -> (pn, (i, pi))) xs))

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -1,5 +1,6 @@
 module Distribution.Solver.Modular.IndexConversion
     ( convPIs
+    , convSP
     ) where
 
 import Distribution.Solver.Compat.Prelude

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Package.hs
@@ -49,11 +49,17 @@ type PId = UnitId
 --
 -- TODO: More information is needed about the repo.
 data Loc = Inst PId | InRepo
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured Loc
+instance Binary Loc
 
 -- | Instance. A version number and a location.
 data I = I Ver Loc
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured I
+instance Binary I
 
 -- | String representation of an instance.
 showI :: I -> String

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
@@ -21,7 +21,9 @@ import Control.Monad hiding (mapM, sequence)
 import Data.Foldable
 import Data.Traversable
 import Prelude hiding (foldr, mapM, sequence)
+import GHC.Generics
 
+import Distribution.Compat.Binary (Binary)
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
 import Distribution.Solver.Modular.Package
@@ -34,6 +36,7 @@ import Distribution.Solver.Types.Flag
 import Distribution.Solver.Types.PackagePath
 import Distribution.Types.PkgconfigVersionRange
 import Distribution.Types.UnitId (UnitId)
+import Distribution.Utils.Structured (Structured (..))
 import Language.Haskell.Extension (Extension, Language)
 
 type Weight = Double
@@ -129,11 +132,17 @@ data FailReason = UnsupportedExtension Extension
                 | DependenciesNotLinked String
                 | CyclicDependencies
                 | UnsupportedSpecVer Ver
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured FailReason
+instance Binary FailReason
 
 -- | Information about a dependency involved in a conflict, for error messages.
 data ConflictingDep = ConflictingDep (DependencyReason QPN) (PkgComponent QPN) CI
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured ConflictingDep
+instance Binary ConflictingDep
 
 -- | Functor for the tree type. 'a' is the type of nodes' children. 'd' and 'c'
 -- have the same meaning as in 'Tree'.

--- a/cabal-install-solver/src/Distribution/Solver/Types/Flag.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Flag.hs
@@ -3,6 +3,13 @@ module Distribution.Solver.Types.Flag
     ) where
 
 import Prelude (Eq, Show)
+import GHC.Generics
+
+import Distribution.Utils.Structured (Structured (..))
+import Distribution.Compat.Binary (Binary)
 
 data FlagType = Manual | Automatic
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Structured FlagType
+instance Binary FlagType

--- a/cabal-install-solver/src/Distribution/Solver/Types/PackagePath.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PackagePath.hs
@@ -18,7 +18,10 @@ import qualified Text.PrettyPrint as Disp
 -- | A package path consists of a namespace and a package path inside that
 -- namespace.
 data PackagePath = PackagePath Namespace Qualifier
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured PackagePath
+instance Binary PackagePath
 
 -- | Top-level namespace
 --
@@ -30,7 +33,10 @@ data Namespace =
 
     -- | A namespace for a specific build target
   | Independent PackageName
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured Namespace
+instance Binary Namespace
 
 -- | Pretty-prints a namespace. The result is either empty or
 -- ends in a period, so it can be prepended onto a qualifier.
@@ -68,7 +74,10 @@ data Qualifier =
     -- tracked only @pn2@, that would require us to pick only one
     -- version of an executable over the entire install plan.)
   | QualExe PackageName PackageName
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured Qualifier
+instance Binary Qualifier
 
 -- | Pretty-prints a qualifier. The result is either empty or
 -- ends in a period, so it can be prepended onto a package name.
@@ -87,7 +96,10 @@ dispQualifier (QualBase pn)  = pretty pn <<>> Disp.text "."
 
 -- | A qualified entity. Pairs a package path with the entity.
 data Qualified a = Q PackagePath a
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance Structured a => Structured (Qualified a)
+instance Binary a => Binary (Qualified a)
 
 -- | Qualified package name.
 type QPN = Qualified PackageName

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -136,7 +136,7 @@ import Distribution.Client.RebuildMonad
 import Distribution.Client.Setup hiding (cabalVersion, packageName)
 import Distribution.Client.SetupWrapper
 import Distribution.Client.Store
-import Distribution.Client.Targets (userToPackageConstraint)
+import Distribution.Client.Targets (userToPackageConstraint, UserConstraint)
 import Distribution.Client.Types
 import Distribution.Client.Utils (concatMapM, duplicatesBy, incVersion)
 
@@ -156,10 +156,13 @@ import Distribution.Utils.Path hiding
 
 import qualified Hackage.Security.Client as Sec
 
+import Distribution.Solver.Modular.Index
+import Distribution.Solver.Modular.IndexConversion
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.InstSolverPackage
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.OptionalStanza
+import Distribution.Solver.Types.PackageConstraint
 import Distribution.Solver.Types.PkgConfigDb
 import Distribution.Solver.Types.Settings
 import Distribution.Solver.Types.SolverId
@@ -836,7 +839,7 @@ rebuildInstallPlan
             verbosity
             fileMonitorSolverPlan
             ( solverSettings
-            , localPackages
+            , pinfos
             , localPackagesEnabledStanzas
             , compiler
             , platform
@@ -883,6 +886,30 @@ rebuildInstallPlan
                     dieWithException verbosity $ PhaseRunSolverErr msg
                   Right plan -> return (plan, pkgConfigDB, tis, ar)
           where
+            sourcePackages :: [SourcePackage UnresolvedPkgLoc]
+            sourcePackages = [ pkg | SpecificSourcePackage pkg <- localPackages ]
+
+            Platform arch os = platform
+
+            pair lpc =
+                  let PackageConstraint scope _ = unlabelPackageConstraint lpc
+                  in (scopeToPackageName scope, [lpc])
+
+            pinfos :: [PInfo]
+            pinfos = [ pinfo
+                     | (_, _, pinfo) <-
+                          map
+                            (convSP os arch
+                              (compilerInfo compiler)
+                              (Map.fromListWith (++) $ map (pair . settingConstraintToLPC) $ solverSettingConstraints solverSettings)
+                              (solverSettingStrongFlags solverSettings)
+                              (SolveExecutables True)
+                            )
+                            sourcePackages
+                     ]
+                     
+              -- TODO: project localPackages down to PInfo
+
             corePackageDbs :: PackageDBStackCWD
             corePackageDbs =
               Cabal.interpretPackageDbFlags False (projectConfigPackageDBs projectConfigShared)
@@ -1423,9 +1450,7 @@ planPackages
             ]
           . addConstraints
             -- version constraints from the config file or command line
-            [ LabeledPackageConstraint (userToPackageConstraint pc) src
-            | (pc, src) <- solverSettingConstraints
-            ]
+            (map settingConstraintToLPC solverSettingConstraints)
           . addPreferences
             -- enable stanza preference unilaterally, regardless if the user asked
             -- accordingly or expressed no preference, to help hint the solver
@@ -1562,6 +1587,10 @@ planPackages
       --
       setupMaxCabalVersionConstraint =
         alterVersion (take 2) $ incVersion 1 $ incVersion 1 cabalVersion
+
+settingConstraintToLPC :: (UserConstraint, ConstraintSource) -> LabeledPackageConstraint
+settingConstraintToLPC (pc, src) =
+  LabeledPackageConstraint (userToPackageConstraint pc) src
 
 ------------------------------------------------------------------------------
 

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -136,7 +136,7 @@ import Distribution.Client.RebuildMonad
 import Distribution.Client.Setup hiding (cabalVersion, packageName)
 import Distribution.Client.SetupWrapper
 import Distribution.Client.Store
-import Distribution.Client.Targets (userToPackageConstraint, UserConstraint)
+import Distribution.Client.Targets (UserConstraint, userToPackageConstraint)
 import Distribution.Client.Types
 import Distribution.Client.Utils (concatMapM, duplicatesBy, incVersion)
 
@@ -887,28 +887,29 @@ rebuildInstallPlan
                   Right plan -> return (plan, pkgConfigDB, tis, ar)
           where
             sourcePackages :: [SourcePackage UnresolvedPkgLoc]
-            sourcePackages = [ pkg | SpecificSourcePackage pkg <- localPackages ]
+            sourcePackages = [pkg | SpecificSourcePackage pkg <- localPackages]
 
             Platform arch os = platform
 
             pair lpc =
-                  let PackageConstraint scope _ = unlabelPackageConstraint lpc
-                  in (scopeToPackageName scope, [lpc])
+              let PackageConstraint scope _ = unlabelPackageConstraint lpc
+               in (scopeToPackageName scope, [lpc])
 
             pinfos :: [PInfo]
-            pinfos = [ pinfo
-                     | (_, _, pinfo) <-
-                          map
-                            (convSP os arch
-                              (compilerInfo compiler)
-                              (Map.fromListWith (++) $ map (pair . settingConstraintToLPC) $ solverSettingConstraints solverSettings)
-                              (solverSettingStrongFlags solverSettings)
-                              (SolveExecutables True)
-                            )
-                            sourcePackages
-                     ]
-                     
-              -- TODO: project localPackages down to PInfo
+            pinfos =
+              [ pinfo
+              | (_, _, pinfo) <-
+                  map
+                    ( convSP
+                        os
+                        arch
+                        (compilerInfo compiler)
+                        (Map.fromListWith (++) $ map (pair . settingConstraintToLPC) $ solverSettingConstraints solverSettings)
+                        (solverSettingStrongFlags solverSettings)
+                        (SolveExecutables True)
+                    )
+                    sourcePackages
+              ]
 
             corePackageDbs :: PackageDBStackCWD
             corePackageDbs =

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -637,10 +637,10 @@ instance ArbitraryOrd ShortText where
     pure $ \l r -> strc (fromShortText l) (fromShortText r)
 
 deriving instance Generic (Variable pn)
-deriving instance Generic (P.Qualified a)
-deriving instance Generic P.PackagePath
-deriving instance Generic P.Namespace
-deriving instance Generic P.Qualifier
+-- deriving instance Generic (P.Qualified a)
+-- deriving instance Generic P.PackagePath
+-- deriving instance Generic P.Namespace
+-- deriving instance Generic P.Qualifier
 
 randomSubset :: Int -> [a] -> Gen [a]
 randomSubset n xs = take n <$> shuffle xs

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -637,10 +637,6 @@ instance ArbitraryOrd ShortText where
     pure $ \l r -> strc (fromShortText l) (fromShortText r)
 
 deriving instance Generic (Variable pn)
--- deriving instance Generic (P.Qualified a)
--- deriving instance Generic P.PackagePath
--- deriving instance Generic P.Namespace
--- deriving instance Generic P.Qualifier
 
 randomSubset :: Int -> [a] -> Gen [a]
 randomSubset n xs = take n <$> shuffle xs

--- a/cabal-testsuite/PackageTests/ReplDashB/cabal.out
+++ b/cabal-testsuite/PackageTests/ReplDashB/cabal.out
@@ -1,6 +1,5 @@
 # cabal clean
 # cabal v2-repl
-Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - fake-package-0 (interactive) (lib) (first run)


### PR DESCRIPTION
Previously, the solver would be re-run whenever anything about the package description changed. This changes that so that only the relevant bits (roughly: the information found in `PInfo`) is taken into account, ignoring other changes to the package description.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)