### PR TITLE
Typo, not build but install command

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 
--- | cabal-install CLI command: build
+-- | cabal-install CLI command: install
 module Distribution.Client.CmdInstall
-  ( -- * The @build@ CLI and action
+  ( -- * The @install@ CLI and action
     installCommand
   , installAction
 


### PR DESCRIPTION
Minor typo in haddocks of module. This is the install command, not the build command.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
