### PR TITLE
act-as-setup BUILD-TYPE, warning and error

### DIFF
--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -232,6 +232,7 @@ import Distribution.Simple.Utils
   , createDirectoryIfMissingVerbose
   , die'
   , dieNoVerbosity
+  , dieNoWrap
   , dieWithException
   , findPackageDesc
   , info
@@ -1572,9 +1573,14 @@ actAsSetupAction actAsSetupFlags args _globalFlags =
             Simple.autoconfSetupHooks
             defaultVerbosityHandles
             args
-        Make -> error "actAsSetupAction Main"
-        Hooks -> error "actAsSetupAction Hooks"
-        Custom -> error "actAsSetupAction Custom"
+        Make -> unsupportedBuildType
+        Hooks -> unsupportedBuildType
+        Custom -> unsupportedBuildType
+  where
+    verbosity = mkVerbosity defaultVerbosityHandles normal
+    unsupportedBuildType = do
+      warn verbosity "act-as-setup accepts --build-type=Simple|Configure, case-sensitively."
+      dieNoWrap verbosity "act-as-setup doesn't accept --build-type=Make|Hooks|Custom."
 
 manpageAction :: [CommandSpec action] -> ManpageFlags -> [String] -> Action
 manpageAction commands flags extraArgs _ = do

--- a/changelog.d/12240.md
+++ b/changelog.d/12240.md
@@ -1,0 +1,15 @@
+---
+synopsis: Warning and error for act-as-setup --build-type
+packages: [cabal-install]
+prs: 12240
+issues: 11456
+---
+
+The `act-as-setup` command accepts `Simple` and `Configure` build types. If
+other build types are supplied anyway, it gives a warning and then an error
+mentioning acceptable and unacceptable build types.
+
+```pre
++ Warning: act-as-setup accepts --build-type=Simple|Configure, case-sensitively.
++ Error: act-as-setup doesn't accept --build-type=Make|Hooks|Custom.
+```


### PR DESCRIPTION
Changes the behaviour for #11456 but doesn't add to the user's guide. The `act-as-setup` command accepts `Simple` and `Configure` build types. If other build types are supplied anyway, it gives a warning and then an error mentioning acceptable and unacceptable build types.

 
 ```diff
- $ cabal-3.18.1.0 act-as-setup --build-type=Custom configure
+ $ cabal act-as-setup --build-type=Custom configure
- actAsSetupAction Custom
- CallStack (from HasCallStack):
-   error, called at src/Distribution/Client/Main.hs:1579:19 in
-   cabal-install-3.18.1.0-inplace:Distribution.Client.Main
+ Warning: act-as-setup accepts --build-type=Simple|Configure, case-sensitively.
+ Error: act-as-setup doesn't accept --build-type=Make|Hooks|Custom.
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

