### PR TITLE
Typo componentif

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -246,7 +246,7 @@ replCommand =
           ++ pname
           ++ " v2-repl --build-depends lens\n"
           ++ "    add the latest version of the library 'lens' to the default component "
-          ++ "(or no componentif there is no project present)\n"
+          ++ "(or no component if there is no project present)\n"
           ++ "  "
           ++ pname
           ++ " v2-repl --build-depends \"lens >= 4.15 && < 4.18\"\n"


### PR DESCRIPTION
Typo in repl command examples, "componentif".

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
