### PR TITLE
Update boostraps on master as per B.2.0 of Release plan

### DIFF
--- a/bootstrap/linux-9.10.3.json
+++ b/bootstrap/linux-9.10.3.json
@@ -116,7 +116,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "b74eed77eb3237c4ab6a39f08bcce4712b4486b091712ee20e92c8864f1e80a0",
@@ -140,7 +140,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -150,7 +150,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "39b25fd929b02b01a3fe59fec7ca8b2da6f0f9e282276b7a84e63a4702c4d725",
@@ -324,7 +324,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -445,7 +445,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "0dc8dc33b9bba0e025e444355f6c2d806f62a4656446961c3647165f80f0d278",
@@ -525,7 +525,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -539,7 +539,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.12.4.json
+++ b/bootstrap/linux-9.12.4.json
@@ -120,7 +120,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "b74eed77eb3237c4ab6a39f08bcce4712b4486b091712ee20e92c8864f1e80a0",
@@ -144,7 +144,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -154,7 +154,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "39b25fd929b02b01a3fe59fec7ca8b2da6f0f9e282276b7a84e63a4702c4d725",
@@ -328,7 +328,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -436,7 +436,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "0dc8dc33b9bba0e025e444355f6c2d806f62a4656446961c3647165f80f0d278",
@@ -516,7 +516,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -530,7 +530,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.6.7.json
+++ b/bootstrap/linux-9.6.7.json
@@ -108,7 +108,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "b74eed77eb3237c4ab6a39f08bcce4712b4486b091712ee20e92c8864f1e80a0",
@@ -132,7 +132,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -142,7 +142,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "39b25fd929b02b01a3fe59fec7ca8b2da6f0f9e282276b7a84e63a4702c4d725",
@@ -326,7 +326,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -447,7 +447,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "0dc8dc33b9bba0e025e444355f6c2d806f62a4656446961c3647165f80f0d278",
@@ -527,7 +527,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -541,7 +541,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         }
     ]
 }

--- a/bootstrap/linux-9.8.4.json
+++ b/bootstrap/linux-9.8.4.json
@@ -108,7 +108,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "b74eed77eb3237c4ab6a39f08bcce4712b4486b091712ee20e92c8864f1e80a0",
@@ -132,7 +132,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -142,7 +142,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "39b25fd929b02b01a3fe59fec7ca8b2da6f0f9e282276b7a84e63a4702c4d725",
@@ -326,7 +326,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": "0e9de2ccce261e7a5b027e842f6f47f50eb0e6059a0de98a5479f75aa8164107",
@@ -447,7 +447,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.19"
         },
         {
             "cabal_sha256": "0dc8dc33b9bba0e025e444355f6c2d806f62a4656446961c3647165f80f0d278",
@@ -527,7 +527,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         },
         {
             "cabal_sha256": null,
@@ -541,7 +541,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.18.1.0"
+            "version": "3.19.0.0"
         }
     ]
 }


### PR DESCRIPTION
Fixes #12233. To be frank, I'm not sure how the resulting dep bumps help people using or abusing the boostrap files (the intended purpose of the files is porting to new architectures, but some distros apparently build from that, too), but if this is not welcome, let's hope they tell us. In principle, this should work as in previous releases and nobody complained then.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
