### PR TITLE
fix(cabal-install): Fix duplicated program-default-options from the config file

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1899,7 +1899,7 @@ withProgramsFields =
 withProgramOptionsFields :: [FieldDescr [(String, [String])]]
 withProgramOptionsFields =
   map viewAsFieldDescr $
-    programDbOptions defaultProgramDb ParseArgs id (++)
+    programDbOptions defaultProgramDb ParseArgs id (\newArgs _ -> newArgs)
 
 parseExtraLines :: Verbosity -> [String] -> IO SavedConfig
 parseExtraLines verbosity extraLines =

--- a/cabal-testsuite/PackageTests/ProgramDefaultOptions/Main.hs
+++ b/cabal-testsuite/PackageTests/ProgramDefaultOptions/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "hello"

--- a/cabal-testsuite/PackageTests/ProgramDefaultOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProgramDefaultOptions/cabal.test.hs
@@ -1,0 +1,18 @@
+import Test.Cabal.Prelude
+
+import System.IO (appendFile)
+
+main :: IO ()
+main =
+  cabalTest $ do
+    env <- getTestEnv
+    let conf = testUserCabalConfigFile env
+    liftIO $
+      appendFile conf $
+        unlines
+          [ "program-default-options"
+          , "  ghc-options: -fno-full-laziness"
+          , "  ar-options: -baz"
+          ]
+    res <- recordMode DoNotRecord $ cabal' "v2-build" []
+    assertOutputDoesNotContain "-fno-full-laziness -fno-full-laziness" res

--- a/cabal-testsuite/PackageTests/ProgramDefaultOptions/p.cabal
+++ b/cabal-testsuite/PackageTests/ProgramDefaultOptions/p.cabal
@@ -1,0 +1,9 @@
+cabal-version: 2.0
+name: p
+version: 0.1.0.0
+build-type: Simple
+
+executable p
+  main-is: Main.hs
+  build-depends: base
+  default-language: Haskell2010

--- a/changelog.d/12258.md
+++ b/changelog.d/12258.md
@@ -1,0 +1,19 @@
+---
+synopsis: Fix duplicated program-default-options from the config file
+packages: [cabal-install]
+prs: 12258
+issues: 10788
+---
+
+The `program-default-options` section of the user config file duplicated the
+options of every program except the last. E.g.
+
+```
+program-default-options
+  gcc-options: -Wno-pragma-pack
+  ar-options: -baz
+```
+
+resulted in `-Wno-pragma-pack` being passed to the C compiler twice, because
+each parsed field appended the list of options accumulated so far to itself.
+The section now combines the options without duplicating them.


### PR DESCRIPTION
fix: #10788

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)