### PR TITLE
Master is broken

### DIFF
--- a/doc/cmd-v2-help/repl.txt
+++ b/doc/cmd-v2-help/repl.txt
@@ -401,7 +401,7 @@ Examples, open an interactive session:
     for the component 'cname' in the package 'pkgname'
 
   cabal repl --build-depends lens
-    add the latest version of the library 'lens' to the default component (or no componentif there is no project present)
+    add the latest version of the library 'lens' to the default component (or no component if there is no project present)
   cabal repl --build-depends "lens >= 4.15 && < 4.18"
     add a version (constrained between 4.15 and 4.18) of the library 'lens' to the default component (or no component if there is no project present)
   cabal repl pkg:cabal-install-solver pkg:Cabal-syntax --enable-multi-repl


### PR DESCRIPTION
CI is down on:

```
 M doc/cmd-v2-help/repl.txt
 doc/cmd-v2-help/repl.txt | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
diff --git a/doc/cmd-v2-help/repl.txt b/doc/cmd-v2-help/repl.txt
index 5a27cf1..2913c65 100644
--- a/doc/cmd-v2-help/repl.txt
+++ b/doc/cmd-v2-help/repl.txt
@@ -401,7 +401,7 @@ Examples, open an interactive session:
     for the component 'cname' in the package 'pkgname'
 
   cabal repl --build-depends lens
-    add the latest version of the library 'lens' to the default component (or no componentif there is no project present)
+    add the latest version of the library 'lens' to the default component (or no component if there is no project present)
   cabal repl --build-depends "lens >= 4.15 && < 4.18"
     add a version (constrained between 4.15 and 4.18) of the library 'lens' to the default component (or no component if there is no project present)
   cabal repl pkg:cabal-install-solver pkg:Cabal-syntax --enable-multi-repl
Error: Process completed with exit code 1.
```