### PR TITLE
Mark CabalSpecV3_18 as latest on the 3.18 branch

### DIFF
--- a/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
+++ b/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
@@ -72,7 +72,7 @@ showCabalSpecVersion CabalSpecV1_2 = "1.2"
 showCabalSpecVersion CabalSpecV1_0 = "1.0"
 
 cabalSpecLatest :: CabalSpecVersion
-cabalSpecLatest = CabalSpecV3_16
+cabalSpecLatest = CabalSpecV3_18
 
 -- | Parse 'CabalSpecVersion' from version digits.
 --

--- a/changelog.d/12273.md
+++ b/changelog.d/12273.md
@@ -1,0 +1,16 @@
+---
+synopsis: Mark CabalSpecV3_18 as the latest supported specification
+packages: [Cabal-syntax, cabal-install]
+prs: 12273
+issues: 12271
+significance: significant
+---
+
+`cabalSpecLatest` remained `CabalSpecV3_16` after `CabalSpecV3_18` was
+introduced. As a result, `cabal-install` treated a `build-type: Simple` package
+that declared `cabal-version: 3.18` as a future-format package. It then tried to
+compile an external `Setup.hs` without a Cabal setup dependency, which caused
+the build to fail.
+
+`cabalSpecLatest` now points at `CabalSpecV3_18`. Affected packages use the
+in-process setup path again.


### PR DESCRIPTION
## Summary

- mark `CabalSpecV3_18` as the latest supported specification on the 3.18 branch
- keep `cabal-version: 3.18` `Simple` packages on the in-process setup path

## Background

Cabal-syntax 3.18 recognizes `CabalSpecV3_18`, but `cabalSpecLatest` remained
`CabalSpecV3_16`. cabal-install therefore classified `Simple` packages that
declare `cabal-version: 3.18` as future-format packages and selected an external
setup script.

Addresses #12271.

## Testing

- `cabal build Cabal-syntax`
- evaluated `cabalSpecLatest` in the Cabal-syntax REPL and obtained
  `CabalSpecV3_18`
