### PR TITLE
Don't depend on zlib.dll on windows.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,3 +15,7 @@ package Cabal
 
 package semaphore-compat
   flags: -build-testing
+
+if os(windows)
+  package zlib
+    flags: -pkg-config +bundled-c-zlib


### PR DESCRIPTION
zlib.DLL might not be available, for example if we build in a msys env, but run under powershell. Fixes #12272

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
