### PR TITLE
Mark CabalSpecV3_20 as latest

### DIFF
--- a/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
+++ b/Cabal-syntax/src/Distribution/CabalSpecVersion.hs
@@ -71,7 +71,7 @@ showCabalSpecVersion CabalSpecV1_2 = "1.2"
 showCabalSpecVersion CabalSpecV1_0 = "1.0"
 
 cabalSpecLatest :: CabalSpecVersion
-cabalSpecLatest = CabalSpecV3_16
+cabalSpecLatest = CabalSpecV3_20
 
 -- | Parse 'CabalSpecVersion' from version digits.
 --

--- a/Cabal-syntax/src/Distribution/SPDX/LicenseListVersion.hs
+++ b/Cabal-syntax/src/Distribution/SPDX/LicenseListVersion.hs
@@ -30,6 +30,7 @@ data LicenseListVersion
   deriving (Eq, Ord, Show, Enum, Bounded)
 
 cabalSpecVersionToSPDXListVersion :: CabalSpecVersion -> LicenseListVersion
+cabalSpecVersionToSPDXListVersion CabalSpecV3_20 = LicenseListVersion_3_28
 cabalSpecVersionToSPDXListVersion CabalSpecV3_18 = LicenseListVersion_3_28
 cabalSpecVersionToSPDXListVersion CabalSpecV3_16 = LicenseListVersion_3_26
 cabalSpecVersionToSPDXListVersion CabalSpecV3_14 = LicenseListVersion_3_25

--- a/changelog.d/cabal-spec-latest-3-20.md
+++ b/changelog.d/cabal-spec-latest-3-20.md
@@ -1,0 +1,34 @@
+---
+synopsis: Make 3.20 the latest known .cabal specification version
+packages: [Cabal-syntax, cabal-install]
+prs: 12275
+issues: 12271
+significance: significant
+---
+
+`cabalSpecLatest` was left at `CabalSpecV3_16` when `CabalSpecV3_18` and
+`CabalSpecV3_20` were introduced, so the newest specification version the
+library knew about lagged two releases behind the tree. It now points at
+`CabalSpecV3_20`, the version under development.
+
+`cabal-install` treated a `build-type: Simple` package whose `cabal-version`
+exceeded `cabalSpecLatest` as a future-format package. It then tried to compile
+an external `Setup.hs` without a Cabal setup dependency. Consequently, packages
+that declared the released `cabal-version: 3.18` could fail to build. Affected
+packages now use the in-process setup path.
+
+Two further changes come with the bump:
+
+- `cabalSpecVersionToSPDXListVersion` gained an explicit `CabalSpecV3_20` case,
+  so standalone `Distribution.SPDX` parsing (and Cabal-QuickCheck's generators)
+  now default to SPDX license list 3.28 rather than 3.26, matching released
+  Cabal 3.18. Without the new case the bump would have fallen through to the
+  catch-all and silently downgraded that default to 3.0 instead.
+
+- `cabal.project` files are parsed at `cabalSpecLatest`, so the
+  `deprecatedSince CabalSpecV3_20` marker on `prefer-oldest` becomes reachable
+  for the first time: using that field now warns and points at `prefer-version`.
+
+This does not change which `cabal-version` values a `.cabal` file may declare —
+the parser accepts any version known to `cabalSpecFromVersionDigits`
+independently of `cabalSpecLatest`.


### PR DESCRIPTION
## Summary

- mark `CabalSpecV3_20` as the latest supported specification on master
- map `CabalSpecV3_20` to SPDX license list 3.28
- document the user-visible setup-policy fix

## Background

Master recognizes both `CabalSpecV3_18` and `CabalSpecV3_20`, but
`cabalSpecLatest` remained `CabalSpecV3_16`. cabal-install therefore classified
`Simple` packages that declare `cabal-version: 3.18` as future-format packages
and selected the broken external setup path described in #12271.

The explicit SPDX mapping is required with this change. Without it,
`cabalSpecVersionToSPDXListVersion CabalSpecV3_20` falls through to SPDX license
list 3.0.

Fixes #12271.

## Testing

- `cabal build Cabal-syntax`
- CabalSpecVersion unit tests: 2 passed
- evaluated `(cabalSpecLatest, cabalSpecVersionToSPDXListVersion cabalSpecLatest)`
  in the Cabal-syntax REPL and obtained
  `(CabalSpecV3_20, LicenseListVersion_3_28)`
