### PR TITLE
fix(cabal-install): Fix spurious "Unknown field: configure-options" warning

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
@@ -235,12 +235,12 @@ parseSection programDb (MkSection (Name pos name) args secFields)
   | name == "program-options" = do
       verifyNullSubsections
       verifyNullSectionArgs
-      opts' <- lift $ parseProgramArgs programDb fields
+      opts' <- lift $ parseProgramArgs programDb True fields
       stateConfig . L.projectConfigLocalPackages . L.packageConfigProgramArgs %= (opts' <>)
   | name == "program-locations" = do
       verifyNullSubsections
       verifyNullSectionArgs
-      paths' <- lift $ parseProgramPaths programDb fields
+      paths' <- lift $ parseProgramPaths programDb True fields
       stateConfig . L.projectConfigLocalPackages . L.packageConfigProgramPaths %= (paths' <>)
   | name == "repository" = do
       verifyNullSubsections
@@ -276,8 +276,8 @@ parseSection programDb (MkSection (Name pos name) args secFields)
     verifyNullSectionArgs = unless (null args) (lift $ parseFailure pos $ "The section '" <> show name <> "' takes no arguments")
     parsePackageConfig = do
       packageCfg <- lift $ parseFieldGrammar cabalSpec fields (packageConfigFieldGrammar programNames)
-      args' <- lift $ parseProgramArgs programDb fields
-      paths <- lift $ parseProgramPaths programDb fields
+      args' <- lift $ parseProgramArgs programDb False fields
+      paths <- lift $ parseProgramPaths programDb False fields
       return packageCfg{packageConfigProgramPaths = paths, packageConfigProgramArgs = args'}
 
 stanzas :: Set BS.ByteString
@@ -343,24 +343,28 @@ parsePackageName pos args = case args of
       P.choice [P.try (P.char '*' >> return AllPackages), SpecificPackage <$> parsec]
 
 -- | Parse fields of a program-options stanza.
-parseProgramArgs :: ProgramDb -> Fields Position -> ParseResult src (MapMappend String [String])
-parseProgramArgs programDb fields = foldM parseField mempty (filter hasOptionsSuffix $ Map.toList fields)
+parseProgramArgs :: ProgramDb -> Bool -> Fields Position -> ParseResult src (MapMappend String [String])
+parseProgramArgs programDb warnUnknown fields = foldM parseField mempty (filter hasOptionsSuffix $ Map.toList fields)
   where
     parseField programArgs (fieldName, fieldLines) = do
       case readProgramName "-options" programDb fieldName of
-        Nothing -> warnUnknownFields fieldName fieldLines >> return programArgs
+        Nothing -> do
+          when warnUnknown $ warnUnknownFields fieldName fieldLines
+          return programArgs
         Just program -> do
           args <- parseProgramArgsField $ reverse fieldLines
           return $ programArgs <> MapMappend (Map.singleton program args)
     hasOptionsSuffix (fieldName, _) = BS.isSuffixOf "-options" fieldName
 
 -- | Parse fields of a program-locations stanza.
-parseProgramPaths :: ProgramDb -> Fields Position -> ParseResult src (MapLast String FilePath)
-parseProgramPaths programDb fields = foldM parseField mempty (filter hasLocationSuffix $ Map.toList fields)
+parseProgramPaths :: ProgramDb -> Bool -> Fields Position -> ParseResult src (MapLast String FilePath)
+parseProgramPaths programDb warnUnknown fields = foldM parseField mempty (filter hasLocationSuffix $ Map.toList fields)
   where
     parseField paths (fieldName, fieldLines) = do
       case readProgramName "-location" programDb fieldName of
-        Nothing -> warnUnknownFields fieldName fieldLines >> return paths
+        Nothing -> do
+          when warnUnknown $ warnUnknownFields fieldName fieldLines
+          return paths
         Just program -> do
           case fieldLines of
             (MkNamelessField pos lines') : _ -> do

--- a/cabal-testsuite/PackageTests/ProjectConfig/ConfigureOptions/cabal.project
+++ b/cabal-testsuite/PackageTests/ProjectConfig/ConfigureOptions/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+package test
+  configure-options: --with-so=/path/to/lib.so

--- a/cabal-testsuite/PackageTests/ProjectConfig/ConfigureOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ProjectConfig/ConfigureOptions/cabal.test.hs
@@ -1,0 +1,7 @@
+import Test.Cabal.Prelude
+
+-- Regression test for #12245: `configure-options` is a valid field in a
+-- `package` stanza, so the parsec project file parser must not warn about it.
+main = cabalTest $ recordMode DoNotRecord $ do
+  result <- cabal' "build" ["--dry-run", "--project-file-parser=parsec"]
+  assertOutputDoesNotContain "Unknown field: \"configure-options\"" result

--- a/cabal-testsuite/PackageTests/ProjectConfig/ConfigureOptions/test.cabal
+++ b/cabal-testsuite/PackageTests/ProjectConfig/ConfigureOptions/test.cabal
@@ -1,0 +1,8 @@
+cabal-version: 3.0
+name: test
+version: 0.1
+license: BSD-3-Clause
+build-type: Simple
+
+library
+  default-language: Haskell2010

--- a/changelog.d/12276.md
+++ b/changelog.d/12276.md
@@ -1,0 +1,20 @@
+---
+synopsis: Fix spurious "Unknown field configure-options" warning
+packages: [cabal-install]
+prs: 12276
+issues: 12245
+---
+
+The parsec project file parser treated every `-options` field in a `package`
+stanza as a program option and warned when the program name was unknown. Since
+`configure`, `test` and `benchmark` are not programs, valid fields like
+`configure-options` got spuriously flagged as unknown. The warning is now only
+emitted in `program-options`/`program-locations` stanzas; inside a `package`
+stanza the field grammar already reports unknown fields.
+
+```diff
+  $ cabal build all --dry-run
+- Warnings found while parsing the project file, cabal.project.local:
+-  - cabal.project.local:2:3: Unknown field: "configure-options"
+  Build profile: -w ghc-9.12.4 -O1
+```


### PR DESCRIPTION
fix: #12245

```diff
  $ cabal build all --dry-run
- Warnings found while parsing the project file, cabal.project.local:
-  - cabal.project.local:2:3: Unknown field: "configure-options"
  Build profile: -w ghc-9.12.4 -O1
```

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)