### PR TITLE
fix(cabal-install): Fix `cabal install <exe>` installing every executable in the package

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -112,6 +112,7 @@ import Distribution.Package
   ( Package (..)
   , PackageName
   , mkPackageName
+  , packageName
   , unPackageName
   )
 import Distribution.Simple.BuildPaths
@@ -775,13 +776,19 @@ getSpecsAndTargetSelectors verbosity reducedVerbosity sourcePkgDb targetSelector
 
       localPkgs = sdistize <$> localPackages baseCtx
 
-      gatherTargets :: UnitId -> TargetSelector
-      gatherTargets targetId = TargetPackageNamed pkgName targetFilter
-        where
-          targetUnit = Map.findWithDefault (error "cannot find target unit") targetId planMap
-          PackageIdentifier{..} = packageId targetUnit
+      localTargets =
+        ordNub
+          [ gatherTarget pkgName ts
+          | (unitId, components) <- Map.toList targetsMap
+          , let pkgName = packageName (planMap Map.! unitId)
+          , (_, selectors) <- components
+          , ts <- NE.toList selectors
+          ]
 
-      localTargets = map gatherTargets (Map.keys targetsMap)
+      gatherTarget pkgName ts = case ts of
+        TargetComponent{} -> ts
+        TargetComponentUnknown{} -> ts
+        _ -> TargetPackageNamed pkgName targetFilter
 
       hackagePkgs :: [PackageSpecifier UnresolvedSourcePackage]
       hackagePkgs = [NamedPackage pn [] | pn <- hackageNames]

--- a/cabal-testsuite/PackageTests/Install/T8614/cabal.project
+++ b/cabal-testsuite/PackageTests/Install/T8614/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/Install/T8614/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Install/T8614/cabal.test.hs
@@ -1,0 +1,21 @@
+import Test.Cabal.Prelude
+
+import System.Directory (doesFileExist)
+import System.FilePath ((<.>), (</>))
+
+-- Test that `cabal install <exe>` installs only the named executable,
+-- not every executable in the package. See #8614.
+main = cabalTest $ do
+  env <- getTestEnv
+  recordMode DoNotRecord $ do
+    let installdir = testPrefixDir env </> "bin"
+        exeExt = if isWindows then "exe" else ""
+
+    cabal "install"
+      ["example1", "--installdir", installdir, "--overwrite-policy=always"]
+
+    example1Installed <- liftIO $ doesFileExist (installdir </> "example1" <.> exeExt)
+    example2Installed <- liftIO $ doesFileExist (installdir </> "example2" <.> exeExt)
+
+    assertBool "example1 should have been installed" example1Installed
+    assertBool "example2 should not have been installed" (not example2Installed)

--- a/cabal-testsuite/PackageTests/Install/T8614/example.cabal
+++ b/cabal-testsuite/PackageTests/Install/T8614/example.cabal
@@ -1,0 +1,12 @@
+name: example
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable example1
+  main-is: example1.hs
+  build-depends: base
+
+executable example2
+  main-is: example2.hs
+  build-depends: base

--- a/cabal-testsuite/PackageTests/Install/T8614/example1.hs
+++ b/cabal-testsuite/PackageTests/Install/T8614/example1.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "example1"

--- a/cabal-testsuite/PackageTests/Install/T8614/example2.hs
+++ b/cabal-testsuite/PackageTests/Install/T8614/example2.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "example2"

--- a/changelog.d/12277.md
+++ b/changelog.d/12277.md
@@ -1,0 +1,29 @@
+---
+synopsis: Fix `cabal install <exe>` installing every executable in the package
+packages: [cabal-install]
+prs: 12277
+issues: 8614
+---
+
+`cabal install` used to collapse a component target into a whole-package target,
+so naming a single executable would build and install *all* of the package's
+executables:
+
+```diff
+  $ cabal install example1 --installdir /tmp/executables
+  Symlinking 'example1' to '/tmp/executables/example1'
+- Symlinking 'example2' to '/tmp/executables/example2'
+```
+
+Now the component selector is preserved and only the requested executable is
+installed:
+
+```diff
+  $ cabal install example1 --installdir /tmp/executables
+  Symlinking 'example1' to '/tmp/executables/example1'
+```
+
+This applies to every way of naming a single executable (`example1`,
+`exe:example1`, `example:exe:example1`). Whole-package targets such as a bare
+package name, `all` or `all:exes` keep their existing behaviour and continue to
+install all of the package's executables.


### PR DESCRIPTION
fix: #8614 and fix: #10943

```diff
  $ cabal install example1 --installdir /tmp/executables
  Symlinking 'example1' to '/tmp/executables/example1'
- Symlinking 'example2' to '/tmp/executables/example2'
```

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
