### PR TITLE
feat(Cabal): Give a better error message when a global option is passed after the command

### DIFF
--- a/Cabal/src/Distribution/Simple/Command.hs
+++ b/Cabal/src/Distribution/Simple/Command.hs
@@ -679,7 +679,9 @@ commandsRunWithFallback globalCommand commands defaultCommand args =
       ("help" : cmdArgs) -> handleHelpCommand flags cmdArgs
       (name : cmdArgs) -> case lookupCommand name of
         [Command _ _ action _] ->
-          pure $ CommandReadyToGo (flags, action cmdArgs)
+          pure $
+            CommandReadyToGo
+              (flags, improveGlobalOptionError cmdArgs (action cmdArgs))
         _ -> do
           final_cmd <- defaultCommand commands' name cmdArgs
           return $ CommandReadyToGo (flags, final_cmd)
@@ -695,6 +697,43 @@ commandsRunWithFallback globalCommand commands defaultCommand args =
 
     commands' = commands ++ [commandAddAction helpCommandUI undefined]
     commandNames = [name | (Command name _ _ NormalCommand) <- commands']
+
+    globalOptions = commandGetOpts ParseArgs globalCommand
+
+    -- If a global option is given after the command name (e.g.
+    -- @cabal get --config-file=foo@), the subcommand parser rejects it as an
+    -- unrecognized option. In that case, produce a more helpful error message
+    -- pointing out that global options have to come before the command.
+    improveGlobalOptionError
+      :: [String]
+      -> CommandParse action
+      -> CommandParse action
+    improveGlobalOptionError cmdArgs parse =
+      case parse of
+        CommandErrors errs ->
+          case misplacedGlobalOptions cmdArgs of
+            [] -> CommandErrors errs
+            [_] -> CommandErrors (errs ++ ["Note: this option is global and must be specified before the command."])
+            _ : _ -> CommandErrors (errs ++ ["Note: these options are global and must be specified before the command."])
+        _ -> parse
+
+    misplacedGlobalOptions :: [String] -> [String]
+    misplacedGlobalOptions = go
+      where
+        go [] = []
+        go ("--" : _) = []
+        go (arg : rest)
+          | isGlobalOption arg = arg : go rest
+          | otherwise = go rest
+
+        isGlobalOption ('-' : '-' : rest) =
+          let (name, _) = break (== '=') rest
+           in name `elem` longNames
+        isGlobalOption ('-' : c : _) = c `elem` shortNames
+        isGlobalOption _ = False
+
+        longNames = [l | GetOpt.Option _ ls _ _ <- globalOptions, l <- ls]
+        shortNames = [s | GetOpt.Option ss _ _ _ <- globalOptions, s <- ss]
 
     -- A bit of a hack: support "prog help" as a synonym of "prog --help"
     -- furthermore, support "prog help command" as "prog command --help"

--- a/cabal-testsuite/PackageTests/ConfigFile/T7704/cabal.out
+++ b/cabal-testsuite/PackageTests/ConfigFile/T7704/cabal.out
@@ -1,0 +1,1 @@
+# cabal get

--- a/cabal-testsuite/PackageTests/ConfigFile/T7704/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ConfigFile/T7704/cabal.test.hs
@@ -1,0 +1,14 @@
+-- 2021-10-06, issue #7704
+--
+-- A global option given after the command (e.g. @cabal get --config-file=foo@)
+-- is rejected by the command parser as an unrecognized option. The error
+-- message should point out that global options have to be given before the
+-- command.
+
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+  res <- fails $ cabalG' [] "get" ["--config-file=foo"]
+  assertOutputContains "unrecognized 'get' option `--config-file=foo'" res
+  assertOutputContains "this option is global" res
+  assertOutputContains "before the command" res

--- a/changelog.d/12280.md
+++ b/changelog.d/12280.md
@@ -1,0 +1,22 @@
+---
+synopsis: Give a better error message when a global option is passed after the command
+packages: [Cabal]
+prs: 12280
+issues: 7704
+---
+
+`cabal` requires global options (such as `--config-file`) to be given before
+the command name. When such an option was given after the command, the parser
+reported it as an option unrecognized by the subcommand, which was misleading
+because the option itself is valid:
+
+```diff
+  $ cabal get --config-file=foo
+- Error: cabal: unrecognized 'get' option `--config-file=foo'
++ Error: cabal: unrecognized 'get' option `--config-file=foo'
++
++ Note: this option is global and must be specified before the command.
+```
+
+The error message now additionally points out that the option is global and
+must be placed before the command name.


### PR DESCRIPTION
fix: #7704

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)