### PR TITLE
fix(Cabal, cabal-install): List global flags in the help text of every command

### DIFF
--- a/Cabal/src/Distribution/Simple/Command.hs
+++ b/Cabal/src/Distribution/Simple/Command.hs
@@ -61,6 +61,7 @@ module Distribution.Simple.Command
     -- * Option Descriptions
   , OptDescr (..)
   , fmapOptDescr
+  , commandOptionsUsageInfo
   , Description
   , SFlags
   , LFlags
@@ -467,6 +468,11 @@ commandHelp command pname =
   where
     cname = commandName command
 
+-- | Render a table of options (given as 'OptionField's) for inclusion in a
+-- help text, in the same format as the options section of 'commandHelp'.
+commandOptionsUsageInfo :: String -> [OptionField flags] -> String
+commandOptionsUsageInfo header = GetOpt.usageInfo header . concatMap viewAsGetOpt
+
 -- | Default "usage" documentation text for commands.
 usageDefault :: String -> String -> String
 usageDefault name pname =
@@ -708,7 +714,7 @@ commandsRunWithFallback globalCommand commands defaultCommand args =
           case lookupCommand name of
             [Command _ _ action _] ->
               case action ("--help" : cmdArgs') of
-                CommandHelp help -> pure $ CommandHelp help
+                CommandHelp help -> pure $ CommandReadyToGo (flags, CommandHelp help)
                 CommandList _ -> pure $ CommandList []
                 _ -> pure $ CommandHelp globalHelp
             _ -> do

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -197,8 +197,10 @@ import Distribution.Simple.Command
   , CommandSpec (..)
   , CommandType (..)
   , CommandUI (..)
+  , ShowOrParseArgs (..)
   , commandAddAction
   , commandFromSpec
+  , commandOptionsUsageInfo
   , commandShowOptions
   , commandsRunWithFallback
   , defaultCommandFallback
@@ -324,6 +326,18 @@ main args = do
 
   mainWorker . (++ args1) =<< expandResponse args0
 
+-- | The section listing the global flags, appended to the help text of
+-- every command, so that global options such as @--store-dir@ can be
+-- discovered there (see issue #7587).
+globalFlagsSection :: String
+globalFlagsSection =
+  "\n"
+    ++ commandOptionsUsageInfo
+      "Global flags:"
+      (commandOptions (globalCommand []) ShowArgs)
+    ++ "\nGlobal flags must be given before the command, e.g.\n"
+    ++ "`cabal --store-dir=DIR build`.\n"
+
 -- | Check whether assertions are enabled and print a warning in that case.
 warnIfAssertionsAreEnabled :: IO ()
 warnIfAssertionsAreEnabled =
@@ -405,6 +419,7 @@ mainWorker args = do
     printCommandHelp help = do
       pname <- getProgName
       putStr (help pname)
+      putStr globalFlagsSection
     printGlobalHelp help = do
       pname <- getProgName
       configFile <- defaultConfigFile

--- a/cabal-testsuite/PackageTests/Help/GlobalFlagsInCommandHelp/global-flags-in-command-help.out
+++ b/cabal-testsuite/PackageTests/Help/GlobalFlagsInCommandHelp/global-flags-in-command-help.out
@@ -1,0 +1,2 @@
+# cabal build
+# cabal --help

--- a/cabal-testsuite/PackageTests/Help/GlobalFlagsInCommandHelp/global-flags-in-command-help.test.hs
+++ b/cabal-testsuite/PackageTests/Help/GlobalFlagsInCommandHelp/global-flags-in-command-help.test.hs
@@ -1,0 +1,15 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+  -- The help of an individual command should mention the global flags.
+  buildHelp <- cabal' "build" ["--help"]
+  assertOutputContains "Global flags:" buildHelp
+  assertOutputContains "--store-dir=DIR" buildHelp
+
+  -- The same help text is reachable via `cabal help build`.
+  buildHelp2 <- cabal_raw' ["help", "build"] Nothing
+  assertOutputContains "--store-dir=DIR" buildHelp2
+
+  -- For comparison, the global help has always listed `--store-dir`.
+  globalHelp <- cabal' "--help" []
+  assertOutputContains "--store-dir=DIR" globalHelp

--- a/changelog.d/12299.md
+++ b/changelog.d/12299.md
@@ -1,0 +1,41 @@
+---
+synopsis: List global flags in the help text of every command
+packages: [Cabal, cabal-install]
+prs: 12299
+issues: 7587
+---
+
+Example of the new `cabal build --help` output:
+
+```diff
+  Examples:
+    cabal build
+      Build the package in the current directory or all packages in the project
+    cabal build pkgname
+      Build the package named pkgname in the project
+    cabal build ./pkgfoo
+      Build the package in the ./pkgfoo directory
+    cabal build cname
+      Build the component named cname in the project
+    cabal build cname --enable-profiling
+      Build the component in profiling mode (including dependencies as needed)
++
++Global flags:
++ -V, --version                # Print version information
++ --full-version               # Print full version information with git
++                                revision (if available) and compiler
++ --numeric-version            # Print just the version number
++ --config-file=FILE           # Set an alternate location for the config file
++ --ignore-expiry              # Ignore expiry dates on signed metadata (use
++                                only in exceptional circumstances)
++ --http-transport=HttpTransport
++                              # Set a transport for http(s) requests. Accepts
++                                'curl', 'wget', 'powershell', and
++                                'plain-http'. (default: 'curl')
++ --store-dir=DIR              # The location of the build store
++ --active-repositories=REPOS  # The active package repositories (set to
++                                ':none' to disable all repositories)
++
++Global flags must be given before the command, e.g.
++`cabal --store-dir=DIR build`.
+```

--- a/doc/cmd-v1-help/bench.txt
+++ b/doc/cmd-v1-help/bench.txt
@@ -54,3 +54,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/build.txt
+++ b/doc/cmd-v1-help/build.txt
@@ -41,3 +41,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/clean.txt
+++ b/doc/cmd-v1-help/clean.txt
@@ -24,3 +24,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/configure.txt
+++ b/doc/cmd-v1-help/configure.txt
@@ -224,3 +224,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/copy.txt
+++ b/doc/cmd-v1-help/copy.txt
@@ -29,3 +29,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/freeze.txt
+++ b/doc/cmd-v1-help/freeze.txt
@@ -84,3 +84,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/gen-bounds.txt
+++ b/doc/cmd-v1-help/gen-bounds.txt
@@ -20,3 +20,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/haddock.txt
+++ b/doc/cmd-v1-help/haddock.txt
@@ -58,3 +58,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/install.txt
+++ b/doc/cmd-v1-help/install.txt
@@ -394,3 +394,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/reconfigure.txt
+++ b/doc/cmd-v1-help/reconfigure.txt
@@ -220,3 +220,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/register.txt
+++ b/doc/cmd-v1-help/register.txt
@@ -31,3 +31,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/repl.txt
+++ b/doc/cmd-v1-help/repl.txt
@@ -51,3 +51,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/run.txt
+++ b/doc/cmd-v1-help/run.txt
@@ -40,3 +40,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v1-help/test.txt
+++ b/doc/cmd-v1-help/test.txt
@@ -70,3 +70,22 @@ case with the nix-style commands.
 
 For more information, see:
 https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/bench.txt
+++ b/doc/cmd-v2-help/bench.txt
@@ -381,3 +381,22 @@ Examples:
     Run the benchmark named cname
   cabal bench cname -O2
     Run the benchmark built with '-O2' (including local libs used)
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/build.txt
+++ b/doc/cmd-v2-help/build.txt
@@ -383,3 +383,22 @@ Examples:
     Build the component named cname in the project
   cabal build cname --enable-profiling
     Build the component in profiling mode (including dependencies as needed)
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/clean.txt
+++ b/doc/cmd-v2-help/clean.txt
@@ -20,3 +20,22 @@ Flags for clean:
                                 files (default dist)
  -s, --save-config            # Save configuration, only remove build
                                 artifacts
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/configure.txt
+++ b/doc/cmd-v2-help/configure.txt
@@ -390,3 +390,22 @@ Examples:
   cabal configure
     Reset the local configuration to empty. To check that the
     project configuration works, use 'cabal build'.
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/exec.txt
+++ b/doc/cmd-v2-help/exec.txt
@@ -371,3 +371,22 @@ Flags for exec:
                                 (relative to the project directory when
                                 relative)
  --project-file-parser=PARSER # Set the parser to use for the project file
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/fetch.txt
+++ b/doc/cmd-v2-help/fetch.txt
@@ -74,3 +74,22 @@ Flags for fetch:
                               # Require these packages to have constraints on
                                 them if they are to be selected (default:
                                 none).
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/freeze.txt
+++ b/doc/cmd-v2-help/freeze.txt
@@ -385,3 +385,22 @@ Examples:
     Check what a solution with the given constraints would look like
   cabal freeze --constraint="aeson < 1"
     Freeze a solution using the given constraints
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/gen-bounds.txt
+++ b/doc/cmd-v2-help/gen-bounds.txt
@@ -368,3 +368,22 @@ Examples:
     Generate bounds for the package named pkgname in the project
   cabal gen-bounds ./pkgfoo
     Generate bounds for the package in the ./pkgfoo directory
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/get.txt
+++ b/doc/cmd-v2-help/get.txt
@@ -37,3 +37,22 @@ Examples:
     Download the latest stable version of hlint;
   cabal get lens --source-repository=head
     Download the source repository of lens (i.e. git clone from github).
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/haddock-project.txt
+++ b/doc/cmd-v2-help/haddock-project.txt
@@ -39,3 +39,22 @@ Flags for haddock-project:
                                 use "" to prevent splitting)
  --haddock-options=OPTS       # Give extra options to haddock (split on
                                 spaces, use "" to prevent splitting)
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/haddock.txt
+++ b/doc/cmd-v2-help/haddock.txt
@@ -380,3 +380,22 @@ Flags for haddock:
 
 Examples:
   cabal haddock pkgname    Build documentation for the package named pkgname
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/hscolour.txt
+++ b/doc/cmd-v2-help/hscolour.txt
@@ -20,3 +20,22 @@ Flags for hscolour:
  --css=PATH                   # Use a cascading style sheet
 
 Deprecated in favour of 'cabal haddock --hyperlink-source'.
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/info.txt
+++ b/doc/cmd-v2-help/info.txt
@@ -16,3 +16,22 @@ Flags for info:
                                 list is ['global'], ['global', 'user'],
                                 depending on context. Use 'clear' to reset the
                                 list to empty. See the user guide for details.
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/init.txt
+++ b/doc/cmd-v2-help/init.txt
@@ -85,3 +85,22 @@ Flags for init:
                                 inferred for the 'base' package.
  -v[n], --verbose[=n]         # Control verbosity (n is 0--3, default
                                 verbosity level is 1)
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/install.txt
+++ b/doc/cmd-v2-help/install.txt
@@ -373,3 +373,22 @@ Examples:
     Install the package named pkgname (fetching it from hackage if necessary)
   cabal install ./pkgfoo
     Install the package in the ./pkgfoo directory
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/list-bin.txt
+++ b/doc/cmd-v2-help/list-bin.txt
@@ -363,3 +363,22 @@ Flags for list-bin:
  -z, --ignore-project         # Ignore local project configuration (unless
                                 --project-dir or --project-file is also set)
  --project-file-parser=PARSER # Set the parser to use for the project file
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/list.txt
+++ b/doc/cmd-v2-help/list.txt
@@ -29,3 +29,22 @@ Flags for list:
 Examples:
   cabal list pandoc
     Will find pandoc, pandoc-citeproc, pandoc-lens, ...
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/outdated.txt
+++ b/doc/cmd-v2-help/outdated.txt
@@ -376,3 +376,22 @@ Flags for outdated:
                                 and '-v0'
  --ignore=PKGS                # Packages to ignore
  --minor[=PKGS]               # Ignore major version bumps for these packages
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/path.txt
+++ b/doc/cmd-v2-help/path.txt
@@ -386,3 +386,22 @@ Examples:
     Print the installation directory, taking project information into account.
   cabal path -z --output-format=key-value --installdir
     Print the installation directory, without taking project information into account.
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/repl.txt
+++ b/doc/cmd-v2-help/repl.txt
@@ -406,3 +406,22 @@ Examples, open an interactive session:
     add a version (constrained between 4.15 and 4.18) of the library 'lens' to the default component (or no component if there is no project present)
   cabal repl pkg:cabal-install-solver pkg:Cabal-syntax --enable-multi-repl
     for default (in this case library) components in two packages
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/report.txt
+++ b/doc/cmd-v2-help/report.txt
@@ -17,3 +17,22 @@ Flags for report:
 
 You can store your Hackage login in the ~/.config/cabal/config file
 (the %APPDATA%\cabal\config file on Windows)
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/run.txt
+++ b/doc/cmd-v2-help/run.txt
@@ -387,3 +387,22 @@ Examples:
     Run the executable-like 'foo-tool' in the package 'pkgfoo'
   cabal run foo -O2 -- dothing --fooflag
     Build with '-O2' and run the program, passing it extra arguments.
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/sdist.txt
+++ b/doc/cmd-v2-help/sdist.txt
@@ -23,3 +23,22 @@ Flags for sdist:
  -o PATH or -oPATH, --output-directory=PATH
                               # Choose the output directory of this command.
                                 '-' sends all output to stdout
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/target.txt
+++ b/doc/cmd-v2-help/target.txt
@@ -403,3 +403,22 @@ Examples:
     Targets of the package in the ./pkgfoo directory
   cabal target cname
     Targets of the component named cname in the project
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/test.txt
+++ b/doc/cmd-v2-help/test.txt
@@ -383,3 +383,22 @@ Examples:
     Run the test-suite named cname
   cabal test cname --enable-coverage
     Run the test-suite built with code coverage (including local libs used)
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/unpack.txt
+++ b/doc/cmd-v2-help/unpack.txt
@@ -37,3 +37,22 @@ Examples:
     Download the latest stable version of hlint;
   cabal unpack lens --source-repository=head
     Download the source repository of lens (i.e. git clone from github).
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/update.txt
+++ b/doc/cmd-v2-help/update.txt
@@ -381,3 +381,22 @@ Examples:
     Download hackage.haskell.org and head.hackage
     head.hackage must be a known repo-id. E.g. from
     your cabal.project(.local) file.
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/upload.txt
+++ b/doc/cmd-v2-help/upload.txt
@@ -31,3 +31,22 @@ Relevant global configuration keys:
   username
   password
   password-command
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-help/user-config.txt
+++ b/doc/cmd-v2-help/user-config.txt
@@ -27,3 +27,22 @@ Flags for user-config:
  -a CONFIGLINE or -aCONFIGLINE, --augment=CONFIGLINE
                               # Additional setting to augment the config file
                                 (replacing a previous setting if it existed).
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-hidden-help/act-as-setup.txt
+++ b/doc/cmd-v2-hidden-help/act-as-setup.txt
@@ -5,3 +5,22 @@ Usage: cabal act-as-setup
 Flags for act-as-setup:
  -h, --help                   # Show this help text
  --build-type=BUILD-TYPE      # Use the given build type.
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-hidden-help/format.txt
+++ b/doc/cmd-v2-hidden-help/format.txt
@@ -4,3 +4,22 @@ Usage: cabal format [FILE]
 
 Flags for format:
  -h, --help                   # Show this help text
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.

--- a/doc/cmd-v2-hidden-help/man.txt
+++ b/doc/cmd-v2-hidden-help/man.txt
@@ -9,3 +9,22 @@ Flags for man:
  -v[n], --verbose[=n]         # Control verbosity (n is 0--3, default
                                 verbosity level is 1)
  --raw                        # Output raw troff content
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.


### PR DESCRIPTION
fix: #7587

Global options of `cabal`, such as `--store-dir`, were only documented in the
help of the `cabal` program itself (`cabal --help`) but not in the help text of
the individual commands that they affect, e.g. `cabal build --help`. This made
options like `--store-dir` hard to discover.

Now every command's help text ends with a `Global flags:` section listing the
same global options as the top-level help, together with a note that these
options must be given /before/ the command, e.g. `cabal --store-dir=DIR build`.

Additionally, `cabal help COMMAND` now shows exactly the same text as
`cabal COMMAND --help`, including the new global flags section and no longer
the "You can edit the cabal configuration file..." epilogue of the global help.

```diff
  Examples:
    cabal build
      Build the package in the current directory or all packages in the project
    cabal build pkgname
      Build the package named pkgname in the project
    cabal build ./pkgfoo
      Build the package in the ./pkgfoo directory
    cabal build cname
      Build the component named cname in the project
    cabal build cname --enable-profiling
      Build the component in profiling mode (including dependencies as needed)
+
+Global flags:
+ -V, --version                # Print version information
+ --full-version               # Print full version information with git
+                                revision (if available) and compiler
+ --numeric-version            # Print just the version number
+ --config-file=FILE           # Set an alternate location for the config file
+ --ignore-expiry              # Ignore expiry dates on signed metadata (use
+                                only in exceptional circumstances)
+ --http-transport=HttpTransport
+                              # Set a transport for http(s) requests. Accepts
+                                'curl', 'wget', 'powershell', and
+                                'plain-http'. (default: 'curl')
+ --store-dir=DIR              # The location of the build store
+ --active-repositories=REPOS  # The active package repositories (set to
+                                ':none' to disable all repositories)
+
+Global flags must be given before the command, e.g.
+`cabal --store-dir=DIR build`.
```

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [X] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [X] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)