### PR TITLE
cabal-install: guard the `base >= 4.22` constraint on wired-in unit ids

### DIFF
--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -445,13 +445,16 @@ setSolverVerbosity verbosity params =
     }
 
 dependOnWiredIns :: CompilerInfo -> DepResolverParams -> DepResolverParams
-dependOnWiredIns compiler params = addConstraints extraConstraints params
+dependOnWiredIns compiler params =
+  case compilerInfoWiredInUnitIds compiler of
+    Nothing -> params
+    Just wiredInUnitIds -> addConstraints (extraConstraints wiredInUnitIds) params
   where
-    extraConstraints =
+    extraConstraints wiredInUnitIds =
       [ LabeledPackageConstraint
         (PackageConstraint (ScopeAnyQualifier pkgName) (PackagePropertyInstalledSpecificUnitId unitId))
         ConstraintSourceNonReinstallablePackage
-      | (pkgName, unitId) <- fromMaybe [] $ compilerInfoWiredInUnitIds compiler
+      | (pkgName, unitId) <- wiredInUnitIds
       ]
         ++
         -- Old versions of `base` must be excluded from build plans still as they do not depend on any version of a wired-in unit.

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -218,6 +218,13 @@ tests =
           allowBootLibInstalls $
             mkTest dbBase "Install base with --allow-boot-library-installs" ["base"] $
               solverSuccess [("base", 5), ("ghc-prim", 1), ("integer-gmp", 1), ("integer-simple", 1)]
+      , -- The base >= 4.22 constraint only makes sense alongside the wired-in
+        -- unit id constraints. A compiler that reports none has no installed
+        -- base satisfying it, so it must not be added here.
+        runTest $
+          allowBootLibInstalls $
+            mkTest dbBaseOld "Install old base with --allow-boot-library-installs" ["base"] $
+              solverSuccess [("base", 1)]
       ]
   , testGroup
       "Reinstallable base, template-haskell, but not ghc{,-internal} (GHC with wiredInUnitIds)"

--- a/changelog.d/base-422-wired-in-guard.md
+++ b/changelog.d/base-422-wired-in-guard.md
@@ -1,0 +1,10 @@
+---
+synopsis: Fix `--allow-boot-library-installs` on GHC < 9.14
+packages: [cabal-install]
+prs: 12301
+issues: 12328
+---
+
+`--allow-boot-library-installs` made builds fail on compilers that report no
+wired-in unit ids, because `base` was constrained to version 4.22 or later
+regardless of the compiler.


### PR DESCRIPTION
Fixes #12328.

`dependOnWiredIns` adds two kinds of constraint: one installed-unit-id
constraint per wired-in unit of the compiler, and one `base >= 4.22` version
constraint added in #12055.

The second only makes sense next to the first. The unit-id constraints pin the
new, reinstallable `base`; the version constraint then excludes the old,
non-reinstallable one. But it is added unconditionally, while the unit-id
constraints are empty for a compiler that reports no wired-in units. Such a
compiler is affected because `--allow-boot-library-installs` alone is enough to
reach this code.

This makes `dependOnWiredIns` a no-op for a compiler that reports no wired-in
unit ids, so the version constraint applies only where the unit-id constraints
do. Behaviour is unchanged for a compiler that reports wired-in unit ids.

## Test

`UnitTests.Distribution.Solver.Modular.Solver` gets one test in the group
"Non-reinstallable base, template-haskell and ghc (GHC without wiredInUnitIds)".
It uses the existing `dbBaseOld` database, which holds `base-1` alone, enables
`--allow-boot-library-installs` and expects a successful plan. Without the fix
the test fails.

## QA notes

The script in #12328 exits non-zero on an unpatched `cabal`. Against this branch
it succeeds with GHC 9.10.3, 9.12.2 and 9.14.1.

## Checklist

**Template A: This PR modifies behaviour or interface**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) No.
* [x] The documentation has been updated, if necessary. No user guide change is necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.

