### PR TITLE
Remove uneeded release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: build sdists
         run: |
-          cabal sdist --output-directory out/ all
+          cabal sdist --output-directory out/ Cabal-syntax Cabal-hooks Cabal cabal-install-solver hooks-exe cabal-install
         shell: bash
 
       - name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: build sdists
         run: |
-          cabal sdist -o out all
+          cabal sdist --output-directory out/ all
         shell: bash
 
       - name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y tar xz-utils
         shell: bash
 
+      # NOTE ☞: Here is where we decide what to output in a GitHub release,
+      # so if we add a package which is meant to be released to Cabal, this
+      # has to be changed. See issue #12179.
       - name: build sdists
         run: |
           cabal sdist --output-directory out/ Cabal-syntax Cabal-hooks Cabal cabal-install-solver hooks-exe cabal-install


### PR DESCRIPTION
Closes #12179.

I tested it locally by running `cabal sdist --output-directory out/ Cabal-syntax Cabal-hooks Cabal cabal-install-solver hooks-exe cabal-install` and confirming it works as expected.

This cannot be backported to `3.16`, we used a different release method at the time.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
