### PR TITLE
fix(CI): bootstrap.py no longer reuses a stale package database

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -44,8 +44,13 @@ jobs:
         id: bootstrap-cache
         with:
           path: "/home/runner/work/cabal/cabal/_build"
-          key: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-${{ hashFiles(format('bootstrap/linux-{0}.json', matrix.ghc)) }}-${{ github.sha }}
-          restore-keys: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-${{ hashFiles(format('bootstrap/linux-{0}.json', matrix.ghc)) }}-
+          # Hash the .cabal files of the local packages into the key too:
+          # the bootstrap plans only reference local packages by name, so
+          # without this the caches of branches with different local package
+          # versions (e.g. master vs a release branch) collide and a stale
+          # _build/packages.conf gets restored. See #12311.
+          key: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-${{ hashFiles(format('bootstrap/linux-{0}.json', matrix.ghc), 'Cabal/Cabal.cabal', 'Cabal-syntax/Cabal-syntax.cabal', 'Cabal-hooks/Cabal-hooks.cabal', 'hooks-exe/hooks-exe.cabal', 'cabal-install-solver/cabal-install-solver.cabal', 'cabal-install/cabal-install.cabal') }}-${{ github.sha }}
+          restore-keys: bootstrap-${{ steps.get-osver.outputs.osver }}-${{ matrix.ghc }}-${{ hashFiles(format('bootstrap/linux-{0}.json', matrix.ghc), 'Cabal/Cabal.cabal', 'Cabal-syntax/Cabal-syntax.cabal', 'Cabal-hooks/Cabal-hooks.cabal', 'hooks-exe/hooks-exe.cabal', 'cabal-install-solver/cabal-install-solver.cabal', 'cabal-install/cabal-install.cabal') }}-
 
       - uses: haskell-actions/setup@v2
         with:

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -275,10 +275,12 @@ UnitId = NewType('UnitId', str)
 PlanUnit = NewType('PlanUnit', dict)
 
 def bootstrap(info: BootstrapInfo, ghc: Compiler) -> None:
-    if not PKG_DB.exists():
-        print(f'Creating package database {PKG_DB}')
-        PKG_DB.parent.mkdir(parents=True, exist_ok=True)
-        subprocess_run([ghc.ghc_pkg_path, 'init', PKG_DB])
+    if PKG_DB.exists():
+        print(f'Deleting stale package database {PKG_DB}')
+        shutil.rmtree(PKG_DB)
+    print(f'Creating package database {PKG_DB}')
+    PKG_DB.parent.mkdir(parents=True, exist_ok=True)
+    subprocess_run([ghc.ghc_pkg_path, 'init', PKG_DB])
 
     for dep in info.builtin:
         check_builtin(dep, ghc)


### PR DESCRIPTION
fix: #12311 

The package database is now deleted and recreated from scratch on every
bootstrap run, making the script idempotent with respect to a dirty or
polluted `_build`. Additionally, the `Bootstrap` workflow now hashes the
`.cabal` files of the local packages into its cache key, so caches are no
longer shared between branches that build different versions of the local
packages.

```diff
  $ python3 bootstrap/bootstrap.py --bootstrap-sources bootstrap-sources.tar.gz
+ Deleting stale package database _build/packages.conf
  Creating package database _build/packages.conf
  Using ...
```

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
