### PR TITLE
Bump cabal-testsuite Cabal version to 3.18.1.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,7 +99,7 @@ jobs:
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: 3.12.1.0 # see https://github.com/haskell/cabal/pull/10251
+          cabal-version: 3.18.1.0 # see https://github.com/haskell/cabal/pull/10251
           ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.9.yaml
 
       # runner.os isn't sufficient for binary compatible caches

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -153,6 +153,6 @@ custom-setup
   -- we only depend on even stable releases of lib:Cabal
   -- and must match the release used in validate.yml (see
   -- https://github.com/haskell/cabal/pull/10251)
-  setup-depends: Cabal ^>= 3.12.1.0,
-                 Cabal-syntax ^>= 3.12.1.0,
+  setup-depends: Cabal ^>= 3.18.1.0,
+                 Cabal-syntax ^>= 3.18.1.0,
                  base, filepath, directory


### PR DESCRIPTION
Allows us to use `--with-repl` in the `Cabal` codebase.

Without it, cabal currently cannot be loaded into HLS with cabal 3.18.1.0.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
